### PR TITLE
Fix compiler warnings in ElementsGame, BleScanner, and BoardPower

### DIFF
--- a/src/games/ElementsGame.cpp
+++ b/src/games/ElementsGame.cpp
@@ -425,7 +425,7 @@ void ElementsGame::renderCard(AppContext& host) {
     tft.setTextDatum(MC_DATUM);
     tft.drawString(e.symbol, 50, 84, 4);
     tft.setTextDatum(TL_DATUM);
-    char buf[16];
+    char buf[32];
     snprintf(buf, sizeof(buf), "%u", static_cast<unsigned>(e.z));
     tft.drawString(buf, 17, 48, 2);
 

--- a/src/hal/BleScanner.cpp
+++ b/src/hal/BleScanner.cpp
@@ -73,7 +73,7 @@ void record(const BleBeacon::Observation& obs, int8_t rssi, uint32_t nowMs) {
     }
 
     Sighting& s = table_[slot];
-    memset(&s, 0, sizeof(s));
+    s = Sighting();
     snprintf(s.deviceId, sizeof(s.deviceId), "%s", obs.deviceId);
     s.sharesActivity = obs.sharesActivity;
     s.gameIndex = obs.gameIndex;

--- a/src/hal/BoardPower.cpp
+++ b/src/hal/BoardPower.cpp
@@ -107,7 +107,7 @@ Board::BatteryTelemetry Board::readBatteryTelemetry() {
 
     if (!s_adcCharacterised) {
         analogSetPinAttenuation(BOARD.battery.adcPin, ADC_11db);
-        esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12,
+        esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_12, ADC_WIDTH_BIT_12,
                                  ADC_DEFAULT_VREF_MV, &s_adcChars);
         s_adcCharacterised = true;
     }


### PR DESCRIPTION
Fixes three compiler warnings:

- ElementsGame: Increase buffer size from 16 to 32 bytes for snprintf output
- BleScanner: Replace memset on non-trivial type with value-initialization  
- BoardPower: Update deprecated ADC_ATTEN_DB_11 to ADC_ATTEN_DB_12