### PR TITLE
Add ESP32-2432S028 board support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           # On pushes to main/dev, build all environments (conservative safety net)
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Building all environments (push to main/dev)"
-            ENVS="app bringup batdiag wifidiag"
+            ENVS="app bringup batdiag wifidiag app_esp32_2432s028 bringup_esp32_2432s028 batdiag_esp32_2432s028"
           else
             # On PRs, check which files changed and build selectively
             files=$(gh api --paginate \
@@ -143,4 +143,17 @@ jobs:
 
       - name: Build firmware
         if: steps.scope.outputs.code == 'true'
-        run: pio run ${{ steps.environments.outputs.envs }}
+        run: |
+          # Build environments with explicit -e flags for check_boards.py verification
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # On pushes to main/dev: build all environments
+            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028 -e bringup_esp32_2432s028 -e batdiag_esp32_2432s028
+          else
+            # On PR: build only affected environments
+            ENVS="${{ steps.environments.outputs.envs }}"
+            ARGS=""
+            for env in $ENVS; do
+              ARGS="$ARGS -e $env"
+            done
+            pio run $ARGS
+          fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
       # through every net. An environment nobody builds is an environment
       # that is already broken and has not been told yet.
       - name: Build firmware
-        run: pio run -e app -e bringup -e batdiag -e wifidiag
+        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028 -e bringup_esp32_2432s028 -e batdiag_esp32_2432s028
 
       # Flash is the scarce resource here (3 MB partition), so put the image
       # size where a reviewer sees it without opening the build log.
@@ -71,7 +71,7 @@ jobs:
             echo
             echo '| Environment | firmware.bin | of 3,145,728 |'
             echo '|---|---:|---:|'
-            for env in app bringup batdiag wifidiag; do
+            for env in app bringup batdiag wifidiag app_esp32_2432s028 bringup_esp32_2432s028 batdiag_esp32_2432s028; do
               bytes=$(stat -c%s ".pio/build/$env/firmware.bin")
               printf '| %s | %s | %.1f%% |\n' "$env" "$bytes" \
                 "$(python -c "print($bytes / 3145728 * 100)")"

--- a/include/boards/esp32-2432s028.h
+++ b/include/boards/esp32-2432s028.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "BoardProfile.h"
+
+/* Makerfabs / Sunton ESP32-2432S028 -- a 2.4-inch CYD variant. ST7789 320x240
+ * TFT, XPT2046 resistive touch, and a battery sense divider.
+ *
+ * Pins are from the vendor's schematics and commonly available pin tables.
+ * Unlike the E32R28T-1, GPIO34 here is the light sensor (LDR), not battery sense.
+ *
+ * The display's own SPI pins are NOT here: TFT_eSPI is configured entirely
+ * through `-D` flags in platformio.ini and reads them from there. BoardConfig.h
+ * cross-checks the two descriptions against each other so they cannot drift.
+ */
+inline constexpr BoardProfile BOARD = {
+    "ESP32-2432S028",
+
+    /* panel: 1 is landscape with the USB edge at the bottom (rotation 1).
+     * 2 is the quarter-turn from it (portrait). Board::pollTouch()
+     * compensates for every rotation, so don't hand-correct in game code. */
+    PanelProfile{
+        /* nativeWidth          */ 240,
+        /* nativeHeight         */ 320,
+        /* landscapeRotation    */ 1,
+        /* portraitRotation     */ 2,
+        /* backlightPin         */ 27,
+        /* backlightActiveHigh  */ true,
+    },
+
+    /* touch: a bus of its own, bit-banged rather than using a second
+     * hardware peripheral since the TFT owns HSPI. */
+    TouchProfile{
+        /* mosi               */ 32,
+        /* miso               */ 39,
+        /* sclk               */ 25,
+        /* cs                 */ 33,
+        /* irq                */ 36,
+        /* pressureThreshold  */ 350,
+        /* hitSlop            */ 8,
+    },
+
+    SdProfile{
+        /* cs    */ 5,
+        /* mosi  */ 23,
+        /* miso  */ 19,
+        /* sclk  */ 18,
+        /* spiHz */ 16000000,
+    },
+
+    /* No RGB LED on this board variant. */
+    RgbLedProfile{
+        /* r           */ PIN_NONE,
+        /* g           */ PIN_NONE,
+        /* b           */ PIN_NONE,
+        /* commonAnode */ false,
+    },
+
+    /* Audio is stubbed. beepOk()/beepError() are no-ops on this variant. */
+    AudioProfile{
+        /* speakerPin */ PIN_NONE,
+    },
+
+    /* Battery sense on IO35 (ADC1_CH7, input-only). The divider ratio is
+     * typically 2:1 (voltage at pin is half the cell voltage). */
+    BatteryProfile{
+        /* adcPin        */ 35,
+        /* dividerRatio  */ 2.0f,
+        /* sensorMaxVolts*/ 4.50f,
+    },
+
+    /* 4 MB part, partitioned huge_app.csv: 3 MB for the app. */
+    MemoryProfile{
+        /* flashBytes */ 4u * 1024u * 1024u,
+    },
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,6 +72,26 @@ build_flags =
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
 
+[board_esp32_2432s028]
+build_flags =
+    -D BOARD_NAME=\"ESP32-2432S028\"
+    -D GUME_BOARD_HEADER=\"boards/esp32-2432s028.h\"
+    -D ST7789_DRIVER=1
+    -D TFT_INVERT_COLORS=1
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D TFT_MISO=12
+    -D TFT_MOSI=13
+    -D TFT_SCLK=14
+    -D TFT_CS=15
+    -D TFT_DC=2
+    -D TFT_RST=-1
+    -D TFT_BL=27
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D USE_HSPI_PORT=1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=16000000
+
 [env:app]
 ; The console, on the 2.8-inch board. A second board is a second stanza of
 ; exactly this shape with a different ${board_*.build_flags}.
@@ -124,3 +144,35 @@ extends = esp32_common
 build_src_filter = +<wifi_diag.cpp>
 build_flags =
     -D CYD_WIFI_DIAG
+
+[env:app_esp32_2432s028]
+; The console on the ESP32-2432S028 board.
+extends = esp32_common
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+lib_deps = ${common.lib_deps}
+lib_ldf_mode = deep+
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_esp32_2432s028.build_flags}
+
+[env:bringup_esp32_2432s028]
+extends = esp32_common
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+lib_deps = ${common.lib_deps}
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_esp32_2432s028.build_flags}
+    -D CYD_BRINGUP_ONLY
+
+[env:batdiag_esp32_2432s028]
+; Isolated battery bring-up and calibration tool for ESP32-2432S028.
+extends = esp32_common
+build_src_filter = +<battery_diag.cpp>
+lib_deps = bodmer/TFT_eSPI@^2.5.43
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_esp32_2432s028.build_flags}
+    -D CYD_BATTERY_DIAG

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -65,6 +65,13 @@ VARIANTS = (
         "note": "The full console: {count} games, profiles, scores, settings, "
                 "Wi-Fi clock and the BLE beacon.",
     },
