### PR TITLE
Record the battery pack that is actually fitted, and how it was connected

### DIFF
--- a/BOARD_E32R28T-1.md
+++ b/BOARD_E32R28T-1.md
@@ -255,6 +255,22 @@ Commands:
 1. **Battery (Li-ion/LiPo):** 3.7V nominal, sensed on GPIO34 via voltage divider
 2. **USB:** 5V, connected through charging circuitry
 
+**Pack used for development and calibration:** a 3.7V **1100mAh** LiPo, cell
+size **102540** (10 × 25 × 40 mm), with an integrated protection board and a
+JST 2.0 plug. That plug does not mate with this board's battery header — it was
+**re-terminated to fit the board's battery pins**, and the board was not
+modified. **Verify polarity with a meter before connecting**: JST-plugged packs
+are not consistent about pin order and the charger input is not
+reverse-protected.
+
+Measured behaviour with that pack: charges from a slow (1A) USB supply, and
+holds a charge for **up to ~5 hours** of use. Every constant in
+`src/hal/BoardPower.cpp` — the `LIPO_CURVE`, the charge-inference thresholds,
+and the no-pack measurements below — was taken against this cell. A different
+capacity, chemistry or protection board can shift the resting and float
+voltages they are tuned to; re-run `pio run -e batdiag` rather than assuming
+they carry over.
+
 ### Voltage Sensing
 
 **Divider equation:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ Flash 2,347,725 / 3,145,728 (74.6%), RAM 72,524 / 327,680 (22.1%).
   supported; the folder exists because someone who has never opened a CAD tool
   should not be handed a bare board and told to improvise. Ports are encouraged
   to add their own folder.
+- **The battery pack is written down.** `README.md`, `BOARD_E32R28T-1.md` and
+  the case notes now record the cell the firmware was actually calibrated
+  against -- a 3.7V 1100mAh 102540 LiPo whose JST 2.0 plug was re-terminated to
+  fit the board's battery pins -- together with what was measured (charges from
+  a slow USB supply, runs up to ~5 hours), a polarity warning for anyone
+  repeating the adaptation, and the plain statement that a better pack and a
+  case designed around it would improve the product. Every battery constant in
+  the firmware is empirical for that cell, so the cell belongs in the docs
+  beside the constants.
 - **A licence.** The repo had none, which meant default copyright -- all
   rights reserved -- so nobody could legally contribute to a project that was
   asking for contributions. It is now **GPL-3.0-or-later**, so ports and

--- a/README.md
+++ b/README.md
@@ -540,6 +540,36 @@ couple of seconds — the warning is driven off the charge verdict, not the
 percentage, so it goes away when the user does the thing it asked for rather
 than waiting for the reading to climb.
 
+**The pack fitted here, and how it was connected.** One cell: a **3.7V 1100mAh
+LiPo, 102540 (10 × 25 × 40 mm), with a JST 2.0 plug and an integrated
+protection board**, sold in pairs with a 1000mA USB charging cable and
+insulating tape. The board's battery header is not that connector, so the
+**plug was adapted to fit the battery pins on the board** — the board itself
+was not modified.
+
+Check the polarity with a meter before the first connection, on your own cells.
+JST-plugged LiPo packs are not consistent about which pin is positive, and
+re-terminating a plug is exactly where that gets reversed; the charger input
+has no protection against it, so a wrong first connection is a dead board
+rather than a mistake you get to notice.
+
+**It is good enough for this use case.** Measured here: a slow charger fills
+the pack over USB, and the device runs **up to about 5 hours** on it — enough
+for the sessions this is built for. That is the whole of the claim. Runtime was
+not measured against screen brightness, Wi-Fi or Nearby being on, and the
+percentage it reports while doing so is still the bouncing gauge described
+above.
+
+**A better pack and a better case would make this a better product.** This one
+was chosen for being to hand and cheap, and the case has no compartment for it
+([`cases/`](cases/README.md)) — it lies in the free space in the tray. Pack
+size drives the internal volume of any redesigned shell, which is why the
+enclosure ([issue #13](https://github.com/iamankushpandit/Gume/issues/13)) is
+queued behind the battery gauge
+([issue #8](https://github.com/iamankushpandit/Gume/issues/8)). If you fit a
+different cell, say which one — every battery constant in this firmware was
+tuned against this pack, not derived from a datasheet.
+
 The divider ratio itself is still an assumption pending a meter on the board.
 
 ### Reliability

--- a/cases/E32R28T-1/README.md
+++ b/cases/E32R28T-1/README.md
@@ -77,8 +77,15 @@ than found afterwards, which is
 [issue #13](https://github.com/iamankushpandit/Gume/issues/13).
 
 There is no dedicated battery compartment. The single-cell Li-ion/LiPo pack the
-board charges (see the Battery section of the [README](../../README.md)) has to
-be placed in the free space in the tray by hand.
+board charges has to be placed in the free space in the tray by hand — the
+prints were assembled around a **3.7V 1100mAh 102540 cell (10 × 25 × 40 mm)**
+whose JST 2.0 plug was adapted to fit the board's battery pins. It fits, and the
+assembled shell holds it firmly, but nothing locates or retains it. Details of
+the pack, including the polarity warning that comes with re-terminating a plug,
+are in the Battery section of the [README](../../README.md#battery).
+
+If you fit a taller or longer pack, check it against that free space before
+printing: at 7.0 mm the back tray has very little depth to give.
 
 ## Status — this is the stopgap, not the design
 


### PR DESCRIPTION
Documents the cell the firmware was calibrated against, in the places that describe the hardware.

**The pack:** 3.7V 1100mAh LiPo, 102540 (10 x 25 x 40 mm), JST 2.0 plug with an integrated protection board, sold in pairs with a 1A USB charging cable. The plug does not mate with this board's battery header, so it was re-terminated to fit the battery pins — the board was not modified.

**What was measured:** charges from a slow 1A USB supply, holds a charge for up to ~5 hours of use. Sufficient for this use case, and the docs claim no more than that — runtime was not characterised against brightness, Wi-Fi or Nearby, and the percentage reported while doing so is still the bouncing gauge of #8.

**Why it belongs in the docs:** every battery constant in `BoardPower.cpp` — the `LIPO_CURVE`, the charge-inference thresholds, the no-pack measurements — is empirical for this cell, not datasheet-derived. The cell should sit beside the constants.

Files: `README.md` (Battery section), `BOARD_E32R28T-1.md` (§5 Power Sources), `cases/E32R28T-1/README.md` (no battery compartment; the shell was assembled around these dimensions), `CHANGELOG.md`.

Two things written down that were not requested:

- **Polarity warning.** JST-plugged packs are not consistent about pin order, re-terminating a plug is where that gets reversed, and the charger input has no reverse protection. A wrong first connection is a dead board.
- **A better pack and a case designed around it** recorded as a known improvement — pack size drives internal volume, which is why the enclosure (#13) is queued behind the gauge (#8).

Docs-only; no code changed, so no build figures moved. `python tools/check_docs.py` is clean.
