### PR TITLE
Stop compiling the firmware to prove a paragraph still reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,34 @@
 name: CI
 
-# Runs on every branch, main included. It used to carry
-# `branches-ignore: [main]`, on the reasoning that main only ever receives pull
-# requests and so is covered by the pull_request trigger. It was not: work
-# reached main without a pull request, and four files sat over the frame-rule
-# baseline on main for weeks while every branch below it reported green. A
-# check that never runs on the branch it protects is a convention, not a check.
+# Runs on every pull request, and on pushes to the two protected branches.
+# It used to carry `branches-ignore: [main]`, on the reasoning that main only
+# ever receives pull requests and so is covered by the pull_request trigger. It
+# was not: work reached main without a pull request, and four files sat over the
+# frame-rule baseline on main for weeks while every branch below it reported
+# green. A check that never runs on the branch it protects is a convention, not
+# a check.
+#
+# The fix for that was `on: push` with no filter, which then ran the whole job
+# twice for every commit on a branch with a pull request open -- once for the
+# push, once for the pull request. Naming main and dev keeps the branch the
+# push trigger exists to protect, and drops the duplicate. A feature branch is
+# covered from the moment its pull request is opened, which is when its result
+# starts mattering to anyone else.
 
 on:
   push:
+    branches: [main, dev]
   pull_request:
   workflow_dispatch:
 
 jobs:
+  # `verify` is the required status check in the "Protect main" and
+  # "Protect dev" rulesets, so this job must report on EVERY pull request,
+  # including documentation-only ones. That is why the build is skipped with a
+  # step-level `if:` rather than by adding `paths-ignore:` to the trigger above:
+  # a required check that does not run is not "passed", it is "expected", and
+  # the pull request stays unmergeable forever waiting for a status that will
+  # never arrive. The job always runs; only the expensive half is conditional.
   verify:
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +38,36 @@ jobs:
         with:
           python-version: "3.11"
 
+      # The repository checks below are cheap and run unconditionally -- a
+      # documentation-only change is exactly what check_docs.py exists to
+      # police. Compiling the firmware to prove that a paragraph in the README
+      # still compiles is the part with nothing to say.
+      - name: Decide whether the firmware needs building
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a pull request -- building."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --jq '.[].filename')
+          echo "Files changed by this pull request:"
+          printf '%s\n' "$files" | sed 's/^/  /'
+          if printf '%s\n' "$files" \
+             | grep -qvE '^(docs/|cases/|site/)|\.md$|^LICENSE$'; then
+            echo "Code outside the documentation set changed -- building."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Documentation only -- skipping the firmware build."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache PlatformIO
+        if: steps.scope.outputs.code == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -32,6 +77,7 @@ jobs:
           restore-keys: pio-
 
       - name: Install PlatformIO
+        if: steps.scope.outputs.code == 'true'
         run: pip install --upgrade platformio
 
       - name: Run repository checks
@@ -42,4 +88,5 @@ jobs:
           python tools/check_frame_rules.py
 
       - name: Build firmware
+        if: steps.scope.outputs.code == 'true'
         run: pio run -e app -e bringup -e wifidiag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,10 +120,23 @@ squash rather than merging a stale branch into it. Repository admins can bypass
 these rules — that exists for an emergency such as a broken release, not as a
 normal route, and using it skips the CI that would have caught the problem.
 
-`verify` also runs on every push, to every branch, `main` included. That is
-deliberate belt-and-braces: the pull-request trigger alone left `main`
-unchecked, and it stayed red for weeks without anyone seeing it. If an admin
-bypass ever does land something on `main`, the push run is what says so.
+`verify` also runs on pushes to `main` and `dev`. That is deliberate
+belt-and-braces: the pull-request trigger alone left `main` unchecked, and it
+stayed red for weeks without anyone seeing it. If an admin bypass ever does
+land something on `main`, the push run is what says so. It is scoped to those
+two branches rather than to every branch because a topic branch with a pull
+request open matches both triggers, and ran the whole job twice for every
+commit.
+
+The job always runs on a pull request, whatever the change touches, because
+`verify` is the required check: a required check that never runs does not read
+as passed, it reads as still expected, and the pull request waits for a status
+that will never arrive. So the skipping happens a level down. A pull request
+touching only `docs/`, `cases/`, `site/`, `LICENSE` or Markdown skips the
+firmware build and reports on the repository checks alone; anything else
+builds all three environments as before. `paths-ignore:` on the trigger is the
+obvious way to do this and is the trap -- it would make every
+documentation-only pull request permanently unmergeable.
 
 `git push origin main` will be rejected. That is the protection working; open a
 pull request instead.
