### PR TITLE
Pay off the frame-rule debt instead of raising the ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,40 @@ A console that upgrades to this gains an Admin profile it did not have, stops
 booting into whatever profile was last used if that profile is the admin, and
 starts refusing settings changes to everyone else in the house.
 
-Flash 2,347,725 / 3,145,728 (74.6%), RAM 72,524 / 327,680 (22.1%).
+Flash 2,346,841 / 3,145,728 (74.6%), RAM 72,524 / 327,680 (22.1%).
+
+### Fixed
+
+- **`verify` was red on `dev` for every pull request**, whatever the request
+  contained. `tools/check_frame_rules.py` is a ratchet over the memory and
+  frame-budget rules, and its baseline had fallen behind four files, so the
+  job failed before it could say anything about the change under review. A
+  check that is always red teaches people to ignore it, so the counts are
+  brought back under the baseline rather than the baseline raised to meet
+  them:
+  - `SettingsGame.cpp` was never in debt at all -- the `new` arm of the heap
+    rule was matching *inside a string literal*, so `renderPinPad(host, "Enter
+    new PIN")` read as two raw allocations. The checker now blanks string
+    literals before matching, which also stops a `"http://..."` URL being
+    mistaken for a trailing `//` comment. `GreWordTable.cpp` was a false
+    positive of the same kind.
+  - `Board::addKid()` grew a `const char*` form that builds the stored name in
+    a stack buffer, so boot's default Admin profile allocates nothing and the
+    empty-name fallback no longer builds `String("Player ") + n` only to throw
+    it away. The `String` overload stays for `ProfileGame`, whose draft name
+    genuinely is one.
+  - `NearbyGame`'s `scoreText()` returned a `String` per row -- four heap
+    blocks per rebuild with two peers on screen, churning while the scanner
+    keeps the list moving. It writes into a caller-owned buffer now, which is
+    what `RowList` itself was rewritten to do.
+  - `SystemInfoGame`'s loop-load, worst-work, worst-frame, loops, boot-count,
+    fragmentation, RSSI, channel, brightness, saver and stall rows build with
+    `snprintf` into a reused stack buffer. These are the rows somebody watches
+    *while* chasing a slow frame, so they were the worst possible place to be
+    churning the heap.
+
+  The ratchet has been lowered to the new counts, so none of it can climb
+  back. Flash is 884 bytes smaller as a side effect.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,347,725 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,346,841 / 3,145,728 bytes,
 **74.6%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,524 / 327,680 (22.1%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,347,725 / 3,145,728 bytes (**74.6%**) |
+| Flash | 2,346,841 / 3,145,728 bytes (**74.6%**) |
 | RAM | 72,524 / 327,680 bytes (**22.1%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -114,7 +114,7 @@ void KidsPlatformApp::begin() {
 
     /* First-boot: automatically create default Admin profile with PIN 0000. */
     if (board_.kidCount() == 0 && board_.adminProfileIndex() == Board::GUEST_INDEX) {
-        uint8_t adminIdx = board_.addKid(String("Admin"));
+        uint8_t adminIdx = board_.addKid("Admin");
         board_.setAdminProfileIndex(adminIdx);
         board_.setAdminPin(0);
         Serial.println("[boot] Created default Admin profile with PIN 0000");

--- a/src/games/NearbyGame.cpp
+++ b/src/games/NearbyGame.cpp
@@ -17,14 +17,24 @@ const char* proximityText(int8_t rssi) {
     return "Far";
 }
 
-String scoreText(uint32_t value, const char* unit) {
-    String out(value);
+/* Writes "1234" or "1234 pts" into a caller-owned buffer.
+ *
+ * This returned a String until the ratchet caught it. Two peers on screen is
+ * four of these per rebuild, each one a heap block made and freed while the
+ * scanner keeps the list churning -- exactly the fragmentation the memory rule
+ * in CLAUDE.md is about, and exactly what RowList itself was rewritten to
+ * avoid. The buffer belongs to the caller because RowList copies out of it
+ * immediately. */
+void scoreText(char* out, size_t cap, uint32_t value, const char* unit) {
     if (unit != nullptr && unit[0] != '\0') {
-        out += ' ';
-        out += unit;
+        snprintf(out, cap, "%lu %s", static_cast<unsigned long>(value), unit);
+    } else {
+        snprintf(out, cap, "%lu", static_cast<unsigned long>(value));
     }
-    return out;
 }
+
+/* Longest realistic value is a 10-digit score, a space and a short unit. */
+constexpr size_t SCORE_TEXT_CAP = 24;
 }
 
 const char* NearbyGame::title() const {
@@ -121,11 +131,17 @@ void NearbyGame::rebuildRows(GameHost& host) {
             continue;
         }
         rows_.addRow("Playing", peer.gameTitle);
-        rows_.addRow("Their best", scoreText(peer.theirScore, peer.unit),
-                     peer.beatsYou ? Ui::warning() : 0);
+
+        char theirs[SCORE_TEXT_CAP];
+        scoreText(theirs, sizeof(theirs), peer.theirScore, peer.unit);
+        rows_.addRow("Their best", theirs, peer.beatsYou ? Ui::warning() : 0);
+
+        char yours[SCORE_TEXT_CAP];
+        if (peer.haveOwnScore) {
+            scoreText(yours, sizeof(yours), peer.yourScore, peer.unit);
+        }
         rows_.addRow("Your best",
-                     peer.haveOwnScore ? scoreText(peer.yourScore, peer.unit)
-                                       : String("Not played yet"),
+                     peer.haveOwnScore ? yours : "Not played yet",
                      peer.haveOwnScore ? 0 : Ui::muted());
         if (peer.beatsYou) {
             rows_.addRow("", "They are ahead of you", Ui::warning());

--- a/src/games/SystemInfoGame.cpp
+++ b/src/games/SystemInfoGame.cpp
@@ -325,7 +325,9 @@ void SystemInfoGame::buildMemoryRows(GameHost& host) {
     /* The number free heap alone will not tell you: plenty available, no
      * single piece big enough for the next allocation. */
     const uint8_t frag = Watchdog::heapFragmentation();
-    rows_.addRow("Fragmented", String(frag) + "%",
+    char fragText[8];
+    snprintf(fragText, sizeof(fragText), "%u%%", static_cast<unsigned>(frag));
+    rows_.addRow("Fragmented", fragText,
                  frag >= 60 ? Ui::error() : (frag >= 35 ? Ui::warning() : Ui::success()));
     rows_.addMeter(frag, frag >= 60 ? Ui::error() : (frag >= 35 ? Ui::warning() : Ui::success()));
     rows_.addRow("PSRAM", psramTotal > 0 ? formatBytes(psramFree) + " free" : "Not present");
@@ -371,12 +373,24 @@ void SystemInfoGame::buildMemoryRows(GameHost& host) {
     rows_.addRow("cydwdt", namespaceValue);
 
     rows_.addSection("CPU");
-    rows_.addRow("Loop load", String(loopPct) + "% (" + stats.lastWorkMs + "/" + stats.lastFrameMs + " ms)");
+    /* One buffer, reused down the block. These are the rows a reader watches
+     * while chasing a slow frame, so they are also the rows most likely to be
+     * rebuilt repeatedly -- the last place that should be churning the heap. */
+    char cpuText[40];
+    snprintf(cpuText, sizeof(cpuText), "%u%% (%lu/%lu ms)",
+             static_cast<unsigned>(loopPct),
+             static_cast<unsigned long>(stats.lastWorkMs),
+             static_cast<unsigned long>(stats.lastFrameMs));
+    rows_.addRow("Loop load", cpuText);
     rows_.addMeter(loopPct, loopPct > 70 ? Ui::warning() : Ui::success());
-    rows_.addRow("Worst work", String(stats.maxWorkMs) + " ms");
-    rows_.addRow("Worst frame", String(stats.maxFrameMs) + " ms");
-    rows_.addRow("Loops", String(stats.loops));
-    rows_.addRow("Boot count", String(stats.bootCount));
+    snprintf(cpuText, sizeof(cpuText), "%lu ms", static_cast<unsigned long>(stats.maxWorkMs));
+    rows_.addRow("Worst work", cpuText);
+    snprintf(cpuText, sizeof(cpuText), "%lu ms", static_cast<unsigned long>(stats.maxFrameMs));
+    rows_.addRow("Worst frame", cpuText);
+    snprintf(cpuText, sizeof(cpuText), "%lu", static_cast<unsigned long>(stats.loops));
+    rows_.addRow("Loops", cpuText);
+    snprintf(cpuText, sizeof(cpuText), "%lu", static_cast<unsigned long>(stats.bootCount));
+    rows_.addRow("Boot count", cpuText);
 }
 
 void SystemInfoGame::buildNetworkRows(GameHost& host) {
@@ -406,8 +420,11 @@ void SystemInfoGame::buildNetworkRows(GameHost& host) {
         wifi_ap_record_t ap{};
         const bool haveAp = esp_wifi_sta_get_ap_info(&ap) == ESP_OK;
         rows_.addRow("SSID", WiFi.SSID());
-        rows_.addRow("RSSI", String(WiFi.RSSI()) + " dBm");
-        rows_.addRow("Channel", String(WiFi.channel()));
+        char radioText[24];
+        snprintf(radioText, sizeof(radioText), "%d dBm", static_cast<int>(WiFi.RSSI()));
+        rows_.addRow("RSSI", radioText);
+        snprintf(radioText, sizeof(radioText), "%d", static_cast<int>(WiFi.channel()));
+        rows_.addRow("Channel", radioText);
         rows_.addRow("PHY", wifiPhyText());
         rows_.addRow("BSSID", haveAp ? WiFi.BSSIDstr() : "-");
         rows_.addRow("IP", WiFi.localIP().toString());
@@ -556,8 +573,11 @@ void SystemInfoGame::buildAppStateRows(GameHost& host) {
     rows_.addSection("Device");
     rows_.addRow("Theme", board.themeMode() == Board::ThemeMode::Light ? "Light" : "Dark");
     rows_.addRow("Layout", board.layoutMode() == Board::LayoutMode::Vertical ? "Portrait" : "Landscape");
-    rows_.addRow("Brightness", String(board.brightness()) + "%");
-    rows_.addRow("Saver", String(board.screenSaverSeconds()) + " s");
+    char deviceText[16];
+    snprintf(deviceText, sizeof(deviceText), "%u%%", static_cast<unsigned>(board.brightness()));
+    rows_.addRow("Brightness", deviceText);
+    snprintf(deviceText, sizeof(deviceText), "%u s", static_cast<unsigned>(board.screenSaverSeconds()));
+    rows_.addRow("Saver", deviceText);
     rows_.addRow("Profile", board.isGuest() ? "Guest" : board.profileName(board.activeProfile()));
     rows_.addRow("Touch cal", board.hasTouchCalibration() ? "Calibrated" : "Uncalibrated");
     rows_.addRow("SD card", board.sdReady() ? "Ready" : "Not found");
@@ -586,7 +606,9 @@ void SystemInfoGame::buildAppStateRows(GameHost& host) {
 
     rows_.addSection("Watchdog");
     rows_.addRow("State", stats.armed ? "Armed" : "Not armed");
-    rows_.addRow("Stalls", String(stats.stalls));
+    char stallText[16];
+    snprintf(stallText, sizeof(stallText), "%lu", static_cast<unsigned long>(stats.stalls));
+    rows_.addRow("Stalls", stallText);
     rows_.addRow("Uptime", uptimeText(stats.uptimeSeconds));
 
     rows_.addSection("Claims");

--- a/src/hal/Board.cpp
+++ b/src/hal/Board.cpp
@@ -73,11 +73,22 @@ void Board::setProfileName(uint8_t index, const String& name) {
     prefs_.putString(key, name.substring(0, PROFILE_NAME_MAX));
 }
 
-uint8_t Board::addKid(const String& name) {
+uint8_t Board::addKid(const char* name) {
     const uint8_t n = kidCount();
     if (n >= MAX_KIDS) return 0xFF;
     prefs_.putUChar("kids", static_cast<uint8_t>(n + 1));
-    setProfileName(n, name.length() ? name : String("Player ") + static_cast<int>(n + 1));
+
+    /* Truncation is the same PROFILE_NAME_MAX the String path applied via
+     * substring(); doing it in a stack buffer just means no temporary. */
+    char stored[PROFILE_NAME_MAX + 1];
+    if (name == nullptr || name[0] == '\0') {
+        snprintf(stored, sizeof(stored), "Player %u", static_cast<unsigned>(n + 1));
+    } else {
+        snprintf(stored, sizeof(stored), "%s", name);
+    }
+    char key[10];
+    snprintf(key, sizeof(key), "pname%u", n);
+    prefs_.putString(key, stored);
     return n;
 }
 

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -162,8 +162,15 @@ public:
 
     /** How many child profiles exist (0..MAX_KIDS). Guest is always extra. */
     uint8_t kidCount();
-    /** Append a child. Returns its index, or 0xFF when full. */
-    uint8_t addKid(const String& name);
+    /* Append a child. Returns its index, or 0xFF when full.
+     *
+     * The char* form is the real one: it builds the stored name in a stack
+     * buffer, so a caller with a literal -- boot's default Admin profile --
+     * allocates nothing, and the empty-name fallback no longer builds
+     * `String("Player ") + n` to throw it away. The String overload is kept
+     * for ProfileGame, whose draft name genuinely is a String. */
+    uint8_t addKid(const char* name);
+    uint8_t addKid(const String& name) { return addKid(name.c_str()); }
     /** Delete a child, shifting later names and persisted profile data down. */
     void removeKid(uint8_t index);
     bool isGuest() { return activeProfile() == GUEST_INDEX; }

--- a/tools/check_frame_rules.py
+++ b/tools/check_frame_rules.py
@@ -52,6 +52,14 @@ RULES = [
 # count and make the ratchet meaningless.
 COMMENT = re.compile(r"^\s*(?://|\*|/\*)")
 
+# Text inside a string literal is data, not code. Without this the `new`
+# arm of the heap rule fires on ordinary UI copy -- renderPinPad(host, "Enter
+# new PIN") was reported as two raw allocations in SettingsGame.cpp, which is
+# not just noise: a rule that cries wolf on a button label is a rule people
+# start editing the baseline to silence. Blanking literals first also stops a
+# "http://..." URL being mistaken for a trailing // comment.
+STRING_LITERAL = re.compile(r'"(?:[^"\\]|\\.)*"')
+
 
 def source_files():
     for parts in SCAN_DIRS:
@@ -71,7 +79,7 @@ def count_violations(path):
         for lineno, line in enumerate(handle, 1):
             if COMMENT.match(line):
                 continue
-            code = line.split("//", 1)[0]
+            code = STRING_LITERAL.sub('""', line).split("//", 1)[0]
             for label, pattern in RULES:
                 if pattern.search(code):
                     counts[label] += 1

--- a/tools/frame_rules_baseline.json
+++ b/tools/frame_rules_baseline.json
@@ -69,11 +69,6 @@
       "delay": 0,
       "heap": 0
     },
-    "src/games/GreWordTable.cpp": {
-      "String": 0,
-      "delay": 0,
-      "heap": 1
-    },
     "src/games/MathGame.cpp": {
       "String": 8,
       "delay": 0,
@@ -145,7 +140,7 @@
       "heap": 0
     },
     "src/games/SystemInfoGame.cpp": {
-      "String": 45,
+      "String": 43,
       "delay": 0,
       "heap": 0
     },
@@ -190,7 +185,7 @@
       "heap": 0
     },
     "src/hal/Board.cpp": {
-      "String": 7,
+      "String": 5,
       "delay": 1,
       "heap": 0
     },


### PR DESCRIPTION
`tools/check_frame_rules.py` has been failing on `dev` for **every** pull request, whatever the request contained -- its baseline had fallen behind four files. This is why [#16](https://github.com/iamankushpandit/Gume/pull/16) went red on a change that adds no violations at all. I verified that by diffing per-file violation counts between `origin/dev` and that branch: no file's count differs.

A check that is always red is a check people learn to skip, so the counts come back **under** the baseline rather than the baseline going up to meet them.

## Two of the four were never debt

The `new` arm of the heap rule was matching **inside string literals**:

```
- src/games/SettingsGame.cpp: 2 'heap' violation(s), baseline allows 0 (line 517, line 521)
```

Both lines are `renderPinPad(host, "Enter new PIN")` and `"Re-enter new PIN"` -- the words *"new PIN"*, reported as raw allocations. `GreWordTable.cpp` was the same kind of false positive. The checker now blanks string literals before matching, which also stops a `"http://..."` URL being mistaken for a trailing `//` comment.

This one mattered more than the count suggests: a rule that cries wolf on a button label is a rule somebody eventually silences by editing the baseline.

## Two were real

- **`Board::addKid()`** grows a `const char*` form that builds the stored name in a stack buffer, so boot's default Admin profile allocates nothing, and the empty-name fallback stops building `String("Player ") + n` only to throw it away. The `String` overload stays for `ProfileGame`, whose draft name genuinely is one.
- **`NearbyGame::scoreText()`** returned a `String` per row -- four heap blocks per rebuild with two peers on screen, churning while the scanner keeps the list moving. It writes into a caller-owned buffer now, which is what `RowList` itself was rewritten to do.
- **`SystemInfoGame`**'s loop-load, worst-work, worst-frame, loops, boot-count, fragmentation, RSSI, channel, brightness, saver and stall rows build with `snprintf` into a reused stack buffer. Those are the rows somebody reads *while* chasing a slow frame, which made them the worst place in the tree to be churning the heap.

The ratchet is lowered to the new counts (`SystemInfoGame` 45 -> 43, `Board.cpp` 7 -> 5, `GreWordTable` dropped) so none of it can climb back.

## Verification

- `pio run` clean. **Flash 2,346,841 / 3,145,728 (74.6%), RAM 72,524 / 327,680 (22.1%)** -- 884 bytes *smaller* than `dev`. Figures updated in `README.md`, `CLAUDE.md` and `CHANGELOG.md`.
- `check_docs.py`, `check_catalog.py`, `check_frame_rules.py` all clean.
- Behaviour is unchanged throughout: every conversion produces the same displayed text, and `addKid` applies the same `PROFILE_NAME_MAX` truncation the `substring()` path did.

### Not verified

Not yet run on hardware -- this is a rendering-text change across three screens, so Nearby, System Info and the first-boot Admin profile are the things worth an eye when it is flashed.

### Unrelated, noted in passing

`src/ui/Ui.cpp` contains a stray NUL byte in `dev` itself, which makes git treat it as binary. I have not touched it -- flagging it rather than folding an unrelated fix into this PR.
