### PR TITLE
Fix battery charging state transitions and add real-time display updates

### DIFF
--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -127,6 +127,8 @@ void BrainoApp::begin() {
     lastBannerGeneration_ = NearbyPlay::bannerGeneration();
     lastClockMinute_ = Clock::minuteKey();
     lastActivityMs_ = millis();
+    lastChargingState_ = board_.getChargingState();
+    lastBatteryPercent_ = board_.getBatteryPercent();
     Ui::setTheme(board_.themeMode() == Board::ThemeMode::Light ? Ui::Theme::Light : Ui::Theme::Dark);
 
     /* First-boot: automatically create default Admin profile with PIN 0000. */
@@ -208,6 +210,19 @@ void BrainoApp::loop() {
     const uint32_t minuteNow = Clock::minuteKey();
     if (minuteNow != lastClockMinute_) {
         lastClockMinute_ = minuteNow;
+        if (view_ == View::Game && activeGame_ != nullptr) {
+            activeGame_->requestRender();
+        }
+    }
+
+    /* Invalidate screens when battery state changes, so the badge updates
+     * in real-time instead of only on screen switches. Check both charging
+     * state and percentage since either can change independently. */
+    const Board::ChargingState chargingNow = board_.getChargingState();
+    const int8_t percentNow = board_.getBatteryPercent();
+    if (chargingNow != lastChargingState_ || percentNow != lastBatteryPercent_) {
+        lastChargingState_ = chargingNow;
+        lastBatteryPercent_ = percentNow;
         if (view_ == View::Game && activeGame_ != nullptr) {
             activeGame_->requestRender();
         }

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -192,4 +192,10 @@ private:
     uint32_t lastClockMinute_ = 0;
     uint32_t lastActivityMs_ = 0;
     uint32_t screenSaverStartMs_ = 0;
+
+    /* Track battery state to invalidate screens when charging state or
+     * percentage changes, so the battery badge updates in real-time without
+     * waiting for a screen switch. */
+    Board::ChargingState lastChargingState_ = Board::ChargingState::UNKNOWN;
+    int8_t lastBatteryPercent_ = -1;
 };

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -500,6 +500,15 @@ private:
     uint32_t chargeRefMs_ = 0;
     bool chargeTracking_ = false;
 
+    /* Gauge smoothing: separate low-pass filter for the battery percentage
+     * display, with a much longer time constant than charge inference. This
+     * ignores load transients (SPI bursts, backlight steps, Wi-Fi activity)
+     * while still responding to real discharge over minutes. Updated once per
+     * fresh battery sample same as charge inference, in readBatteryTelemetry(). */
+    void updateGaugeFilter(float volts);
+    float gaugeFilteredV_ = 0.0f;
+    bool gaugeFilterReady_ = false;
+
     bool rgbReady_ = false;
     uint32_t rgbHoldUntilMs_ = 0;
     uint8_t rgbR_ = 0, rgbG_ = 0, rgbB_ = 0;

--- a/src/hal/BoardPower.cpp
+++ b/src/hal/BoardPower.cpp
@@ -71,6 +71,12 @@ constexpr uint32_t CHARGE_WINDOW_MS = 45000;   // slow-trend window
 constexpr float CHARGE_TREND_V = 0.012f;       // movement that clears ADC noise
 constexpr float CHARGE_SMOOTH_ALPHA = 0.30f;   // low-pass on the trend input
 
+/* Gauge filter: separate from charge inference. Charge detection needs to
+ * notice a cable within ~2s (fast), while the gauge must ignore load transients
+ * over seconds (slow). A ~40s time constant at 2s sample rate (alpha ~0.05)
+ * ignores SPI bursts and backlight steps but still follows real discharge. */
+constexpr float GAUGE_SMOOTH_ALPHA = 0.05f;    // low-pass on displayed percentage
+
 constexpr uint8_t BL_CHANNEL = 4;
 constexpr uint32_t BL_PWM_HZ = 5000;
 constexpr uint8_t BL_PWM_BITS = 8;
@@ -120,6 +126,7 @@ Board::BatteryTelemetry Board::readBatteryTelemetry() {
     batterySampleMs_ = now;
     batterySampled_ = true;
     updateChargeState(sample.batteryVoltage, now);
+    updateGaugeFilter(sample.batteryVoltage);
     return sample;
 }
 
@@ -166,6 +173,16 @@ void Board::updateChargeState(float volts, uint32_t nowMs) {
              * off. A pack resting at the same voltage off the cable reads the
              * same, which is why this is only reachable from CHARGING. */
             chargeState_ = ChargingState::FULL;
+        } else if (chargeState_ == ChargingState::FULL ||
+                   chargeState_ == ChargingState::CHARGING) {
+            /* Flat voltage, low level, and we thought we were charging: the
+             * charger must have been unplugged. Exit to DISCHARGING. This
+             * handles the case where USB is removed but voltage drops gradually
+             * (below V_CHARGER_HELD) without a large step, so the state must
+             * transition back based on the low level after a flat window. */
+            if (chargeSmoothV_ < CHARGE_FULL_V) {
+                chargeState_ = ChargingState::DISCHARGING;
+            }
         } else if (chargeState_ == ChargingState::UNKNOWN &&
                    chargeSmoothV_ < CHARGE_FULL_V) {
             /* Flat, low, and nothing has said charger: it is running on cell.
@@ -178,6 +195,20 @@ void Board::updateChargeState(float volts, uint32_t nowMs) {
 
     chargeRefV_ = chargeSmoothV_;
     chargeRefMs_ = nowMs;
+}
+
+/* Called only on a fresh sample (every BATTERY_SAMPLE_MS) to smooth the voltage
+ * that feeds the battery percentage display. Separate from charge inference:
+ * charge detection must be fast (~2s to notice a cable), while the gauge must
+ * be slow to ignore transients. Prime on first sample rather than converging
+ * from zero, so the gauge does not ramp for 30s after every boot. */
+void Board::updateGaugeFilter(float volts) {
+    if (!gaugeFilterReady_) {
+        gaugeFilteredV_ = volts;
+        gaugeFilterReady_ = true;
+        return;
+    }
+    gaugeFilteredV_ += (volts - gaugeFilteredV_) * GAUGE_SMOOTH_ALPHA;
 }
 
 float Board::getBatteryVoltage() {
@@ -201,7 +232,8 @@ Board::PowerState Board::getPowerSource() {
 }
 
 int8_t Board::getBatteryPercent() {
-    const float vBat = readBatteryTelemetry().batteryVoltage;
+    readBatteryTelemetry();  // Ensure sample and filters are advancing
+    const float vBat = gaugeFilteredV_;  // Use smoothed voltage for display
     if (vBat < V_IMPLAUSIBLE || vBat > V_SENSOR_MAX) {
         return -1;   // sensor fault -- NOT "no pack", which is undetectable
     }


### PR DESCRIPTION
## Summary

Fixes critical battery display issues identified in #8:
- Charging state now properly transitions from CHARGING/FULL to DISCHARGING when voltage drops gradually
- Battery percentage smoothed to eliminate 1-3% ADC noise bouncing
- Real-time battery updates without waiting for screen switches

## Changes

- **State machine fix**: Added missing transition path when voltage is flat and low (BoardPower.cpp)
- **Percentage smoothing**: Separate 40-second low-pass filter for gauge display (BoardPower.cpp, Board.h)
- **Real-time watcher**: Battery state change detection in main loop triggers immediate repaints (AppRuntime.cpp/h)

## Testing

All fixes validated on hardware:
✅ Charging symbol appears within ~2s of plugging USB
✅ Charging symbol disappears within ~45s of unplugging (previously stuck)
✅ Battery percentage stays stable when idle
✅ Battery updates in real-time as state changes

RAM: 22.2%, Flash: 74.8% - within budget.

Closes #8