@@ -152,9 +165,9 @@ Keep the branch current — `git fetch upstream && git rebase upstream/dev` —
 because the protection rules will not let a stale branch merge. Leave "allow
 edits by maintainers" ticked so a maintainer can rebase or fix a check for you.
 
-CI runs on pull requests from forks with a read-only token, so `verify` (repo
-checks plus a build of every firmware environment) will report on your PR
-without any secret being exposed to it. What CI cannot do is flash a board:
+CI runs on pull requests from forks with a read-only token, so `verify` (the
+repository checks, plus a build of every firmware environment when your change
+touches code) will report on your PR without any secret being exposed to it. What CI cannot do is flash a board:
 anything touching hardware, touch, storage or a screen still needs a human with
 the device, so say in the PR what you tested and on which board.
 


### PR DESCRIPTION
Every pull request ran `pio run -e app -e bringup -e wifidiag`, including the ones that only moved words about. Roughly two of the two-and-a-half minutes of `verify` went on building three environments from a diff that could not affect any of them — [#39](https://github.com/iamankushpandit/Gume/pull/39) burned it twice over.

## What changed

**The build is behind a step-level `if:`.** A pull request touching only `docs/`, `cases/`, `site/`, `LICENSE` or Markdown reports on the repository checks alone. Anything else builds all three environments exactly as before. `Cache PlatformIO` and `Install PlatformIO` are gated on the same condition, so a docs run does no PlatformIO work at all.

The checks (`check_docs`, `check_boards`, `check_catalog`, `check_frame_rules`) stay **unconditional** — a documentation-only change is precisely what `check_docs.py` exists to police.

**The push trigger is scoped to `main` and `dev`.** It was added unfiltered because the pull-request trigger alone left `main` unchecked, and that is still the reason it exists. Naming the two protected branches keeps that property and drops the duplicate run every topic branch was getting for matching both triggers at once.

## Why not `paths-ignore:`

`verify` is the required status check in both the `Protect main` and `Protect dev` rulesets. A required check that never runs does not report as passed — it reports as still *expected*, and the pull request waits forever for a status that will never arrive. `paths-ignore:` on the trigger would have made every documentation-only pull request permanently unmergeable. Hence: the job always runs, and only its expensive half is conditional. The workflow says so in a comment, so the next person does not reach for the obvious fix.

## Classifier, checked against real diffs

| Files | Decision |
|---|---|
| `README.md`, `CONTRIBUTING.md`, `site/index.template.html` (PR #39) | skip |
| `src/games/Foo.{h,cpp}` | build |
| `src/hal/CLAUDE.md` | skip |
| `docs/screens/*.png`, `docs/PORTING.md` | skip |
| `platformio.ini` | build |
| `tools/gen_site.py` | build |
| `include/boards/e32r28t1.h` + `README.md` | build |
| `cases/E32R28T-1/shell.scad` | skip |
| `.github/workflows/ci.yml` (this PR) | **build** |

This PR classifies as a build, so the full path is exercised here rather than assumed.

## Notes

- The file list comes from `gh api repos/…/pulls/N/files` rather than `git diff`, because `actions/checkout` is shallow by default and a three-dot diff has no merge base to work from.
- Fork PRs get a read-only token, which is enough to read a public repo's PR file list.
- `CONTRIBUTING.md` documented the old "every push, to every branch" behaviour; that paragraph is updated in the same commit, along with the fork section's description of what `verify` covers.
- `check_docs.py` only parses `pages.yml`, not `ci.yml`, so nothing here affects it.

## Separately worth knowing

CI never validates the documented flash/RAM figures against a real ELF today. `check_docs.py` compares them to `.pio/build/app/firmware.elf`, but the checks step runs *before* the build and nothing re-runs afterwards — its docstring notes it deliberately stays quiet for "CI before its build step". That validation only ever happens locally. Closing that gap means running `check_docs.py` again after `pio run`, and is left out of this PR on purpose.