### PR TITLE
Describe the board in one profile, and read the firmware off it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run repository checks
         run: |
           python tools/check_docs.py
+          python tools/check_boards.py
           python tools/check_catalog.py
           python tools/check_frame_rules.py
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,11 +254,24 @@ Everything above still applies, plus:
 
 ## Supporting a new board — the whole checklist
 
+**The mechanics are in [docs/PORTING.md](docs/PORTING.md) and are now small**: a
+board is a profile header in `include/boards/` plus a `[board_*]` section in
+`platformio.ini`, and nothing under `src/` names a GPIO. Read that first — this
+section is about everything a port needs *around* the code, which is the part
+that has actually been getting skipped.
+
 Before adding support for a new hardware variant, complete a comprehensive hardware reference and verification app. This prevents silent failures, driver misconfigurations, and port-specific quirks from reaching users.
 
 ### 1. Hardware documentation — must precede any game support
 
-1. **Create `BOARD_<VARIANT>.md`** — complete hardware reference for the new board
+1. **Check the board can be supported at all.** A panel of at least 320×240 in
+   landscape, a touch controller, the backlight on a GPIO, and 4 MB of flash
+   are hard requirements; a board missing one fails to compile and is out of
+   scope, not a porting task. SD, LED, speaker and battery sense are optional
+   and the firmware does without them. The table is in
+   [docs/PORTING.md](docs/PORTING.md).
+
+2. **Create `BOARD_<VARIANT>.md`** — complete hardware reference for the new board
    - Copy structure from [`BOARD_E32R28T-1.md`](BOARD_E32R28T-1.md) — the template
    - Sections: overview, GPIO pinout, display driver, touch, battery sensing, RGB LED, radios, memory, watchdog, known issues, verification procedures
    - Include all TFT_eSPI flags, SPI frequencies, ADC attenuation, power thresholds
@@ -266,13 +279,26 @@ Before adding support for a new hardware variant, complete a comprehensive hardw
    - **List every known hardware bug, quirk and workaround** (crossed LED pins, inverted polarity, ADC2 unavailable, etc.)
    - Do NOT skip "known issues" section — it is where you prevent the next person from re-discovering the same bugs
 
-2. **Update `AGENTS.md`** to reference the new board file in this section
+3. **Update `AGENTS.md`** to reference the new board file in this section
 
-3. **Update `platformio.ini`** with a new environment for the variant
-   - Example: `[panel_st7789]` or `[env:app4]` for a 4-inch board
-   - Include all build flags (`-D TFT_WIDTH=`, `-D TFT_HEIGHT=`, `-D PANEL_<VARIANT>=1`, etc.)
-   - Partition table (3 MB app? 1.5 MB app?)
-   - SPI speeds (some displays require lower frequencies)
+4. **Write `include/boards/<id>.h`** — the board profile. Pins, rotations, the
+   battery divider, and `PIN_NONE` for anything the board does not wire. Label
+   every value with its field name in a `/* comment */`; `check_boards.py`
+   reads those labels to prove nothing was left out.
+
+5. **Add `[board_<id>]` and `[env:<name>]` to `platformio.ini`** — the board
+   section carries only `BOARD_NAME`, `GUME_BOARD_HEADER`, the driver and the
+   TFT_eSPI pin/size/SPI macros. Everything shared is already in `[common]`,
+   and putting a board-specific flag there fails `check_boards.py`. The
+   environment composes `${common.build_flags}` with exactly one
+   `${board_*.build_flags}`.
+
+6. **Put it on the web installer.** `tools/gen_site.py` derives its board list
+   from those same sections, so add a `BOARD_DETAILS` entry (label, chip
+   family, where to buy one) and make sure `.github/workflows/ci.yml` and
+   `pages.yml` build the environment. A board that can be supported must be
+   flashable by the person who owns it, not only by someone with a toolchain;
+   `check_boards.py` fails the port until that is true.
 
 ### 2. Hardware verification app — exercises all subsystems before game support
 
@@ -307,9 +333,11 @@ Before adding support for a new hardware variant, complete a comprehensive hardw
    - Renderer stretches to physical panel size
    - Touch reverse-scales from physical space back to logical canvas
 
-2. **Pin abstraction layer** — if multiple GPIO assignments across boards
-   - Do NOT hardcode pins in driver code; use `BoardConfig.h` and `-D` flags
-   - Use compile-time constants; no runtime conditionals for pins
+2. **Pin abstraction layer** — already built; use it rather than adding to it
+   - Do NOT hardcode pins in driver code. Read `BOARD` (`include/BoardProfile.h`)
+   - If the fact you need is not on `BOARD`, add the field and fill it in for
+     every existing board in the same commit — do not add a `#if` instead
+   - It is all `constexpr`, so it costs nothing at runtime
 
 3. **Driver selection flags** — if multiple display/touch controllers
    - Use `-D PANEL_<NAME>=1` and `#if PANEL_<NAME>` in driver init
@@ -317,14 +345,21 @@ Before adding support for a new hardware variant, complete a comprehensive hardw
 
 ### 4. Verification before merge
 
-1. `python tools/check_docs.py` — must pass (board list, build figures)
-2. `pio run -e app` and `pio run -e app4` (or new variant) — both must build
-3. Firmware flashes successfully on the new board
-4. All hardware verification tests pass
-5. At least one playable game runs and is responsive (no frames > 40ms)
+1. `python tools/check_docs.py` and `python tools/check_boards.py` — both must pass
+2. `pio run -e app` and `pio run -e <new variant>` — both must build
+3. The board is offered by the web installer, and CI builds its firmware — a
+   board people cannot flash from the page is not a supported board
+4. Firmware flashes successfully on the new board
+5. All hardware verification tests pass
+6. At least one playable game runs and is responsive (no frames > 40ms)
 
 ### What NOT to do
 
+- Do NOT claim support for a board that trips one of the hard requirements. It
+  is out of scope, and the static_assert saying so is the answer, not an
+  obstacle to work around
+- Do NOT land a board the web installer does not offer — support that needs a
+  toolchain is not support for the person who owns the board
 - Do NOT add support for a new board without a `BOARD_<VARIANT>.md` file
 - Do NOT merge to `main` unless all verification tests pass
 - Do NOT ship a board driver without documenting known bugs and workarounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ A console that upgrades to this gains an Admin profile it did not have, stops
 booting into whatever profile was last used if that profile is the admin, and
 starts refusing settings changes to everyone else in the house.
 
-Flash 2,350,141 / 3,145,728 (74.7%), RAM 72,548 / 327,680 (22.1%).
+Flash 2,350,197 / 3,145,728 (74.7%), RAM 72,548 / 327,680 (22.1%).
 
 ### Fixed
 
@@ -69,6 +69,42 @@ Flash 2,350,141 / 3,145,728 (74.7%), RAM 72,548 / 327,680 (22.1%).
 
 ### Added
 
+- **Board profiles — a board is now two files, and nothing else.** The
+  firmware was tied to the E32R28T-1 by construction: `include/BoardConfig.h`
+  held one board's pins as global constants, `SCREEN_WIDTH`/`SCREEN_HEIGHT`
+  were literal 320 and 240, and a second board meant copying thirty `-D` flags
+  into a second `platformio.ini` section. Now `include/boards/<id>.h` holds the
+  whole board — pins, rotations, the battery divider, which peripherals exist
+  at all — and a `[board_<id>]` section carries only the macros TFT_eSPI
+  insists on being told at compile time. **No file under `src/` names a GPIO
+  number any more.** The landscape canvas is derived from the panel and its
+  rotation rather than stated, so a differently sized board gets the right
+  constants without an edit. A peripheral a board does not wire is `PIN_NONE`
+  and the firmware degrades quietly, so a board with no SD slot, no LED or no
+  battery needs no code change. `docs/PORTING.md` is the checklist.
+- **A statement of which boards *cannot* be supported.** Optional hardware and
+  missing hardware are different answers and used to be blurred together. Four
+  things are now hard requirements — a panel of at least 320×240 in landscape,
+  a touch controller, the backlight on a GPIO, and 4 MB of flash for the 3 MB
+  app — and a board missing one fails to compile with a message naming it,
+  rather than flashing into a screen nobody can read or press. The SD slot, the
+  RGB LED, the speaker and battery sensing stay genuinely optional.
+- **The web installer now derives its board list from `platformio.ini`.** A
+  board that can be supported has to be flashable by the person who owns it,
+  not only by someone with a toolchain, so "supported" and "offered on the
+  page" are now the same set by construction. `gen_site.py` reads the
+  `[board_*]` sections and refuses to generate until a new board has a label, a
+  firmware entry and a CI build behind it; `check_boards.py` reports the same
+  gaps without needing to build.
+- **`tools/check_boards.py`, and a compile-time cross-check.** The panel is
+  necessarily described twice — once to TFT_eSPI, once to us — so
+  `BoardConfig.h` static_asserts `TFT_WIDTH`, `TFT_HEIGHT` and `TFT_BL` against
+  the profile. The backlight one matters most: with the wrong `TFT_BL` the
+  panel is completely dark while Wi-Fi, BLE, NVS, the LED and the screen saver
+  all run perfectly, so it reads as a dead screen rather than a wrong pin. The
+  script catches what the compiler cannot — a profile field a board never
+  filled in, a header no section points at, a board-specific flag that has
+  drifted into `[common]` where it would silently apply to every board.
 - **Hold to unlock, coming out of the screen saver or panel sleep.** A single
   stray press used to dismiss the saver and land straight on whatever screen
   was underneath -- mid-game, or on Settings -- which in a bag or a coat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ build), `AGENTS.md` (agent protocol) and the relevant directory `CLAUDE.md`.
 A README claiming the wrong game count or a stale flash figure is a defect
 belonging to whoever last changed the thing it describes.
 
-**Run `python tools/check_docs.py` before you commit.** It fails if the version,
+**Run `python tools/check_docs.py` and `python tools/check_boards.py` before
+you commit.** It fails if the version,
 the game count, the source-tree listing or the build figures have drifted, and
 if the About app has started restating facts instead of deriving them. These
 rules existed and the docs went stale anyway -- the README shipped claiming 23
@@ -180,15 +181,17 @@ Three diagnostic environments exist for hardware triage:
   watchdog and the 2s telemetry cache are all correct product decisions that
   get in the way of watching an ADC for an hour. BOOT cycles pages; CSV
   (`ms,raw,adc_mv,cell_mv,pct,state`) streams to serial for capturing a full
-  discharge. Its charge-inference constants are copied from `BoardPower.cpp`
-  deliberately, so what it shows is what the product will do — **if you change
-  one, change both.**
+  discharge. It reads the divider ratio and the ADC fault ceiling from the same
+  board profile the product does. Its charge-inference constants are still
+  copied from `BoardPower.cpp` deliberately, so what it shows is what the
+  product will do — **if you change one of those, change both.**
 
 ### Build gotchas
 
 - **BLE pulls in NimBLE, not Bluedroid.** `h2zero/NimBLE-Arduino` costs ~192 KB of flash for host plus controller; the core's Bluedroid stack costs several times that and this partition cannot absorb it.
 - `lib_ldf_mode = deep+` is required on `env:app` â€” transitive library headers do not resolve without it.
 - **TFT_eSPI is configured entirely through `-D` flags in `platformio.ini`** (`USER_SETUP_LOADED=1`, pins, `USE_HSPI_PORT`, fonts, SPI speeds). There is no `User_Setup.h` â€” editing one would do nothing.
+- **One board = one `[board_*]` section plus one profile header.** `platformio.ini` splits into `[common]` (true of every board), `[esp32_common]` (the MCU), and a `[board_*]` section per board holding only the TFT_eSPI macros, `BOARD_NAME` and `GUME_BOARD_HEADER`. An environment composes `${common.build_flags}` with exactly one `${board_*.build_flags}`. Put a board-specific `-D` in `[common]` and it becomes a claim about every board â€” `check_boards.py` fails on that. The panel is described twice, to TFT_eSPI and to us, and `BoardConfig.h` static_asserts `TFT_WIDTH`, `TFT_HEIGHT` and `TFT_BL` against the profile so the two cannot disagree past the compiler.
 - Partition is `huge_app.csv` (3 MB app). Flash is the scarce resource; artwork and data tables dominate.
 - `CYD_SCREEN_ROTATION=3` is landscape with the USB edge at the bottom. `Board::pollTouch()` compensates for every rotation, so don't hand-correct coordinates in game code.
 