+    {
+        "env": "app_esp32_2432s028",
+        "label": "Braino! (the games) -- ESP32-2432S028",
+        "name": "Braino!",
+        "note": "The full console for the 2.4 inch board: {count} games, profiles, scores, settings, "
+                "Wi-Fi clock and the BLE beacon.",
+    },
 )
 
 # The pin map, screen rotation and touch controller are compile-time constants,
@@ -84,6 +91,11 @@ BOARD_DETAILS = {
         "chip": "ESP32",
         "buy": "https://www.amazon.com/dp/B0D92C9MMH"
                "?ref=ppx_yo2ov_dt_b_fed_asin_title&th=1",
+    },
+    "esp32_2432s028": {
+        "label": "ESP32-2432S028 -- 2.4 inch ST7789 + XPT2046 (resistive)",
+        "chip": "ESP32",
+        "buy": "https://www.aliexpress.com/w/wholesale-esp32-2432s028.html",
     },
 }
 


### PR DESCRIPTION
## Summary

Add support for the Makerfabs/Sunton ESP32-2432S028 2.4-inch CYD board variant with color inversion fix.

- Board profile configured for ST7789 driver (not ILI9341)
- Added TFT_INVERT_COLORS=1 to fix inverted color display issue
- Backlight on GPIO27 (different from E32R28T-1's GPIO21)
- Battery sense on GPIO35 (GPIO34 is the light sensor on this variant)
- Three new build environments: app_esp32_2432s028, bringup_esp32_2432s028, batdiag_esp32_2432s028

## Test plan

- [x] Build succeeds for app_esp32_2432s028
- [x] check_boards.py passes
- [x] check_docs.py passes
- [ ] Test on physical device (user to verify colors are no longer inverted)

🤖 Generated with Claude Code