### PR TITLE
Run the checks on main, the branch they were meant to protect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
 
+# Runs on every branch, main included. It used to carry
+# `branches-ignore: [main]`, on the reasoning that main only ever receives pull
+# requests and so is covered by the pull_request trigger. It was not: work
+# reached main without a pull request, and four files sat over the frame-rule
+# baseline on main for weeks while every branch below it reported green. A
+# check that never runs on the branch it protects is a convention, not a check.
+
 on:
   push:
-    branches-ignore: [main]
   pull_request:
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,11 @@ squash rather than merging a stale branch into it. Repository admins can bypass
 these rules — that exists for an emergency such as a broken release, not as a
 normal route, and using it skips the CI that would have caught the problem.
 
+`verify` also runs on every push, to every branch, `main` included. That is
+deliberate belt-and-braces: the pull-request trigger alone left `main`
+unchecked, and it stayed red for weeks without anyone seeing it. If an admin
+bypass ever does land something on `main`, the push run is what says so.
+
 `git push origin main` will be rejected. That is the protection working; open a
 pull request instead.
 


### PR DESCRIPTION
Closes the second item of #7.

## What this changes

`.github/workflows/ci.yml` carried `branches-ignore: [main]`. The reasoning was
that `main` only ever receives pull requests, so the `pull_request` trigger
covers it. It did not hold: work reached `main` without a pull request, and four
files sat over the frame-rule baseline there for weeks while every branch below
reported green. #4 then had to be merged with an admin bypass to get four
markdown files onto a branch whose checks had never once run.

Dropping the filter is the whole fix. `push:` with no branch list runs
everywhere, and a branch that is also open as a pull request was already being
built twice before this, so the only new cost is one extra run per release
merge. What it buys is that an admin bypass -- or anything else that lands on
`main` outside a pull request -- is followed by a run that says so.

`CONTRIBUTING.md` gains a paragraph in the branch-protection section, because
"the checks run on every push, `main` included" is now part of the contract a
contributor is being asked to work under.

## Where #7 stands after this

| Item | State |
|---|---|
| 1. Fix the four violations | Done on `dev` in 78fbe7a -- `check_frame_rules.py` reports clean there. Reaches `main` at the next release, not here. |
| 2. Remove `branches-ignore: [main]` | This PR. |
| 3. Verify on hardware | Not done, and not claimable from this change -- see below. |

## Testing

No firmware source is touched, so the flash and RAM figures are unchanged and
nothing here can alter what a screen draws. `check_docs.py`, `check_boards.py`,
`check_catalog.py` and `check_frame_rules.py` are all clean locally, and
`ci.yml` parses to `{push: None, pull_request: None, workflow_dispatch: None}`
-- `push` with a null value is the "every branch" form.

The trigger change itself only proves itself once this is on `dev`: the push run
for the merge commit is the first one that could not have happened before.