@@ -277,7 +280,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,350,141 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,350,197 / 3,145,728 bytes,
 **74.7%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,548 / 327,680 (22.1%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -348,6 +351,10 @@ orientation that were up before. Three things about it are load-bearing:
 
 ### Invariants worth knowing before editing
 
+- **The board is described in two files and nowhere else.** `include/boards/<id>.h` holds the whole board -- pins, rotations, the battery divider, which peripherals exist; the `[board_<id>]` section in `platformio.ini` holds only what TFT_eSPI must be told at compile time. **No file under `src/` may name a GPIO number, a panel size or a divider ratio.** If you need one, read it off `BOARD`; if `BOARD` does not have it, add the field to `include/BoardProfile.h` and fill it in for every existing board in the same commit. `tools/check_boards.py` enforces the completeness, and `BoardConfig.h` static_asserts the overlap with TFT_eSPI. See `docs/PORTING.md`.
+- **Some boards cannot be supported, and that is a compile error, not a degradation.** Braino needs a panel of at least `GAME_CANVAS_WIDTH`x`GAME_CANVAS_HEIGHT` in landscape, a touch controller, the backlight on a GPIO, and 4 MB of flash. `BoardConfig.h` static_asserts each with a message naming what is missing. Optional hardware -- SD slot, RGB LED, speaker, battery sense -- is `PIN_NONE` plus a `has...()` guard, and the firmware does without it. **Do not blur the two:** turning a requirement into a quiet degradation ships a board that flashes and then cannot be read or pressed.
+- **A supported board must be flashable from the web installer.** `tools/gen_site.py` derives the picker's board list from the `[board_*]` sections rather than a hand-kept list, and refuses to generate until a new board has a `BOARD_DETAILS` label, an offered environment and a CI build behind it. `tools/check_boards.py` reports the same gaps without a build. "Supported" means someone who owns the board can flash it from the page, not that it builds here.
+- **`SCREEN_WIDTH` / `SCREEN_HEIGHT` are derived, not stated.** They come out of `BOARD.screenWidth()` / `screenHeight()`, which rotate the panel's native size by the profile's landscape rotation. Do not reintroduce a literal 320 or 240 next to them; a board that states its size twice will eventually state it two different ways.
 - **Every screen is a `Game`.** Launcher, Settings, Wi-Fi, Profiles, Scores, System Info and About are all `Game` subclasses with the same `begin`/`update`/`render`/`end` lifecycle.
 - **`end()` is called on every screen change** via `BrainoApp::leaveActiveGame()`, before the next screen's `begin()`. Add new transitions through that funnel, not by assigning `activeGame_` directly. Override `end()` for anything a screen holds that outlives a frame; nothing here runs off a task or timer, and the hook is what keeps that true.
 - **Never sample the battery ADC more than once per frame.** `Board::readBatteryTelemetry()` caches for 2s and everything else reads through it. Each accessor used to run its own blocking 10ms conversion, and a top bar calls two of them. See `src/hal/CLAUDE.md`.
@@ -507,7 +514,10 @@ Playable games are authored against a fixed 320Ã—240 landscape canvas. Launch
 ## Layout
 
 ```
-include/BoardConfig.h     pins + screen constants   include/AppVersion.h
+include/BoardProfile.h    the contract every board fills in
+include/BoardConfig.h     selects one profile; derives SCREEN_* from it
+include/boards/           one header per supported board -- the ONLY place
+                          in the tree that names a GPIO      include/AppVersion.h
 src/main.cpp              bringup entrypoint + normal app setup/loop
 src/wifi_diag.cpp         standalone radio test (env:wifidiag only)
 src/engine/               Game, LauncherGame, GameCatalog, AppRegistry, NearbyPlay,
@@ -525,7 +535,7 @@ src/ui/                   Renderer, TftRenderer, Ui, LauncherIcons,
 site/                     index.template.html â€” the GitHub Pages landing page
 .github/workflows/        ci.yml validates checks + builds; pages.yml publishes
                           the site from the same firmware set
-docs/                     SD_CONTENT_SPEC.md, screens/
+docs/                     SD_CONTENT_SPEC.md, PORTING.md, screens/
 ```
 
 ## The web installer is part of the deliverable
@@ -556,17 +566,22 @@ page. The flash button will 404 there â€” the binaries only exist in CI.
 
 ## Hardware notes
 
-Pins live in `include/BoardConfig.h`; read it rather than trusting generic ESP32 pinouts online.
+Pins live in `include/boards/<board>.h` -- one profile header per supported
+board, and the only place in the tree that names a GPIO. Read the profile
+rather than trusting generic ESP32 pinouts online, and never copy a pin map
+between CYD variants: GPIO34 is battery sense here and the light sensor on the
+ESP32-2432S028R. `docs/PORTING.md` is the checklist for adding a board.
 
-- **The RGB LED's red and green lines are crossed on this unit** relative to the usual standard pinout â€” `PIN_RGB_R = 16`, `PIN_RGB_G = 4`, `PIN_RGB_B = 17`. This is already corrected in `BoardConfig.h` and verified on hardware; do not "fix" it again. Common anode, so drive is inverted.
-- Touch is bit-banged SPI (the TFT owns HSPI), 3-point affine calibration persisted in NVS behind a magic number. `TOUCH_PRESSURE_THRESHOLD = 350`, `TOUCH_HIT_SLOP = 8`.
+- **The RGB LED's red and green lines are crossed on this unit** relative to the usual standard pinout â€” `rgb.r = 16`, `rgb.g = 4`, `rgb.b = 17` in the E32R28T-1 profile. This is already corrected there and verified on hardware; do not "fix" it again. Common anode, so drive is inverted â€” which the profile states rather than the driver assuming.
+- Touch is bit-banged SPI (the TFT owns HSPI), 3-point affine calibration persisted in NVS behind a magic number. `touch.pressureThreshold = 350`, `touch.hitSlop = 8` in the profile.
 - Backlight brightness floors at `Board::BRIGHTNESS_MIN = 25` â€” at lower duty the panel is unreadable and a player could not see the slider to undo it.
-- `PIN_SPEAKER = 26` exists but audio is stubbed; `beepOk()`/`beepError()` pulse the RGB LED instead.
+- `audio.speakerPin = 26` exists but audio is stubbed; `beepOk()`/`beepError()` pulse the RGB LED instead.
 - Wi-Fi/NTP is a non-blocking state machine driven by `tickTimeSync()` each frame, with a raw-UDP `ntpUdpProbe()` fallback for when lwIP's SNTP never answers. The success-path automatic resync interval is a cached global setting, 1–24 hours with a 6-hour default; boot sync, manual sync and failure retries are separate. Timezone comes from a named POSIX zone or public-IP lookup â€” routers don't advertise one in practice.
 
 ## Conventions
 
 - Hit testing: `Rect{...}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)`. `Rect` is in `Ui.h`, `TouchPoint` in `hal/TouchTypes.h`.
+- Board facts come from `BOARD` (`include/BoardProfile.h`), never from a literal. A peripheral a board does not wire is `PIN_NONE`, and the caller guards with `BOARD.hasSdSlot()`, `hasRgbLed()`, `hasSpeaker()`, `hasBatterySense()` or `hasBacklightControl()`.
 - Feedback: `board.beepOk()` / `board.beepError()`.
 - Draw through `Ui::` helpers so the Dark/Light theme is respected; avoid hardcoded colours outside icon art.
 - `src/games/CountryDataTable.cpp` is generated â€” edit `tools/gen_country_facts.py` and regenerate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,15 @@ add a second.
 **Board ports.** Braino targets the E32R28T-1 properly, with a 4-inch ST7796
 variant in progress. The CYD family has many variants whose differences fail
 silently — backlight on GPIO21 versus GPIO27, GPIO34 as a battery sense here
-but a light sensor on the ESP32-2432S028R. If you own a variant, the checklist
-is [AGENTS.md → "Supporting a new board"](AGENTS.md#supporting-a-new-board--the-whole-checklist):
-hardware reference first, then the PlatformIO env, then a verification app,
-then games. The "known issues" section of the board doc is not optional.
+but a light sensor on the ESP32-2432S028R. A board is described in two files
+and nowhere else — a profile header in `include/boards/` and a `[board_*]`
+section in `platformio.ini` — and no file under `src/` names a GPIO. The
+mechanics are in [docs/PORTING.md](docs/PORTING.md); everything a port needs
+around the code is in
+[AGENTS.md → "Supporting a new board"](AGENTS.md#supporting-a-new-board--the-whole-checklist):
+hardware reference first, then the profile and the PlatformIO env, then a
+verification app, then games. The "known issues" section of the board doc is
+not optional.
 
 **Tell us what's wrong with the code.** Much of this firmware was written by
 coding agents under human direction. Confident mistakes survive longer that

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,350,141 / 3,145,728 bytes (**74.7%**) |
+| Flash | 2,350,197 / 3,145,728 bytes (**74.7%**) |
 | RAM | 72,548 / 327,680 bytes (**22.1%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -41,9 +41,25 @@ Contribution workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md).
 **Board ports.** Braino targets the E32R28T-1 properly, with a 4-inch ST7796
 variant in progress. The CYD family has many variants whose differences fail
 silently — backlight on GPIO21 versus GPIO27, GPIO34 as a battery sense here
-but a light sensor on the ESP32-2432S028R. If you own a variant,
-[AGENTS.md](AGENTS.md) has the checklist: hardware reference first, then the
-PlatformIO env, then a verification app, then games.
+but a light sensor on the ESP32-2432S028R. A board is now described in two
+files and nowhere else: a profile header in `include/boards/` and a
+`[board_*]` section in `platformio.ini`. No file under `src/` names a GPIO,
+and the panel size the games draw on is derived from the profile rather than
+stated.
+
+Not every board can be supported. Braino needs a panel of at least 320×240
+in landscape, a touch controller (the only input it has), the backlight on a
+GPIO, and 4 MB of flash for the 3 MB app; a board missing one of those fails
+to compile with a message saying which, rather than flashing into something
+unreadable. An SD slot, an RGB LED, a speaker and battery sensing are all
+genuinely optional — the firmware does without them.
+
+And a board that *can* be supported has to be flashable from
+[the web installer](https://iamankushpandit.github.io/Gume/), not just from a
+toolchain: the page derives its board list from the same `[board_*]` sections,
+and the checks fail a port that CI does not build. [docs/PORTING.md](docs/PORTING.md)
+is the checklist, and [AGENTS.md](AGENTS.md) covers the hardware reference and
+bring-up app a port needs before it ships.
 
 **Tell us what's wrong with the code.** Much of this firmware was written by
 coding agents under human direction. Confident mistakes survive longer that
@@ -728,6 +744,11 @@ The main firmware also traces the clock over serial at 115200:
 ## Layout of the code
 
 ```
+include/
+  BoardProfile.h        the contract every supported board fills in
+  BoardConfig.h         selects one board profile; derives the screen constants
+  boards/
+    e32r28t1.h          the 2.8-inch board: pins, rotations, battery divider
 src/
   main.cpp              bringup entrypoint + normal app setup/loop
   wifi_diag.cpp         standalone radio test (env:wifidiag only)
@@ -782,6 +803,7 @@ tools/
   gen_screens.py        regenerates the images in this README
   gen_site.py           builds the GitHub Pages site and its flash manifests
   check_docs.py         fails if these docs have drifted from the code
+  check_boards.py       fails if a board is described inconsistently
 site/
   index.template.html   the landing page, with {{PLACEHOLDERS}} gen_site fills
 .github/workflows/
@@ -789,6 +811,7 @@ site/
   pages.yml             publishes the site with the same built firmware
 docs/
   BLE_BEACON_SPEC.md    what the beacon broadcasts, and why that is checkable
+  PORTING.md            adding a board: the two files, and the bring-up order
   SD_CONTENT_SPEC.md    optional SD content format
 ```
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,217 @@
+# Porting Braino! to another board
+
+Braino! describes each board it supports in **two files, and nowhere else**:
+
+| Where | What it holds |
+|---|---|
+| `include/boards/<id>.h` | the whole board: pins, rotations, the battery divider, which peripherals exist at all |
+| `platformio.ini` `[board_<id>]` | only the macros TFT_eSPI insists on being told at compile time, plus the board's name and the header naming it |
+
+No file under `src/` names a GPIO number, a panel size or a divider ratio. If
+you find yourself adding one, the board profile is missing a field — add it to
+`include/BoardProfile.h` instead, and fill it in for every existing board in the
+same commit.
+
+## First: can this board be supported at all?
+
+**Not every ESP32 display board can run Braino!, and one that cannot is out of
+scope rather than a porting task.** Four things are hard requirements. A board
+missing any of them fails to compile, with a message saying which — that is
+deliberate, because the alternative is firmware that flashes and then cannot be
+read or pressed.
+
+| Requirement | Why | If it is missing |
+|---|---|---|
+| A panel at least 320×240 in landscape | The playable games are drawn on a fixed canvas and position controls by arithmetic on it. A smaller panel puts buttons off the edge, and a player cannot press what is not there | Not supportable |
+| A touch controller | It is the only input this firmware has. There are no buttons | Not supportable |
+| The backlight on a GPIO | Brightness is a setting with a readability floor, and the idle path blanks the screen rather than only dimming it | Not supportable |
+| 4 MB of flash | The app partition is 3 MB (`huge_app.csv`) and the firmware is most of it. No partitioning makes a 2 MB part fit | Not supportable |
+
+Everything else is optional, and a board without it gets a firmware that
+quietly does without — no code change, just `PIN_NONE`:
+
+| Optional | What the firmware does without it |
+|---|---|
+| SD card slot | `sdReady()` is false; optional SD content simply is not loaded. Everything has defaults |
+| RGB LED | `beepOk()`/`beepError()` become no-ops. There is no audio either way |
+| Speaker | Already stubbed on every board |
+| Battery sense | The gauge blanks its digits, which is the honest reading for a board that cannot see a cell |
+
+A larger panel clears the size requirement, but see
+[What is *not* decoupled yet](#what-is-not-decoupled-yet) before assuming the
+games look right on it.
+
+## Second: a supported board is one people can flash
+
+If a board can be supported, **the web installer has to offer it**. Someone who
+owns the board should be able to put the firmware on it from
+`https://iamankushpandit.github.io/Gume/` without installing a toolchain;
+"supported" that only means "builds on the maintainer's machine" is not
+support.
+
+That is enforced rather than remembered. `tools/gen_site.py` derives the
+picker's board list from the same `[board_*]` sections in `platformio.ini`, so
+a new board appears on the page automatically — and refuses to generate the
+site until it has a label, an environment offered in `VARIANTS`, and a CI build
+producing the binaries its manifest points at. `tools/check_boards.py` reports
+the same gaps without needing to build. Both are in the checklist below.
+
+## The short version
+
+0. Check the board clears the four hard requirements above.
+1. Write `include/boards/<id>.h`.
+2. Add `[board_<id>]` to `platformio.ini`.
+3. Add `[env:<something>]` pointing at it.
+4. `python tools/check_boards.py`
+5. `pio run -e <something>`
+6. Flash it and check the six things in [Bring-up](#bring-up).
+7. Put it on the web installer and in CI, and update the docs —
+   [Landing a port](#landing-a-port).
+
+## 1. The board profile
+
+Copy `include/boards/e32r28t1.h` and work through it. Two rules:
+
+**Label every value with its field name in a `/* comment */`.** `BOARD` is
+aggregate-initialised, so the initialisers are positional and carry no names of
+their own. `tools/check_boards.py` reads those labels to prove the board filled
+in every field the contract declares — without them, a field added later would
+compile on your board with a silent zero in it.
+
+**An optional peripheral the board does not wire gets `PIN_NONE`.** The
+firmware checks `BOARD.hasSdSlot()`, `hasRgbLed()`, `hasSpeaker()` and
+`hasBatterySense()` and degrades quietly. A board with no battery connector
+needs no code change; the gauge blanks its digits, which is the honest answer.
+`PIN_NONE` is not a way past the four hard requirements above — those are
+asserted, and a board that trips one is telling you it cannot run this
+firmware.
+
+Things worth getting right the first time:
+
+- **`landscapeRotation`** is the quarter-turn that puts the USB socket at the
+  bottom. `portraitRotation` is a quarter-turn from it, and `BoardConfig.h`
+  static_asserts that the two are not the same axis. `Board::pollTouch()`
+  compensates for every rotation, so nothing in game code needs adjusting.
+- **The panel size is native (portrait)**, matching `TFT_WIDTH`/`TFT_HEIGHT`.
+  The landscape canvas the games draw on is *derived* — `SCREEN_WIDTH` and
+  `SCREEN_HEIGHT` come out of `BoardProfile::screenWidth()`. Do not state it
+  twice; the second statement would eventually be the wrong one.
+- **`commonAnode`** on the LED means a channel lights when its line is driven
+  LOW. Get it backwards and the LED is on and stays on.
+- **`dividerRatio`** is the multiplier from the voltage at the ADC to the
+  voltage at the cell. Read it off the vendor's own documentation, then confirm
+  it against a meter with `pio run -e batdiag` — that tool reads the same
+  profile, so what it measures is what the product will report.
+- **Use the vendor's pin table, not a generic ESP32 pinout, and never another
+  CYD variant's.** GPIO34 is battery sense on the E32R28T-1 and the light
+  sensor on the classic ESP32-2432S028R. They look like the same board.
+
+## 2. The platformio.ini section
+
+```ini
+[board_<id>]
+build_flags =
+    -D BOARD_NAME=\"<what the owner should see>\"
+    -D GUME_BOARD_HEADER=\"boards/<id>.h\"
+    -D <DRIVER>_DRIVER=1
+    -D TFT_WIDTH=...
+    -D TFT_HEIGHT=...
+    -D TFT_MISO=...  -D TFT_MOSI=...  -D TFT_SCLK=...
+    -D TFT_CS=...    -D TFT_DC=...    -D TFT_RST=...
+    -D TFT_BL=...
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D SPI_FREQUENCY=...
+    -D SPI_READ_FREQUENCY=...
+```
+
+Only what is *specific to this board* goes here. Everything shared —
+`USER_SETUP_LOADED`, the fonts, the language standard — is already in
+`[common]`, and `check_boards.py` fails if a board-specific macro drifts up
+into it, because in `[common]` it would be a claim about every board.
+
+The panel is now described twice: once for TFT_eSPI, once for us.
+`include/BoardConfig.h` static_asserts `TFT_WIDTH`, `TFT_HEIGHT` and `TFT_BL`
+against the profile, so the two cannot disagree past the compiler.
+
+**`TFT_BL` deserves its own paragraph.** With the wrong backlight pin the panel
+is completely dark while Wi-Fi, BLE, NVS, the LED and the screen saver all run
+perfectly — the serial log looks healthy and it reads as a dead screen or a
+wrong driver. The static_assert exists because that afternoon has already been
+spent once.
+
+## 3. The environment
+
+```ini
+[env:<something>]
+extends = esp32_common
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+lib_deps = ${common.lib_deps}
+lib_ldf_mode = deep+
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_<id>.build_flags}
+```
+
+One environment targets exactly one board; `check_boards.py` enforces that too.
+
+## Bring-up
+
+Flash it, open `pio device monitor`, and check these in order. Each failure
+mode below has actually happened.
+
+1. **Serial says `[boot] board=<name> rot=…`.** If nothing appears, it is the
+   partition or the upload, not the board profile.
+2. **The backlight comes on.** If the log is healthy and the screen is black,
+   it is `TFT_BL` — and the static_assert means the profile and the ini agree,
+   so *both* are wrong. Try the alternates for your panel.
+3. **The image is the right way round and not garbled.** ST7796S accepts most
+   ILI9341 commands, so the wrong driver gives you a real but mirrored,
+   partly-corrupt picture rather than nothing — easy to misread as "sort of
+   working".
+4. **Touch lands where you tap**, after the calibration wizard. If it is
+   mirrored or transposed, that is `landscapeRotation`, not the touch pins.
+5. **The battery percentage matches a meter.** `pio run -e batdiag` is the tool
+   for this; page CALIBRATE resolves the real divider ratio.
+6. **The LED shows the colour asked for.** Wrong colour, not no colour, means
+   the channels are crossed; LED permanently on means `commonAnode` is wrong.
+
+If the board has no battery, no SD slot or no LED, set those to `PIN_NONE` and
+skip the corresponding step — that is a supported configuration, not a
+limitation.
+
+## Landing a port
+
+A board that boots is not a board that ships. In the same commit:
+
+- `python tools/check_boards.py` and `python tools/check_docs.py`, both clean.
+  Between them they check the board is complete, that its two descriptions
+  agree, and that the web installer can actually offer it.
+- `README.md` — say which boards are supported, and record the flash/RAM
+  figures from your own `pio run` for the environment you added.
+- `CLAUDE.md` — the same figures, and the environment in the build section.
+- `tools/gen_site.py` — a `BOARD_DETAILS` entry (label, chip family, where to
+  buy one), and a `VARIANTS` entry for any new environment. The board list
+  itself is derived from `platformio.ini`, so this is the part that cannot be.
+  A picker entry whose firmware CI never built fails halfway through erasing
+  somebody's board, so `.github/workflows/pages.yml` and `ci.yml` must build it
+  too. `check_boards.py` and `check_docs.py` cross-check all of this.
+- `site/index.template.html` — the copy still describes **one** board in
+  prose. `gen_site.py` refuses to generate with a second board until that is
+  generalised, on purpose: offering a firmware the page then mislabels is worse
+  than not offering it.
+- `CHANGELOG.md`.
+
+## What is *not* decoupled yet
+
+The playable games are authored against a fixed landscape canvas and lay
+themselves out against `SCREEN_WIDTH`/`SCREEN_HEIGHT`. Those constants now
+follow the board, so a differently sized panel gets the right numbers — but a
+game that positions things by arithmetic on them has not been checked at any
+other size. The launcher and the system apps read `tft.width()`/`tft.height()`
+at render time and are responsive by rule (see `CLAUDE.md`); Settings and Wi-Fi
+are known violators.
+
+A port to a board with the same 320×240 landscape canvas needs nothing beyond
+this document. A port to a different panel size needs the games looked at, one
+at a time, and that is the work — not this layer.

--- a/include/BoardConfig.h
+++ b/include/BoardConfig.h
@@ -2,37 +2,116 @@
 
 #include <Arduino.h>
 
-constexpr int16_t SCREEN_WIDTH = 320;
-constexpr int16_t SCREEN_HEIGHT = 240;
+#include "BoardProfile.h"
+
+/* Selects the one board this build targets, and checks that its description
+ * agrees with TFT_eSPI's.
+ *
+ * `GUME_BOARD_HEADER` comes from platformio.ini -- one flag per `[board_*]`
+ * section, naming a header in `include/boards/`. Nothing else here is
+ * board-specific: the constants below are *derived* from the selected profile
+ * so that a new board changes one header and one ini section, never this file.
+ */
+#ifndef GUME_BOARD_HEADER
+#error "No board selected. Define GUME_BOARD_HEADER (see platformio.ini and docs/PORTING.md)."
+#endif
+
+#include GUME_BOARD_HEADER
+
+/* The canvas the playable games are drawn on. This is a property of the
+ * *games*, not of any board -- they were authored against it and position
+ * things by arithmetic on it. It is the floor a panel has to clear to be
+ * supportable at all, which is why it is stated here rather than derived. */
+constexpr int16_t GAME_CANVAS_WIDTH = 320;
+constexpr int16_t GAME_CANVAS_HEIGHT = 240;
+
+/* TFT_eSPI is configured through its own `-D` flags, so the panel is described
+ * twice: once for the driver, once for us. These asserts are what stops the
+ * two from drifting.
+ *
+ * The backlight one earns its keep on its own. With the wrong TFT_BL the panel
+ * is completely dark while Wi-Fi, BLE, NVS, the LED and the screen saver all
+ * run perfectly, so the serial log looks healthy and it reads as a dead
+ * screen. Catching it at compile time costs nothing; catching it on the bench
+ * costs an afternoon. */
+#if defined(TFT_WIDTH) && defined(TFT_HEIGHT)
+static_assert(BOARD.panel.nativeWidth == TFT_WIDTH,
+              "board profile disagrees with TFT_WIDTH in platformio.ini");
+static_assert(BOARD.panel.nativeHeight == TFT_HEIGHT,
+              "board profile disagrees with TFT_HEIGHT in platformio.ini");
+#endif
+#if defined(TFT_BL)
+static_assert(BOARD.panel.backlightPin == TFT_BL,
+              "board profile disagrees with TFT_BL in platformio.ini");
+#endif
+
+/* ---- What a board must have to be supported at all --------------------
+ *
+ * Not every ESP32 display board can run this firmware, and the honest place to
+ * say so is here, at the compiler, rather than in a build that flashes and
+ * then cannot be read or pressed. Each assert below is a hard requirement;
+ * a board failing one is out of scope, not a porting task.
+ *
+ * Everything NOT asserted here is optional: SD slot, RGB LED, speaker and
+ * battery sense are all `PIN_NONE`-able and the firmware does without them.
+ * Keep that line clear -- "degrades" and "cannot work" are different answers.
+ */
+
+/* A panel, and enough of one. The playable games are drawn on a fixed
+ * landscape canvas; a smaller panel would clip controls off the edge, and a
+ * player cannot press what is not there. */
+static_assert(BOARD.panel.nativeWidth > 0 && BOARD.panel.nativeHeight > 0,
+              "board profile has no panel size");
+static_assert(BOARD.panel.landscapeRotation < 4 && BOARD.panel.portraitRotation < 4,
+              "board rotations must be 0..3");
+static_assert((BOARD.panel.landscapeRotation & 1) != (BOARD.panel.portraitRotation & 1),
+              "landscape and portrait rotations must be a quarter-turn apart");
+static_assert(BOARD.screenWidth() >= GAME_CANVAS_WIDTH
+                  && BOARD.screenHeight() >= GAME_CANVAS_HEIGHT,
+              "panel is smaller than the canvas the games are drawn on; this "
+              "board cannot be supported");
+
+/* Touch is the only input this firmware has. There are no buttons. */
+static_assert(BOARD.touch.cs != PIN_NONE && BOARD.touch.irq != PIN_NONE,
+              "board has no touch controller; it is the only input the "
+              "firmware has, so this board cannot be supported");
+static_assert(BOARD.touch.mosi != PIN_NONE && BOARD.touch.miso != PIN_NONE
+                  && BOARD.touch.sclk != PIN_NONE,
+              "board profile is missing a touch bus line");
+static_assert(BOARD.touch.pressureThreshold > 0, "touch pressure threshold must be positive");
+static_assert(BOARD.touch.hitSlop >= 0, "touch hit slop cannot be negative");
+
+/* A backlight the firmware can drive. Brightness is a setting with a
+ * readability floor, and the idle path blanks the screen rather than only
+ * dimming it; neither works on a backlight wired permanently on. */
+static_assert(BOARD.hasBacklightControl(),
+              "board does not bring the backlight out to a GPIO; brightness "
+              "and screen blanking both need it, so this board cannot be "
+              "supported");
+
+/* Flash. The app partition is 3 MB (huge_app.csv), and the firmware is most of
+ * it -- a 2 MB part cannot hold this build however it is partitioned. */
+static_assert(BOARD.memory.flashBytes >= 4u * 1024u * 1024u,
+              "board has less than 4 MB of flash; the 3 MB app partition does "
+              "not fit, so this board cannot be supported");
+
+/* ---- Optional hardware: stated so the guards cannot be forgotten ------- */
+static_assert(!BOARD.hasBatterySense() || BOARD.battery.dividerRatio > 0.0f,
+              "a board with battery sense must state its divider ratio");
+static_assert(!BOARD.hasSdSlot()
+                  || (BOARD.sd.mosi != PIN_NONE && BOARD.sd.miso != PIN_NONE
+                      && BOARD.sd.sclk != PIN_NONE),
+              "a board with an SD slot must state its whole SD bus");
+
+/* The landscape canvas the playable games are authored against, derived from
+ * the panel and its rotation rather than stated. A 320x480 board gets 480x320
+ * here without touching a line of this file. */
+constexpr int16_t SCREEN_WIDTH = BOARD.screenWidth();
+constexpr int16_t SCREEN_HEIGHT = BOARD.screenHeight();
+
+/* Product chrome, not hardware: the same everywhere. */
 constexpr int16_t TOP_BAR_HEIGHT = 30;
 
-constexpr uint8_t PIN_TFT_BACKLIGHT = 21;
-
-constexpr uint8_t PIN_SD_CS = 5;
-constexpr uint8_t PIN_SD_MOSI = 23;
-constexpr uint8_t PIN_SD_MISO = 19;
-constexpr uint8_t PIN_SD_SCLK = 18;
-
-constexpr uint8_t PIN_TOUCH_MOSI = 32;
-constexpr uint8_t PIN_TOUCH_MISO = 39;
-constexpr uint8_t PIN_TOUCH_SCLK = 25;
-constexpr uint8_t PIN_TOUCH_CS = 33;
-constexpr uint8_t PIN_TOUCH_IRQ = 36;
-
-/* RGB LED, common anode (drive LOW to light a channel).
- *
- * The red and green lines are crossed relative to the usual standard pinout on this
- * unit (E32R28T-1): driving GPIO4 lit GREEN, not red. Verified on hardware -- an orange
- * (R255 G110) mix came out green, and purple (R200 B255) came out cyan/blue,
- * which is exactly what swapping R and G produces. */
-constexpr uint8_t PIN_RGB_R = 16;
-constexpr uint8_t PIN_RGB_G = 4;
-constexpr uint8_t PIN_RGB_B = 17;
-constexpr uint8_t PIN_SPEAKER = 26;
-
-// TODO(HARDWARE-VALIDATION): Verify E32R28T-1 battery ADC calibration, divider ratio, battery-present thresholds, no-battery behavior, USB-power behavior, and charging-state detection using physical hardware.
-constexpr uint8_t PIN_BAT_ADC = 34;
-
-constexpr uint16_t TOUCH_PRESSURE_THRESHOLD = 350;
-constexpr uint8_t TOUCH_HIT_SLOP = 8;
-
+/* Named here because every game hit-tests with it; it is the profile's value,
+ * not a second opinion about it. */
+constexpr int16_t TOUCH_HIT_SLOP = BOARD.touch.hitSlop;

--- a/include/BoardProfile.h
+++ b/include/BoardProfile.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <stdint.h>
+
+/* The contract every supported board has to fill in.
+ *
+ * Everything the firmware needs to know about a *specific* piece of hardware
+ * lives in one `BoardProfile` constant, declared by one header in
+ * `include/boards/`. Nothing outside that header may name a GPIO number, a
+ * panel size or a divider ratio; the rest of the firmware reads `BOARD`.
+ *
+ * That is the whole point. Before this existed, supporting a second board
+ * meant copying thirty `-D` flags into a second platformio.ini section and
+ * hoping every `PIN_*` constant in `include/BoardConfig.h` still applied --
+ * and the constants were global, so it could only ever describe one board at
+ * a time. `docs/PORTING.md` is the checklist; this file is the shape.
+ *
+ * Not every board can be supported, and this file is where that is decided.
+ * Braino! needs a colour panel of at least the size the games are drawn at,
+ * touch as its only input, a controllable backlight, and a 4 MB part to hold
+ * the 3 MB app. A board missing any of those cannot run this firmware, and
+ * `include/BoardConfig.h` refuses to compile for it rather than producing
+ * something that boots into a screen nobody can read or press. Saying no at
+ * the compiler is the kindest place to say it.
+ *
+ * Everything else is genuinely optional -- SD slot, RGB LED, speaker, battery
+ * sense -- and a board without one sets `PIN_NONE` and gets a firmware that
+ * quietly does without. That distinction is the useful one: "degrades" and
+ * "cannot work" are different answers and must not be blurred into each other.
+ *
+ * Rules for adding a field:
+ *
+ * - It must be a property of the *hardware*, not a product decision. Screen
+ *   rotation belongs here (the USB socket is on a physical edge); the idle
+ *   timeout does not.
+ * - Decide, and write down, whether a board can be supported without it. If it
+ *   can, `PIN_NONE` plus a `has...()` guard at every call site. If it cannot,
+ *   a static_assert in `BoardConfig.h` with a message saying what is missing.
+ * - Fill it in for every existing board in the same commit.
+ *   `tools/check_boards.py` reads the field names out of this file, so an
+ *   unfilled field fails the check rather than defaulting to zero.
+ */
+
+/* A line the board does not wire. Signed, because a GPIO number is not. */
+constexpr int8_t PIN_NONE = -1;
+
+/* The panel, as the hardware presents it -- native (portrait) dimensions, not
+ * the landscape canvas the games draw on. `screenWidth()` derives that. */
+struct PanelProfile {
+    int16_t nativeWidth;          // TFT_WIDTH: the panel's own short edge
+    int16_t nativeHeight;         // TFT_HEIGHT: its own long edge
+    uint8_t landscapeRotation;    // rotation putting the USB edge at the bottom
+    uint8_t portraitRotation;     // the quarter-turn from that
+    int8_t  backlightPin;         // must equal TFT_BL; see BoardConfig.h
+    bool    backlightActiveHigh;
+};
+
+/* XPT2046 resistive touch. `mosi`/`miso`/`sclk` may repeat the display's SPI
+ * pins on boards that share the bus; the firmware bit-bangs either way. */
+struct TouchProfile {
+    int8_t   mosi;
+    int8_t   miso;
+    int8_t   sclk;
+    int8_t   cs;
+    int8_t   irq;
+    uint16_t pressureThreshold;   // below this, and with IRQ high, it is noise
+    int16_t  hitSlop;             // pixels of forgiveness on every hit test
+};
+
+struct SdProfile {
+    int8_t   cs;
+    int8_t   mosi;
+    int8_t   miso;
+    int8_t   sclk;
+    uint32_t spiHz;
+};
+
+/* Status LED. `commonAnode` boards sink current, so a channel lights when the
+ * line is driven LOW -- getting this backwards is a lit LED that never goes
+ * out, not a dark one. */
+struct RgbLedProfile {
+    int8_t r;
+    int8_t g;
+    int8_t b;
+    bool   commonAnode;
+};
+
+struct AudioProfile {
+    int8_t speakerPin;
+};
+
+/* What the part has, as distinct from what the PCB wires. `flashBytes` gates
+ * support outright: the app partition is 3 MB (huge_app.csv), so a 4 MB part
+ * is the floor and nothing smaller can hold this firmware. It is declared
+ * rather than probed because the answer has to be known before the build, not
+ * after it has failed to fit. */
+struct MemoryProfile {
+    uint32_t flashBytes;
+};
+
+/* Battery sense. `dividerRatio` is the multiplier from the voltage at the ADC
+ * to the voltage at the cell; `sensorMaxVolts` is a plausibility ceiling on
+ * the reading, above which the divider or the ADC is faulty. Neither is a
+ * "is a pack fitted?" test -- see the comment block in hal/BoardPower.cpp. */
+struct BatteryProfile {
+    int8_t adcPin;
+    float  dividerRatio;
+    float  sensorMaxVolts;
+};
+
+struct BoardProfile {
+    const char*   name;           // what About and System Info show the owner
+    PanelProfile  panel;
+    TouchProfile  touch;
+    SdProfile     sd;
+    RgbLedProfile rgb;
+    AudioProfile  audio;
+    BatteryProfile battery;
+    MemoryProfile memory;
+
+    /* The landscape canvas the games are authored against. Derived, because a
+     * board that states both its panel size and its screen size can state them
+     * inconsistently, and one of the two would then be a lie. */
+    constexpr int16_t screenWidth() const {
+        return (panel.landscapeRotation & 1) ? panel.nativeHeight : panel.nativeWidth;
+    }
+    constexpr int16_t screenHeight() const {
+        return (panel.landscapeRotation & 1) ? panel.nativeWidth : panel.nativeHeight;
+    }
+
+    constexpr bool hasBacklightControl() const { return panel.backlightPin != PIN_NONE; }
+    constexpr bool hasSdSlot() const { return sd.cs != PIN_NONE; }
+    constexpr bool hasRgbLed() const { return rgb.r != PIN_NONE || rgb.g != PIN_NONE || rgb.b != PIN_NONE; }
+    constexpr bool hasSpeaker() const { return audio.speakerPin != PIN_NONE; }
+    constexpr bool hasBatterySense() const { return battery.adcPin != PIN_NONE; }
+};

--- a/include/boards/e32r28t1.h
+++ b/include/boards/e32r28t1.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "BoardProfile.h"
+
+/* HOSYOND / LCDWIKI E32R28T-1 (ESP32-32E) -- the 2.8-inch board Braino! ships
+ * on. ILI9341 320x240 TFT, XPT2046 resistive touch on its own bit-banged bus,
+ * micro-SD on VSPI, RGB status LED, and a TP4054 single-cell charger.
+ *
+ * Pins are from the vendor's own table, not a generic ESP32 pinout:
+ * https://www.lcdwiki.com/res/E32R28T-1/2.8inch_E32R28T-1_E32N28T-1_Arduino_Demo_Instructions.pdf
+ *
+ * The display's own SPI pins are NOT here: TFT_eSPI is configured entirely
+ * through `-D` flags in platformio.ini and reads them from there. BoardConfig.h
+ * cross-checks the two descriptions against each other so they cannot drift.
+ */
+inline constexpr BoardProfile BOARD = {
+    "E32R28T-1",
+
+    /* panel: 3 is landscape with the USB edge at the bottom (1 is the same
+     * view rotated 180). 0 is the quarter-turn from it. Board::pollTouch()
+     * compensates for every rotation, so don't hand-correct in game code. */
+    PanelProfile{
+        /* nativeWidth          */ 240,
+        /* nativeHeight         */ 320,
+        /* landscapeRotation    */ 3,
+        /* portraitRotation     */ 0,
+        /* backlightPin         */ 21,
+        /* backlightActiveHigh  */ true,
+    },
+
+    /* touch: a bus of its own, deliberately -- the TFT owns HSPI. See
+     * src/hal/CLAUDE.md for why this is bit-banged rather than a second
+     * hardware peripheral. */
+    TouchProfile{
+        /* mosi               */ 32,
+        /* miso               */ 39,
+        /* sclk               */ 25,
+        /* cs                 */ 33,
+        /* irq                */ 36,
+        /* pressureThreshold  */ 350,
+        /* hitSlop            */ 8,
+    },
+
+    SdProfile{
+        /* cs    */ 5,
+        /* mosi  */ 23,
+        /* miso  */ 19,
+        /* sclk  */ 18,
+        /* spiHz */ 16000000,
+    },
+
+    /* RGB LED, common anode (drive LOW to light a channel).
+     *
+     * The red and green lines are crossed relative to the usual standard pinout on this
+     * unit (E32R28T-1): driving GPIO4 lit GREEN, not red. Verified on hardware -- an orange
+     * (R255 G110) mix came out green, and purple (R200 B255) came out cyan/blue,
+     * which is exactly what swapping R and G produces. */
+    RgbLedProfile{
+        /* r           */ 16,
+        /* g           */ 4,
+        /* b           */ 17,
+        /* commonAnode */ true,
+    },
+
+    /* The pin exists; audio is stubbed. beepOk()/beepError() pulse the LED. */
+    AudioProfile{
+        /* speakerPin */ 26,
+    },
+
+    /* Battery sense on IO34 (ADC1_CH6, input-only). The vendor manual states
+     * the divider plainly: "the obtained voltage multiplied by 2 is the actual
+     * battery voltage". sensorMaxVolts is a fault ceiling on the ADC, NOT a
+     * pack-present test -- this board cannot tell a missing pack from a
+     * present one, and hal/BoardPower.cpp records the measurements proving it.
+     *
+     * GPIO34 on the classic CYD (ESP32-2432S028R) is the LDR, not a battery
+     * sense. Do not copy pin maps between CYD variants. */
+    BatteryProfile{
+        /* adcPin        */ 34,
+        /* dividerRatio  */ 2.0f,
+        /* sensorMaxVolts*/ 4.50f,
+    },
+
+    /* 4 MB part, partitioned huge_app.csv: 3 MB for the app. */
+    MemoryProfile{
+        /* flashBytes */ 4u * 1024u * 1024u,
+    },
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,6 +2,9 @@
 default_envs = app
 
 [common]
+; Everything here is true of Braino! on ANY board. Nothing board-specific may
+; live in this section -- that is what the [board_*] sections below are for,
+; and tools/check_boards.py fails the build if the two get mixed up.
 lib_deps =
     bodmer/TFT_eSPI@^2.5.43
     bblanchon/ArduinoJson@^7.0.4
@@ -14,11 +17,41 @@ build_unflags =
 build_flags =
     -std=gnu++17
     -Wall
-    -D BOARD_NAME=\"E32R28T-1\"
-    ; 3 = landscape with the USB edge at the bottom (1 is the same view
-    ; rotated 180). pollTouch() already compensates for every rotation.
-    -D CYD_SCREEN_ROTATION=3
     -D USER_SETUP_LOADED=1
+    -D LOAD_GLCD=1
+    -D LOAD_FONT2=1
+    -D LOAD_FONT4=1
+    -D SUPPORT_TRANSACTIONS
+    -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_INFO
+    -D DISABLE_ALL_LIBRARY_WARNINGS=1
+
+[esp32_common]
+; The MCU side of the target, shared by every environment on an ESP32 board.
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+monitor_rts = 0
+monitor_dtr = 0
+upload_speed = 460800
+board_build.partitions = huge_app.csv
+
+; ---------------------------------------------------------------------------
+; Boards. One section per supported board, and it holds ONLY what that board
+; makes true: its name, the header describing its pins, and the TFT_eSPI macros
+; the display driver insists on being told at compile time.
+;
+; Everything else about the board -- touch pins, SD pins, the LED, the battery
+; divider, which rotation is landscape -- lives in include/boards/<id>.h, and
+; BoardConfig.h static_asserts the two descriptions against each other so a
+; panel size or a backlight pin cannot be right in one place and wrong in the
+; other. docs/PORTING.md is the checklist for adding a section here.
+; ---------------------------------------------------------------------------
+
+[board_e32r28t1]
+build_flags =
+    -D BOARD_NAME=\"E32R28T-1\"
+    -D GUME_BOARD_HEADER=\"boards/e32r28t1.h\"
     -D ILI9341_2_DRIVER=1
     -D TFT_WIDTH=240
     -D TFT_HEIGHT=320
@@ -31,44 +64,29 @@ build_flags =
     -D TFT_BL=21
     -D TFT_BACKLIGHT_ON=HIGH
     -D USE_HSPI_PORT=1
-    -D LOAD_GLCD=1
-    -D LOAD_FONT2=1
-    -D LOAD_FONT4=1
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
-    -D SUPPORT_TRANSACTIONS
-    -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_INFO
-    -D DISABLE_ALL_LIBRARY_WARNINGS=1
 
 [env:app]
+; The console, on the 2.8-inch board. A second board is a second stanza of
+; exactly this shape with a different ${board_*.build_flags}.
+extends = esp32_common
 build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-monitor_rts = 0
-monitor_dtr = 0
-upload_speed = 460800
-board_build.partitions = huge_app.csv
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags}
+build_flags =
+    ${common.build_flags}
+    ${board_e32r28t1.build_flags}
 
 [env:bringup]
+extends = esp32_common
 build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-monitor_rts = 0
-monitor_dtr = 0
-upload_speed = 460800
-board_build.partitions = huge_app.csv
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}
+    ${board_e32r28t1.build_flags}
     -D CYD_BRINGUP_ONLY
 
 [env:batdiag]
@@ -83,31 +101,21 @@ build_flags =
 ; V_NO_BATTERY, which is the one threshold the vendor manual does not give),
 ; CALIBRATE (read the true divider ratio off against a meter) and LOG (CSV
 ; capture of a full discharge).
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-monitor_rts = 0
-monitor_dtr = 0
-upload_speed = 460800
-board_build.partitions = huge_app.csv
+extends = esp32_common
 build_src_filter = +<battery_diag.cpp>
 lib_deps = bodmer/TFT_eSPI@^2.5.43
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}
+    ${board_e32r28t1.build_flags}
     -D CYD_BATTERY_DIAG
 
 [env:wifidiag]
 ; Isolated Wi-Fi radio test: builds src/wifi_diag.cpp ALONE, so the TFT, touch,
 ; SD and game code cannot interfere. Flash it, open the serial monitor, and the
-; scan result tells us whether the fault is software or RF.
-platform = espressif32
-board = esp32dev
-framework = arduino
-monitor_speed = 115200
-upload_speed = 460800
-board_build.partitions = huge_app.csv
+; scan result tells us whether the fault is software or RF. It touches no board
+; peripheral, so it needs no board section.
+extends = esp32_common
 build_src_filter = +<wifi_diag.cpp>
 build_flags =
     -D CYD_WIFI_DIAG

--- a/src/battery_diag.cpp
+++ b/src/battery_diag.cpp
@@ -56,7 +56,7 @@
 namespace cfg {
 /* Everything a calibration session might need to change lives here, so no
  * measurement ever requires editing logic. */
-constexpr float DIVIDER_RATIO = 2.0f;      // vendor manual: "multiplied by 2"
+constexpr float DIVIDER_RATIO = BOARD.battery.dividerRatio;  // from the board profile
 constexpr float CAL_FACTOR = 1.0f;         // set from page CAL if the meter disagrees
 constexpr uint32_t ADC_VREF_MV = 1100;     // fallback only; eFuse overrides
 constexpr uint8_t BURST_SAMPLES = 32;      // per statistics burst
@@ -101,7 +101,7 @@ constexpr float CHARGE_SMOOTH_ALPHA = 0.30f;
  * V_SENSOR_MAX is the plausibility ceiling the firmware actually uses, and
  * means "the ADC is faulty", not "no pack". */
 constexpr float V_NO_BATTERY = 4.35f;
-constexpr float V_SENSOR_MAX = 4.50f;
+constexpr float V_SENSOR_MAX = BOARD.battery.sensorMaxVolts;
 constexpr float V_IMPLAUSIBLE = 3.00f;
 }   // namespace cfg
 
@@ -248,7 +248,7 @@ void sampleBurst() {
     uint16_t s[cfg::BURST_SAMPLES];
     uint32_t sum = 0;
     for (uint8_t i = 0; i < cfg::BURST_SAMPLES; ++i) {
-        s[i] = (uint16_t)analogRead(PIN_BAT_ADC);
+        s[i] = (uint16_t)analogRead(BOARD.battery.adcPin);
         sum += s[i];
     }
     qsort(s, cfg::BURST_SAMPLES, sizeof(uint16_t), cmpU16);
@@ -893,8 +893,8 @@ void setup() {
     pinMode(PIN_LED_GREEN, OUTPUT);
     pinMode(PIN_LED_BLUE, OUTPUT);
     led(false, false, false);
-    pinMode(PIN_BAT_ADC, INPUT);
-    analogSetPinAttenuation(PIN_BAT_ADC, ADC_11db);
+    pinMode(BOARD.battery.adcPin, INPUT);
+    analogSetPinAttenuation(BOARD.battery.adcPin, ADC_11db);
     /* Same characterisation the product uses: eFuse-backed, not a nominal
      * 3.3V reference. At 11dB the converter is linear only to ~2.45V, and a
      * 4.2V cell through a 2:1 divider lands at 2.1V -- comfortably inside it. */
@@ -902,9 +902,9 @@ void setup() {
                              cfg::ADC_VREF_MV, &adcChars);
 
     tft.init();
-    tft.setRotation(CYD_SCREEN_ROTATION);
-    pinMode(PIN_TFT_BACKLIGHT, OUTPUT);
-    digitalWrite(PIN_TFT_BACKLIGHT, HIGH);
+    tft.setRotation(BOARD.panel.landscapeRotation);
+    pinMode(BOARD.panel.backlightPin, OUTPUT);
+    digitalWrite(BOARD.panel.backlightPin, BOARD.panel.backlightActiveHigh ? HIGH : LOW);
 
     startedMs = millis();
     sampleBurst();

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -96,10 +96,12 @@ void BrainoApp::begin() {
      * engine/Entropy.h. */
     content_.begin(board_);
     Clock::begin();
-    Serial.printf("[boot] rot=%d layout=%s (CYD_SCREEN_ROTATION=%d)\n",
+    Serial.printf("[boot] board=%s rot=%d layout=%s (landscape=%d portrait=%d)\n",
+                  BOARD.name,
                   (int)board_.displayRotation(),
                   board_.layoutMode() == Board::LayoutMode::Vertical ? "Vertical" : "Horizontal",
-                  (int)CYD_SCREEN_ROTATION);
+                  (int)BOARD.panel.landscapeRotation,
+                  (int)BOARD.panel.portraitRotation);
     Serial.printf("[boot] ntp=%d creds=%d ssid='%s' tzmin=%d\n",
                   (int)board_.ntpEnabled(), (int)board_.hasWifiCredentials(),
                   board_.wifiSsid().c_str(), (int)board_.tzOffsetMinutes());
@@ -329,7 +331,9 @@ void BrainoApp::applyRotation(uint8_t rotation) {
 }
 
 uint8_t BrainoApp::effectiveRotation(bool landscape) {
-    return landscape ? CYD_SCREEN_ROTATION : CYD_PORTRAIT_ROTATION;
+    /* Which quarter-turn is "landscape" depends on where the board puts its
+     * USB socket, so both come from the board profile. */
+    return landscape ? BOARD.panel.landscapeRotation : BOARD.panel.portraitRotation;
 }
 
 /* One place that decides orientation, because it used to be three and one of

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -61,8 +61,6 @@ private:
         Locked
     };
 
-    static constexpr uint8_t CYD_PORTRAIT_ROTATION = 0;
-
     uint8_t effectiveRotation(bool landscape);
     /** The rotation the screen that is up right now asks for. */
     uint8_t rotationForActiveScreen();

--- a/src/hal/Board.cpp
+++ b/src/hal/Board.cpp
@@ -9,30 +9,41 @@ void Board::begin() {
     Serial.begin(115200);
     delay(100);
 
-    pinMode(PIN_BAT_ADC, INPUT);
+    /* Every peripheral below is optional in the profile. A board that does not
+     * wire one sets PIN_NONE and skips it here -- that is what makes a port a
+     * header rather than a patch. Touch and the panel are not optional. */
+    if (BOARD.hasBatterySense()) {
+        pinMode(BOARD.battery.adcPin, INPUT);
+    }
 
-    pinMode(PIN_TFT_BACKLIGHT, OUTPUT);
-    digitalWrite(PIN_TFT_BACKLIGHT, HIGH);
+    if (BOARD.hasBacklightControl()) {
+        pinMode(BOARD.panel.backlightPin, OUTPUT);
+        digitalWrite(BOARD.panel.backlightPin, BOARD.panel.backlightActiveHigh ? HIGH : LOW);
+    }
 
-    pinMode(PIN_RGB_R, OUTPUT);
-    pinMode(PIN_RGB_G, OUTPUT);
-    pinMode(PIN_RGB_B, OUTPUT);
-    setRgb(false, false, false);
+    if (BOARD.hasRgbLed()) {
+        if (BOARD.rgb.r != PIN_NONE) pinMode(BOARD.rgb.r, OUTPUT);
+        if (BOARD.rgb.g != PIN_NONE) pinMode(BOARD.rgb.g, OUTPUT);
+        if (BOARD.rgb.b != PIN_NONE) pinMode(BOARD.rgb.b, OUTPUT);
+        setRgb(false, false, false);
+    }
 
-    pinMode(PIN_SPEAKER, OUTPUT);
-    digitalWrite(PIN_SPEAKER, LOW);
+    if (BOARD.hasSpeaker()) {
+        pinMode(BOARD.audio.speakerPin, OUTPUT);
+        digitalWrite(BOARD.audio.speakerPin, LOW);
+    }
 
-    pinMode(PIN_TOUCH_MOSI, OUTPUT);
-    pinMode(PIN_TOUCH_MISO, INPUT);
-    pinMode(PIN_TOUCH_SCLK, OUTPUT);
-    pinMode(PIN_TOUCH_CS, OUTPUT);
-    pinMode(PIN_TOUCH_IRQ, INPUT);
-    digitalWrite(PIN_TOUCH_CS, HIGH);
-    digitalWrite(PIN_TOUCH_SCLK, LOW);
+    pinMode(BOARD.touch.mosi, OUTPUT);
+    pinMode(BOARD.touch.miso, INPUT);
+    pinMode(BOARD.touch.sclk, OUTPUT);
+    pinMode(BOARD.touch.cs, OUTPUT);
+    pinMode(BOARD.touch.irq, INPUT);
+    digitalWrite(BOARD.touch.cs, HIGH);
+    digitalWrite(BOARD.touch.sclk, LOW);
 
     tft_.init();
-    tft_.setRotation(CYD_SCREEN_ROTATION);
-    displayRotation_ = CYD_SCREEN_ROTATION;
+    tft_.setRotation(BOARD.panel.landscapeRotation);
+    displayRotation_ = BOARD.panel.landscapeRotation;
     tft_.setTextWrap(false, false);
     tft_.fillScreen(Ui::bg());
 
@@ -52,8 +63,12 @@ bool Board::sdReady() const {
 }
 
 bool Board::mountSd() {
-    sdSpi_.begin(PIN_SD_SCLK, PIN_SD_MISO, PIN_SD_MOSI, PIN_SD_CS);
-    sdMounted_ = SD.begin(PIN_SD_CS, sdSpi_, 16000000);
+    if (!BOARD.hasSdSlot()) {
+        sdMounted_ = false;
+        return false;
+    }
+    sdSpi_.begin(BOARD.sd.sclk, BOARD.sd.miso, BOARD.sd.mosi, BOARD.sd.cs);
+    sdMounted_ = SD.begin(BOARD.sd.cs, sdSpi_, BOARD.sd.spiHz);
     setRgb(!sdMounted_, sdMounted_, false);
     Serial.printf("SD mount: %s\n", sdMounted_ ? "ok" : "failed");
     return sdMounted_;

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -75,8 +75,8 @@ public:
 
     /* This board brings no charge-status line out to a GPIO: the TP4056-style
      * charger's CHRG pin is not wired to the ESP32, so the only thing the
-     * firmware can see is the cell voltage on PIN_BAT_ADC. Charging is
-     * therefore *inferred* from how that voltage moves, in BoardPower.cpp.
+     * firmware can see is the cell voltage on the profile's battery ADC pin.
+     * Charging is therefore *inferred* from how that voltage moves, in BoardPower.cpp.
      *
      * UNKNOWN is the honest answer for the first few seconds after boot, and
      * whenever the ADC reads outside a plausible range. It is NOT a no-battery

--- a/src/hal/BoardDisplay.cpp
+++ b/src/hal/BoardDisplay.cpp
@@ -90,7 +90,7 @@ bool Board::drawBmp(const char* path, int16_t x, int16_t y, int16_t maxW, int16_
             }
             const int16_t px = x + col;
             const int16_t py = y + row;
-            if (px >= 0 && px < SCREEN_WIDTH && py >= 0 && py < SCREEN_HEIGHT) {
+            if (px >= 0 && px < tft_.width() && py >= 0 && py < tft_.height()) {
                 tft_.drawPixel(px, py, color);
             }
         }

--- a/src/hal/BoardFeedback.cpp
+++ b/src/hal/BoardFeedback.cpp
@@ -8,6 +8,18 @@ constexpr uint8_t RGB_CH_G = 6;
 constexpr uint8_t RGB_CH_B = 7;
 constexpr uint32_t RGB_PWM_HZ = 5000;
 constexpr uint8_t RGB_PWM_BITS = 8;
+
+void attachRgbChannel(int8_t pin, uint8_t channel) {
+    if (pin == PIN_NONE) return;
+    ledcSetup(channel, RGB_PWM_HZ, RGB_PWM_BITS);
+    ledcAttachPin(pin, channel);
+}
+
+/* Duty is inverted on a common-anode LED: full brightness is a line held low. */
+void writeRgbChannel(int8_t pin, uint8_t channel, uint8_t level) {
+    if (pin == PIN_NONE) return;
+    ledcWrite(channel, BOARD.rgb.commonAnode ? 255 - level : level);
+}
 }
 
 void Board::beep(uint16_t frequency, uint16_t ms) {
@@ -25,10 +37,15 @@ void Board::beepError() {
     beep(220, 120);
 }
 
+/* Common-anode boards sink current, so a channel lights when its line is
+ * driven LOW. A board that wires the LED the other way says so in its profile
+ * rather than needing this inverted here. */
 void Board::setRgb(bool red, bool green, bool blue) {
-    digitalWrite(PIN_RGB_R, red ? LOW : HIGH);
-    digitalWrite(PIN_RGB_G, green ? LOW : HIGH);
-    digitalWrite(PIN_RGB_B, blue ? LOW : HIGH);
+    const uint8_t on = BOARD.rgb.commonAnode ? LOW : HIGH;
+    const uint8_t off = BOARD.rgb.commonAnode ? HIGH : LOW;
+    if (BOARD.rgb.r != PIN_NONE) digitalWrite(BOARD.rgb.r, red ? on : off);
+    if (BOARD.rgb.g != PIN_NONE) digitalWrite(BOARD.rgb.g, green ? on : off);
+    if (BOARD.rgb.b != PIN_NONE) digitalWrite(BOARD.rgb.b, blue ? on : off);
 }
 
 void Board::setRgbEnabled(bool on) {
@@ -70,21 +87,19 @@ void Board::setNearbyEnabled(bool on) {
 }
 
 void Board::setRgbColor(uint8_t r, uint8_t g, uint8_t b) {
+    if (!BOARD.hasRgbLed()) return;
     if (!rgbReady_) {
-        ledcSetup(RGB_CH_R, RGB_PWM_HZ, RGB_PWM_BITS);
-        ledcSetup(RGB_CH_G, RGB_PWM_HZ, RGB_PWM_BITS);
-        ledcSetup(RGB_CH_B, RGB_PWM_HZ, RGB_PWM_BITS);
-        ledcAttachPin(PIN_RGB_R, RGB_CH_R);
-        ledcAttachPin(PIN_RGB_G, RGB_CH_G);
-        ledcAttachPin(PIN_RGB_B, RGB_CH_B);
+        attachRgbChannel(BOARD.rgb.r, RGB_CH_R);
+        attachRgbChannel(BOARD.rgb.g, RGB_CH_G);
+        attachRgbChannel(BOARD.rgb.b, RGB_CH_B);
         rgbReady_ = true;
     }
     rgbR_ = r;
     rgbG_ = g;
     rgbB_ = b;
-    ledcWrite(RGB_CH_R, 255 - r);
-    ledcWrite(RGB_CH_G, 255 - g);
-    ledcWrite(RGB_CH_B, 255 - b);
+    writeRgbChannel(BOARD.rgb.r, RGB_CH_R, r);
+    writeRgbChannel(BOARD.rgb.g, RGB_CH_G, g);
+    writeRgbChannel(BOARD.rgb.b, RGB_CH_B, b);
 }
 
 void Board::pulseRgb(uint8_t r, uint8_t g, uint8_t b, uint16_t ms) {

--- a/src/hal/BoardPower.cpp
+++ b/src/hal/BoardPower.cpp
@@ -8,7 +8,10 @@ bool s_adcCharacterised = false;
 
 constexpr uint32_t ADC_DEFAULT_VREF_MV = 1100;
 constexpr uint8_t BATTERY_SAMPLES = 8;
-constexpr float DIVIDER_RATIO = 2.0f;
+/* The divider and the ADC's fault ceiling are properties of the board, so they
+ * come from its profile rather than being restated here. Everything below them
+ * is a property of a lithium cell, and is the same on any board. */
+constexpr float DIVIDER_RATIO = BOARD.battery.dividerRatio;
 /* ---- Why there is no "is a pack fitted?" test -------------------------
  * There is not one, and on this board there cannot be. Measured 2026-08-24
  * with the batdiag wizard, three power states, 8s averaged:
@@ -32,7 +35,7 @@ constexpr float DIVIDER_RATIO = 2.0f;
  * With no pack fitted the gauge reads HIGH -- about 4.16 V, near full -- and
  * that is the honest description of what this hardware can see.
  */
-constexpr float V_SENSOR_MAX = 4.50f;
+constexpr float V_SENSOR_MAX = BOARD.battery.sensorMaxVolts;
 constexpr float V_IMPLAUSIBLE = 3.0f;
 
 struct CurvePoint { float volts; uint8_t pct; };
@@ -72,6 +75,13 @@ constexpr uint8_t BL_CHANNEL = 4;
 constexpr uint32_t BL_PWM_HZ = 5000;
 constexpr uint8_t BL_PWM_BITS = 8;
 bool blReady = false;
+
+/* A backlight wired active-low is off at full duty, so the duty is inverted
+ * rather than the pin, which would defeat the PWM entirely. */
+uint32_t backlightDuty(uint8_t percent) {
+    const uint32_t duty = (static_cast<uint32_t>(percent) * 255) / 100;
+    return BOARD.panel.backlightActiveHigh ? duty : 255 - duty;
+}
 }
 
 Board::BatteryTelemetry Board::readBatteryTelemetry() {
@@ -80,8 +90,17 @@ Board::BatteryTelemetry Board::readBatteryTelemetry() {
         return batterySample_;
     }
 
+    /* No sense line means no reading. A zeroed sample reads as implausible
+     * downstream, which is already how the gauge says "I cannot see this". */
+    if (!BOARD.hasBatterySense()) {
+        batterySample_ = BatteryTelemetry{};
+        batterySampleMs_ = now;
+        batterySampled_ = true;
+        return batterySample_;
+    }
+
     if (!s_adcCharacterised) {
-        analogSetPinAttenuation(PIN_BAT_ADC, ADC_11db);
+        analogSetPinAttenuation(BOARD.battery.adcPin, ADC_11db);
         esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12,
                                  ADC_DEFAULT_VREF_MV, &s_adcChars);
         s_adcCharacterised = true;
@@ -89,7 +108,7 @@ Board::BatteryTelemetry Board::readBatteryTelemetry() {
 
     uint32_t accumulator = 0;
     for (uint8_t i = 0; i < BATTERY_SAMPLES; ++i) {
-        accumulator += static_cast<uint32_t>(analogRead(PIN_BAT_ADC));
+        accumulator += static_cast<uint32_t>(analogRead(BOARD.battery.adcPin));
     }
 
     BatteryTelemetry sample;
@@ -240,17 +259,18 @@ void Board::setBrightness(uint8_t percent) {
 }
 
 void Board::applyBrightness() {
+    if (!BOARD.hasBacklightControl()) return;
     if (!blReady) {
         ledcSetup(BL_CHANNEL, BL_PWM_HZ, BL_PWM_BITS);
-        ledcAttachPin(PIN_TFT_BACKLIGHT, BL_CHANNEL);
+        ledcAttachPin(BOARD.panel.backlightPin, BL_CHANNEL);
         blReady = true;
     }
-    ledcWrite(BL_CHANNEL, (brightness() * 255) / 100);
+    ledcWrite(BL_CHANNEL, backlightDuty(brightness()));
 }
 
 void Board::displaySleep() {
     if (displayAsleep_) return;
-    ledcWrite(BL_CHANNEL, 0);
+    if (BOARD.hasBacklightControl()) ledcWrite(BL_CHANNEL, backlightDuty(0));
     tft_.writecommand(0x10);
     displayAsleep_ = true;
     displaySleepTelemetry_.sleepCount++;

--- a/src/hal/BoardTouch.cpp
+++ b/src/hal/BoardTouch.cpp
@@ -72,25 +72,25 @@ void Board::saveTouchCalibration() {
 
 uint16_t Board::readTouchAdc(uint8_t command) {
     uint16_t raw = 0;
-    digitalWrite(PIN_TOUCH_CS, LOW);
+    digitalWrite(BOARD.touch.cs, LOW);
 
     for (int8_t bit = 7; bit >= 0; --bit) {
-        digitalWrite(PIN_TOUCH_MOSI, (command & (1 << bit)) ? HIGH : LOW);
-        digitalWrite(PIN_TOUCH_SCLK, HIGH);
+        digitalWrite(BOARD.touch.mosi, (command & (1 << bit)) ? HIGH : LOW);
+        digitalWrite(BOARD.touch.sclk, HIGH);
         delayMicroseconds(2);
-        digitalWrite(PIN_TOUCH_SCLK, LOW);
+        digitalWrite(BOARD.touch.sclk, LOW);
         delayMicroseconds(2);
     }
 
     for (uint8_t bit = 0; bit < 16; ++bit) {
-        digitalWrite(PIN_TOUCH_SCLK, HIGH);
+        digitalWrite(BOARD.touch.sclk, HIGH);
         delayMicroseconds(2);
-        raw = static_cast<uint16_t>((raw << 1) | (digitalRead(PIN_TOUCH_MISO) ? 1 : 0));
-        digitalWrite(PIN_TOUCH_SCLK, LOW);
+        raw = static_cast<uint16_t>((raw << 1) | (digitalRead(BOARD.touch.miso) ? 1 : 0));
+        digitalWrite(BOARD.touch.sclk, LOW);
         delayMicroseconds(2);
     }
 
-    digitalWrite(PIN_TOUCH_CS, HIGH);
+    digitalWrite(BOARD.touch.cs, HIGH);
     return static_cast<uint16_t>((raw >> 3) & 0x0FFF);
 }
 
@@ -103,8 +103,8 @@ Board::RawTouch Board::readRawTouch() {
         pressure = static_cast<uint16_t>(z1 + 4095 - z2);
     }
 
-    const bool irqDown = digitalRead(PIN_TOUCH_IRQ) == LOW;
-    if (!irqDown && pressure < TOUCH_PRESSURE_THRESHOLD) {
+    const bool irqDown = digitalRead(BOARD.touch.irq) == LOW;
+    if (!irqDown && pressure < BOARD.touch.pressureThreshold) {
         return touch;
     }
 

--- a/src/hal/CLAUDE.md
+++ b/src/hal/CLAUDE.md
@@ -2,6 +2,12 @@
 
 The only place that talks to hardware. Ordinary games should not reach this directly; system screens use `GameHost::board()` and should prefer the narrow access facets when they only need one concern.
 
+## Which board, and how this code knows
+
+**Nothing in here may name a GPIO number, a panel size or a divider ratio.** Every hardware fact comes from `BOARD`, the one `BoardProfile` constant selected at compile time by `GUME_BOARD_HEADER` and defined in `include/boards/<id>.h`. That is what lets a second board be a header rather than a patch, and it is the rule that stops this directory becoming board-specific again.
+
+A peripheral the board does not wire is `PIN_NONE`, and the caller guards: `BOARD.hasSdSlot()`, `hasRgbLed()`, `hasSpeaker()`, `hasBatterySense()`, `hasBacklightControl()`. Degrade quietly rather than fail -- a board with no battery connector blanks the gauge's digits, which is the honest answer, and needs no code change here at all. Adding a field to the contract means filling it in for every existing board in the same commit; `tools/check_boards.py` is what notices when that did not happen. `docs/PORTING.md` has the rest.
+
 ## Board.* + BoardAccess.h + BoardStorage.cpp + BoardStorageMaintenance.cpp
 
 `Board.h` remains the legacy aggregate for existing call sites, but it also exposes no-vtable concern facades: `displayAccess()`, `touchAccess()`, `storageAccess()`, `powerAccess()`, `networkAccess()` and `feedbackAccess()`. New subsystem code should take the narrowest facade it can. The implementation is split by concern:
@@ -35,7 +41,7 @@ Deleting a player is a storage operation, not a name-list edit. `removePlayer()`
 
 ### Touch
 
-Bit-banged SPI to the XPT2046 (the TFT owns HSPI). `pollTouch()` averages samples, applies `TOUCH_PRESSURE_THRESHOLD`, maps through a 3-point affine calibration, and compensates for the active rotation — so game code should never adjust coordinates itself. Calibration persists in NVS behind a magic number; `runTouchCalibration()` re-runs the wizard.
+Bit-banged SPI to the XPT2046 (the TFT owns HSPI). `pollTouch()` averages samples, applies `BOARD.touch.pressureThreshold`, maps through a 3-point affine calibration, and compensates for the active rotation — so game code should never adjust coordinates itself. Calibration persists in NVS behind a magic number; `runTouchCalibration()` re-runs the wizard.
 
 `TouchPoint` lives in `TouchTypes.h` and carries `down`, `justPressed`, `justReleased`, `x`, `y`, `pressure`; edge flags come from diffing against `lastTouch_`.
 
@@ -47,9 +53,9 @@ Panel sleep/wake is observable: `displaySleepTelemetry()` reports sleep count, w
 
 ### RGB LED
 
-LEDC PWM, common anode (inverted drive). `setRgbColor()` holds a colour, `pulseRgb()` shows one briefly, `tickRgb()` fades it and must be called every frame from the main loop. `beepOk()`/`beepError()` are the game-facing wrappers — there is no audio despite the name; `PIN_SPEAKER` is stubbed.
+LEDC PWM, common anode (inverted drive). `setRgbColor()` holds a colour, `pulseRgb()` shows one briefly, `tickRgb()` fades it and must be called every frame from the main loop. `beepOk()`/`beepError()` are the game-facing wrappers — there is no audio despite the name; the speaker pin is stubbed. Whether the drive is inverted comes from `BOARD.rgb.commonAnode`, not from an assumption in the driver.
 
-The red and green GPIOs are physically crossed on this unit versus the standard pinout. `BoardConfig.h` already accounts for it (`PIN_RGB_R = 16`, `PIN_RGB_G = 4`) and it was verified on hardware — leave it alone.
+The red and green GPIOs are physically crossed on this unit versus the standard pinout. The E32R28T-1 profile already accounts for it (`rgb.r = 16`, `rgb.g = 4`) and it was verified on hardware — leave it alone.
 
 ### Wi-Fi and time
 
@@ -67,7 +73,7 @@ Time/date formatting and sync-state helpers over the ESP32 RTC.
 
 ## Battery sensing
 
-`PIN_BAT_ADC` is GPIO34 = **ADC1**_CH6, and that matters: ADC2 is unusable while Wi-Fi is associated, and this radio comes up for NTP. Don't move battery sensing to an ADC2 pin.
+`BOARD.battery.adcPin` is GPIO34 on this board = **ADC1**_CH6, and that matters: ADC2 is unusable while Wi-Fi is associated, and this radio comes up for NTP. Don't move battery sensing to an ADC2 pin.
 
 `readBatteryTelemetry()` caches one sample set for `BATTERY_SAMPLE_MS` (2s) and every other accessor — `getBatteryVoltage()`, `getPowerSource()`, `getBatteryPercent()` — reads through it. **Keep it that way.** Before this, each accessor ran its own 10-sample conversion with a `delay(1)` between samples, and `Ui::drawTopBar()` calls two of them: every top bar cost ~20ms of blocking delay, and the System Info board tab ~30ms per repaint. That is most of a frame, and it is what made scrolling feel sluggish.
 

--- a/tools/check_boards.py
+++ b/tools/check_boards.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Check that every supported board is described once, completely, and consistently.
+
+A board is described in exactly two places, and they have to agree:
+
+  * `include/boards/<id>.h` -- the `BoardProfile` the firmware reads. Pins,
+    rotations, the battery divider, which peripherals exist at all.
+  * a `[board_<id>]` section in `platformio.ini` -- only the handful of macros
+    TFT_eSPI insists on being told at compile time, plus the board's name and
+    the header naming.
+
+`include/BoardConfig.h` static_asserts the overlap, so a mismatch cannot be
+flashed. This check runs without a toolchain and catches the rest: a field
+added to `BoardProfile` that an existing board never filled in, a header with
+no section pointing at it, a board-specific macro that has drifted up into
+`[common]` where it would silently apply to every board.
+
+    python tools/check_boards.py
+
+Exit 0 = consistent, 1 = something needs fixing.
+
+Why the fields are checked by comment
+-------------------------------------
+`BOARD` is aggregate-initialised, so the initialisers are positional and carry
+no field names of their own. Each board header therefore labels every value
+with a `/* fieldName */` comment, and this check reads those labels. It is a
+convention, not a language rule -- which is exactly why it needs a checker.
+Adding a field to `BoardProfile` without filling it in on every board would
+otherwise compile, and the board would boot with a zero for it.
+"""
+
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOARDS_DIR = os.path.join(ROOT, "include", "boards")
+
+# Macros that describe one specific board. In [common] they would be a claim
+# about every board, which is how a second board ends up with the first one's
+# backlight pin.
+BOARD_SPECIFIC_MACRO = re.compile(
+    r"-D\s*(BOARD_NAME|GUME_BOARD_HEADER|TFT_\w+|\w+_DRIVER|SPI_FREQUENCY"
+    r"|SPI_READ_FREQUENCY|USE_HSPI_PORT)\b")
+
+# Every [board_*] section has to state these; the firmware or the display
+# driver reads each one, and a missing one fails late and confusingly.
+REQUIRED_BOARD_MACROS = ("BOARD_NAME", "GUME_BOARD_HEADER",
+                         "TFT_WIDTH", "TFT_HEIGHT", "TFT_BL")
+
+# Environments that build no board peripheral, so they need no board section.
+BOARDLESS_ENVS = ("wifidiag",)
+
+
+def read(*parts):
+    with open(os.path.join(ROOT, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def profile_contract():
+    """What include/BoardProfile.h requires of every board.
+
+    Read out of the header rather than listed here, so adding a field to the
+    contract automatically starts requiring it of every board.
+
+    Returns (leaf field names, the peripheral struct types BoardProfile nests).
+    """
+    text = read("include", "BoardProfile.h")
+    fields = []
+    groups = []
+    for name, body in re.findall(r"struct\s+(\w+)\s*\{(.*?)\n\};", text, re.S):
+        for line in body.splitlines():
+            line = line.split("//")[0].strip()
+            match = re.match(r"^(?:const\s+)?([\w:]+)\*?\s+(\w+)\s*;$", line)
+            if not match:
+                continue
+            kind, field = match.groups()
+            if name == "BoardProfile":
+                # A nested peripheral group. Its own leaves are required below;
+                # the group itself is satisfied by naming the type.
+                if kind.endswith("Profile"):
+                    groups.append(kind)
+                continue
+            fields.append(field)
+    return fields, groups
+
+
+def ini_sections(text):
+    """{section name: raw body} for every section in an ini file."""
+    sections = {}
+    current = None
+    for line in text.splitlines():
+        header = re.match(r"^\[([^\]]+)\]\s*$", line)
+        if header:
+            current = header.group(1)
+            sections[current] = []
+        elif current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(body) for name, body in sections.items()}
+
+
+def check_headers(problems, fields, groups):
+    if not os.path.isdir(BOARDS_DIR):
+        problems.append("include/boards/ does not exist")
+        return []
+
+    headers = sorted(name for name in os.listdir(BOARDS_DIR)
+                     if name.endswith(".h"))
+    if not headers:
+        problems.append("include/boards/ contains no board profile")
+
+    for name in headers:
+        text = read("include", "boards", name)
+        where = "include/boards/%s" % name
+
+        if '#include "BoardProfile.h"' not in text:
+            problems.append("%s does not include BoardProfile.h" % where)
+        if not re.search(r"\binline\s+constexpr\s+BoardProfile\s+BOARD\s*=", text):
+            problems.append(
+                "%s does not define `inline constexpr BoardProfile BOARD`" % where)
+
+        for group in groups:
+            if not re.search(r"\b%s\s*\{" % group, text):
+                problems.append("%s never initialises its %s" % (where, group))
+
+        labelled = set(re.findall(r"/\*\s*(\w+)\s*\*/", text))
+        for field in fields:
+            if field not in labelled:
+                problems.append(
+                    "%s never fills in BoardProfile field '%s' -- add it, or the "
+                    "board boots with a zero for it" % (where, field))
+
+    return headers
+
+
+def check_ini(problems, headers):
+    text = read("platformio.ini")
+    sections = ini_sections(text)
+
+    common = sections.get("common", "")
+    for macro in BOARD_SPECIFIC_MACRO.findall(common):
+        problems.append(
+            "platformio.ini [common] defines -D %s, which is true of one board "
+            "rather than all of them; move it to a [board_*] section" % macro)
+
+    boards = {name: body for name, body in sections.items()
+              if name.startswith("board_")}
+    if not boards:
+        problems.append("platformio.ini declares no [board_*] section")
+
+    referenced_headers = set()
+    for name, body in sorted(boards.items()):
+        for macro in REQUIRED_BOARD_MACROS:
+            if not re.search(r"-D\s*%s\s*=" % macro, body):
+                problems.append("platformio.ini [%s] does not define %s"
+                                % (name, macro))
+
+        header = re.search(r'-D\s*GUME_BOARD_HEADER\s*=\s*\\?"([^"\\]+)\\?"', body)
+        if not header:
+            continue
+        relative = header.group(1)
+        referenced_headers.add(os.path.basename(relative))
+        if not os.path.isfile(os.path.join(ROOT, "include", *relative.split("/"))):
+            problems.append("platformio.ini [%s] points GUME_BOARD_HEADER at "
+                            "include/%s, which does not exist" % (name, relative))
+            continue
+        check_agreement(problems, name, body, relative)
+
+    for header in headers:
+        if header not in referenced_headers:
+            problems.append(
+                "include/boards/%s is not referenced by any [board_*] section, "
+                "so nothing can build for it" % header)
+
+    board_envs = {}
+    for name, body in sorted(sections.items()):
+        if not name.startswith("env:"):
+            continue
+        env = name[4:]
+        if env in BOARDLESS_ENVS:
+            continue
+        used = re.findall(r"\$\{(board_\w+)\.build_flags\}", body)
+        if len(used) != 1:
+            problems.append(
+                "platformio.ini [%s] pulls in %d board sections; an environment "
+                "targets exactly one board" % (name, len(used)))
+        elif used[0] not in boards:
+            problems.append("platformio.ini [%s] extends [%s], which does not exist"
+                            % (name, used[0]))
+        else:
+            board_envs.setdefault(used[0], []).append(env)
+
+    check_reachable(problems, boards, board_envs)
+
+
+def check_reachable(problems, boards, board_envs):
+    """A board that can be supported has to be flashable from the web page.
+
+    "Supported" is not a private fact about this repository. Someone who owns
+    the board should be able to put the firmware on it from
+    iamankushpandit.github.io/Gume without a toolchain -- so a [board_*]
+    section that the site cannot offer, or that CI never builds, is an
+    unfinished port rather than a supported board. gen_site.py derives its
+    picker from these same sections; this check is what stops one being added
+    without the label and the CI build that make the offer real.
+    """
+    site = read("tools", "gen_site.py")
+    offered = set(re.findall(r'"env":\s*"(\w+)"', site))
+    labelled = set(re.findall(r'^\s{4}"(\w+)":\s*\{', site, re.M))
+
+    workflows = {}
+    for name in ("ci.yml", "pages.yml"):
+        try:
+            workflows[name] = read(".github", "workflows", name)
+        except OSError:
+            problems.append(".github/workflows/%s is missing" % name)
+
+    for board in sorted(boards):
+        board_id = board[len("board_"):]
+        envs = board_envs.get(board, [])
+
+        if board_id not in labelled:
+            problems.append(
+                "board '%s' has no entry in gen_site.py's BOARD_DETAILS, so the "
+                "web installer has no label for it and the site will not "
+                "generate" % board_id)
+
+        games = [env for env in envs if env in offered]
+        if not games:
+            problems.append(
+                "board '%s' has no environment offered by the web installer; a "
+                "board that can be supported must be flashable from the page, "
+                "so add one to gen_site.py's VARIANTS or say why the board is "
+                "not supported" % board_id)
+
+        for env in games:
+            for name, text in sorted(workflows.items()):
+                if not re.search(r"pio run\b[^\n]*-e %s\b" % re.escape(env), text):
+                    problems.append(
+                        "board '%s' is offered as firmware '%s', but "
+                        ".github/workflows/%s never builds it -- its manifest "
+                        "would point at binaries that do not exist"
+                        % (board_id, env, name))
+
+
+def check_agreement(problems, section, body, relative):
+    """The panel is described to TFT_eSPI and to us; compare the two."""
+    header = read("include", *relative.split("/"))
+    labelled = {}
+    for match in re.finditer(r"/\*\s*(\w+)\s*\*/\s*([^,\n]+),", header):
+        labelled[match.group(1)] = match.group(2).strip()
+
+    pairs = (("TFT_WIDTH", "nativeWidth"),
+             ("TFT_HEIGHT", "nativeHeight"),
+             ("TFT_BL", "backlightPin"))
+    for macro, field in pairs:
+        found = re.search(r"-D\s*%s\s*=\s*(-?\d+)" % macro, body)
+        if not found or field not in labelled:
+            continue
+        stated = labelled[field].rstrip("f")
+        if stated != found.group(1):
+            problems.append(
+                "platformio.ini [%s] says %s=%s but include/%s says %s=%s"
+                % (section, macro, found.group(1), relative, field, stated))
+
+
+def main():
+    problems = []
+    fields, groups = profile_contract()
+    if not fields:
+        problems.append("parsed no fields out of include/BoardProfile.h")
+    headers = check_headers(problems, fields, groups)
+    check_ini(problems, headers)
+
+    if problems:
+        print("Board descriptions have drifted:\n")
+        for problem in problems:
+            print("  - %s" % problem)
+        print("\n%d problem(s). See docs/PORTING.md." % len(problems))
+        return 1
+    print("Board check: clean (%d board(s), %d profile field(s))."
+          % (len(headers), len(fields)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -68,20 +68,24 @@ VARIANTS = (
 )
 
 # The pin map, screen rotation and touch controller are compile-time constants,
-# so a build is only meaningful on the board it was compiled for. One entry.
-BOARDS = (
-    {
-        "id": "e32r28t1",
+# so a build is only meaningful on the board it was compiled for -- the picker
+# offers one firmware per supported board.
+#
+# The board LIST is not written here. It is read out of platformio.ini's
+# [board_*] sections by boards(), because "supported" and "offered on the page"
+# have to be the same set: a board someone can build is a board someone should
+# be able to flash from the browser, and a hand-kept list here is exactly how
+# the two drift. What cannot be derived -- the human label and the chip family
+# the flasher needs -- is looked up below, and a board missing an entry stops
+# the site from generating rather than being quietly dropped.
+BOARD_DETAILS = {
+    "e32r28t1": {
         "label": "E32R28T-1 / ESP32-32E -- 2.8 inch ILI9341 + XPT2046 (resistive)",
         "chip": "ESP32",
-        "envs": ("app",),
+        "buy": "https://www.amazon.com/dp/B0D92C9MMH"
+               "?ref=ppx_yo2ov_dt_b_fed_asin_title&th=1",
     },
-)
-
-BOARD_BUY_URL = (
-    "https://www.amazon.com/dp/B0D92C9MMH"
-    "?ref=ppx_yo2ov_dt_b_fed_asin_title&th=1"
-)
+}
 
 SCREEN_CAPTIONS = {
     "about-radios": "About: what the radios do",
@@ -255,9 +259,49 @@ def version():
                 read("include", "AppVersion.h"), "the version").group(1)
 
 
-def board_name():
-    return find(r'BOARD_NAME=\\"([^\\"]+)\\"',
-                read("platformio.ini"), "BOARD_NAME").group(1)
+def boards():
+    """Every supported board, read out of platformio.ini's [board_*] sections.
+
+    A board is supported when it has a section and an environment building the
+    games firmware for it. Both are facts about platformio.ini, so both are
+    read from it -- the page cannot offer a board that does not build, and
+    cannot omit one that does.
+    """
+    ini = read("platformio.ini")
+    offered = {entry["env"] for entry in VARIANTS}
+
+    found = []
+    for section in re.findall(r"^\[board_(\w+)\]", ini, re.M):
+        body = re.search(r"^\[board_%s\](.*?)(?=^\[|\Z)" % re.escape(section),
+                         ini, re.M | re.S).group(1)
+        name = find(r'BOARD_NAME=\\"([^\\"]+)\\"', body,
+                    "BOARD_NAME in [board_%s]" % section).group(1)
+
+        envs = tuple(env for env in re.findall(
+            r"^\[env:(\w+)\](?:(?!^\[).)*?\$\{board_%s\.build_flags\}"
+            % re.escape(section), ini, re.M | re.S) if env in offered)
+        if not envs:
+            die("platformio.ini declares [board_%s] but no environment builds "
+                "the games firmware for it, so the site cannot offer it. A "
+                "board that can be supported must be flashable from the page "
+                "-- see docs/PORTING.md." % section)
+
+        details = BOARD_DETAILS.get(section)
+        if not details:
+            die("board '%s' has no BOARD_DETAILS entry in tools/gen_site.py, "
+                "so the picker has no label for it. Add one." % section)
+
+        found.append({"id": section, "name": name, "envs": envs, **details})
+
+    if not found:
+        die("platformio.ini declares no [board_*] section")
+    if len(found) > 1:
+        die("more than one board is supported, but site/index.template.html "
+            "still describes a single board in prose ({{BOARD}}, "
+            "{{BOARD_BUY_URL}}). Generalise that copy before adding the "
+            "second board -- offering a firmware the page then mislabels is "
+            "worse than not offering it.")
+    return found
 
 
 def games():
@@ -447,7 +491,7 @@ def main():
     args = parser.parse_args()
 
     release = version()
-    board = board_name()
+    supported = boards()
     catalog = playable_apps()
     validate_site_screens(catalog)
     flash, ram = build_figures()
@@ -459,7 +503,7 @@ def main():
 
     variants = {entry["env"]: entry for entry in VARIANTS}
     builds = []
-    for target in BOARDS:
+    for target in supported:
         for env in target["envs"]:
             if env not in variants:
                 die("board %s offers env '%s', which is not in VARIANTS"
@@ -481,7 +525,7 @@ def main():
 
     board_options = "\n".join(
         '          <option value="%s">%s</option>' % (t["id"], escape(t["label"]))
-        for t in BOARDS)
+        for t in supported)
     variant_options = "\n".join(
         '          <option value="%s">%s</option>' % (v["env"], escape(v["label"]))
         for v in VARIANTS)
@@ -494,10 +538,10 @@ def main():
     for key, value in (
         ("{{VERSION}}", release),
         ("{{GAME_COUNT}}", str(len(catalog))),
-        ("{{BOARD}}", escape(board)),
+        ("{{BOARD}}", escape(supported[0]["name"])),
         ("{{FLASH}}", escape(flash)),
         ("{{RAM}}", escape(ram)),
-        ("{{BOARD_BUY_URL}}", BOARD_BUY_URL),
+        ("{{BOARD_BUY_URL}}", supported[0]["buy"]),
         ("{{BOARD_OPTIONS}}", board_options),
         ("{{VARIANT_OPTIONS}}", variant_options),
         ("{{SCREEN_COUNT}}", str(screen_count)),


### PR DESCRIPTION
Closes #19.

The firmware was tied to the E32R28T-1 by construction. `include/BoardConfig.h`
held one board's pins as global constants, `SCREEN_WIDTH`/`SCREEN_HEIGHT` were a
literal 320 and 240, the landscape rotation was a `-D` flag, and a second board
meant copying thirty build flags into a second `platformio.ini` section and
hoping every constant still applied. It could only ever describe one board.

## A board is now two files, and nothing else

| Where | What it holds |
|---|---|
| `include/boards/<id>.h` | the whole board: pins, rotations, the battery divider, which peripherals exist |
| `platformio.ini` `[board_<id>]` | only the macros TFT_eSPI insists on being told at compile time |

**No file under `src/` names a GPIO number any more.** The landscape canvas is
derived from the panel and its rotation rather than stated, so a differently
sized board gets the right constants without an edit. `[common]` now holds only
what is true of every board, and an environment composes it with exactly one
`${board_*.build_flags}`.

The panel is necessarily described twice, to TFT_eSPI and to us, so
`BoardConfig.h` static_asserts `TFT_WIDTH`, `TFT_HEIGHT` and `TFT_BL` against
the profile. The backlight one earns its keep on its own: with the wrong
`TFT_BL` the panel is completely dark while Wi-Fi, BLE, NVS, the LED and the
screen saver all run perfectly, so the serial log looks healthy and it reads as
a dead screen. It is a compile error now.

## Not every board can be supported

Optional hardware and missing hardware are different answers and were being
blurred. Four things are hard requirements, each a `static_assert` naming what
is missing rather than a build that flashes into something unusable:

- a panel at least as large as the game canvas in landscape
- a touch controller — the only input this firmware has
- the backlight on a GPIO — brightness has a readability floor, and the idle
  path blanks the screen rather than only dimming it
- 4 MB of flash for the 3 MB app partition

The SD slot, the RGB LED, the speaker and battery sensing stay genuinely
optional: `PIN_NONE` plus a `has...()` guard, and the firmware does without.

## A supported board is one people can flash

Support that only means "builds on the maintainer's machine" is not support for
the person holding the board. `gen_site.py` now derives the web installer's
board list from the same `[board_*]` sections instead of a hand-kept tuple, and
refuses to generate until a new board has a label, an offered firmware and a CI
build behind it — so "supported" and "offered on the page" are the same set by
construction.

## Checking

`tools/check_boards.py` catches what the compiler cannot: a profile field a
board never filled in, a header no section points at, a board-specific flag
drifted into `[common]` where it would silently apply to every board, and a
board CI does not build. Wired into `ci.yml`. `docs/PORTING.md` is the
checklist.

## Verified

- All environments build. Flash 2,350,197 / 3,145,728 (74.7%), RAM 72,548 —
  figures updated in README, CLAUDE.md and CHANGELOG.
- Setting `TFT_BL=27` against a profile still saying 21 fails the build with
  `board profile disagrees with TFT_BL in platformio.ini`.
- Added a fake second board section and confirmed `check_boards.py` reports all
  five problems (three panel/name drifts, no site label, no offered firmware)
  and `gen_site.py` refuses to generate.
- `check_docs.py`, `check_boards.py`, `check_catalog.py` and
  `check_frame_rules.py` all clean.

## Not in scope

The playable games are still authored against a fixed landscape canvas. Those
constants now follow the board, so a differently sized panel gets the right
numbers, but no game has been checked at another size — `docs/PORTING.md` says
so plainly. A port to a board with the same canvas needs nothing beyond that
document; a different panel size means going through the games one at a time,
which is separate work.
