### PR TITLE
Prepare repository for open-source launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           python -m py_compile tools/check_catalog.py
           python -m py_compile tools/check_frame_rules.py
           python -m py_compile tools/check_privacy.py
+          python -m py_compile tools/gen_site.py
 
       - name: Run repository checks
         run: |
@@ -97,6 +98,36 @@ jobs:
           python tools/check_catalog.py
           python tools/check_frame_rules.py
           python tools/check_privacy.py
+
+      # Site generation is cheap -- seconds, pure standard library, no
+      # PlatformIO -- and it MUST run on every pull request. Do not put this
+      # step behind `steps.scope.outputs.code` or any other firmware-source
+      # gate.
+      #
+      # The reasoning is the whole point of the step. The firmware gate above
+      # deliberately skips changes under site/, docs/, tools/ and .github/,
+      # and to Markdown -- and those are exactly the changes most likely to
+      # break the installer: a renamed template placeholder, a new still that
+      # nothing references, a board section gen_site.py cannot label, a
+      # VARIANTS entry pointing at an environment no workflow builds. Gate
+      # this on firmware source and the only run that would have caught any of
+      # them is the one that never happens.
+      #
+      # gen_site.py is a headline path: it writes the landing page and the
+      # esp-web-tools manifests behind the flash button. When it fails, it
+      # fails in someone else's browser, and until now it was only ever
+      # executed by the Pages workflow -- after merge to main, where the cost
+      # of finding out is a dead installer rather than a red pull request.
+      #
+      # It runs before any firmware exists, which is why no build is needed:
+      # it lays down the manifests, and Pages later copies .bin files beside
+      # them. Output goes to a scratch directory outside the repository so the
+      # run cannot leave the working tree dirty.
+      - name: Generate the site and installer manifests
+        run: |
+          python tools/gen_site.py \
+            --out /tmp/gume-site-check \
+            --repo "${{ github.server_url }}/${{ github.repository }}"
 
       # Detect which environments to build based on file changes.
       # On pushes to main/dev: build all (conservative).

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,23 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Fail fast. Site generation runs BEFORE the expensive PlatformIO
+      # install and the ten-environment firmware build, so a structural
+      # failure -- a missing template placeholder, an orphaned still, a board
+      # with no BOARD_DETAILS entry, a VARIANTS environment that does not
+      # exist -- is discovered in seconds instead of after twenty minutes of
+      # compiling. None of those failures depend on a single byte of firmware,
+      # so there is nothing to be gained by finding them later.
+      #
+      # This writes the real _site directory that the rest of the job fills
+      # in: the steps below copy each environment's binaries next to the
+      # manifests laid down here, and then prove every manifest resolves.
+      - name: Generate the site
+        run: |
+          python tools/gen_site.py \
+            --out _site \
+            --repo "${{ github.server_url }}/${{ github.repository }}"
+
       - name: Cache PlatformIO
         uses: actions/cache@v4
         with:
@@ -77,9 +94,6 @@ jobs:
                 "$(python -c "print($bytes / 3145728 * 100)")"
             done
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Generate the site
-        run: python tools/gen_site.py --out _site --repo "${{ github.server_url }}/${{ github.repository }}"
 
       # The env list is *derived* from what gen_site.py actually laid down,
       # never written out again here. Every environment is still built above --

--- a/BOARD_E32R28T-1.md
+++ b/BOARD_E32R28T-1.md
@@ -27,7 +27,8 @@ Complete hardware specification and driver configuration for the E32R28T-1 / ESP
 
 ## 2. GPIO Pinout
 
-All pins defined in `include/BoardConfig.h`.
+All pins defined in `include/boards/e32r28t1.h`, the board profile. `include/BoardConfig.h` only selects a profile and derives the screen
+constants from it -- it holds no pin of its own.
 
 ### Display (ILI9341) — HSPI Bus
 
@@ -121,7 +122,7 @@ V_cell = ADC_millivolts × 2.0  (DIVIDER_RATIO = 2.0f)
 - Expected: GPIO4 = red, GPIO16 = green.
 - Actual: GPIO4 = green, GPIO16 = red.
 - If you see orange (R255 G110) output as green and purple (R200 B255) as cyan, the swap is working correctly.
-- **DO NOT "FIX" THIS.** It is intentional in `BoardConfig.h` and verified on device. Any future board must have its own quirk check.
+- **DO NOT "FIX" THIS.** It is intentional in `include/boards/e32r28t1.h` and verified on device. Any future board must have its own quirk check.
 
 **PWM:** LEDC channel 4, 5 kHz PWM, 8-bit depth (0–255), PWM_HIGH_MODE.
 
@@ -340,7 +341,8 @@ Two thresholds, both disabled while charging (plugging in clears warning immedia
 ## 6. Radio: Wi-Fi (lwIP + SNTP)
 
 ### Purpose
-NTP time synchronization only. No telemetry, no data logging.
+NTP time synchronization, plus one `ip-api.com` lookup to guess the time
+zone on first connect. Nothing else. No telemetry, no data logging.
 
 ### State Machine (Non-blocking)
 - **Idle** → (credentials available) → **Connecting**
@@ -470,7 +472,7 @@ Five player slots (`p0_` through `p4_`) plus permanent Guest (`p5_`, writes drop
 ### Red/Green LED Crossing (HARDWARE QUIRK)
 - **Symptom:** Colors appear wrong (e.g., red looks green)
 - **Root cause:** Board schematic swapped GPIO16 (R) and GPIO4 (G)
-- **Fix:** Already applied in `BoardConfig.h` (`PIN_RGB_R = 16`, `PIN_RGB_G = 4`)
+- **Fix:** Already applied in `include/boards/e32r28t1.h`, in that profile's `RgbLedProfile` (red on 16, green on 4)
 - **Verification:** Tested on hardware; orange (R255 G110) output confirmed green
 - **Action:** DO NOT "FIX" this. Verify with hardware if porting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ real hardware has not met that bar. `docs/PORTING.md` is the checklist.
 
 ### Changed
 
+- **The build is reproducible.** `platform = espressif32` was bare and every
+  library carried a caret range, so a checkout of a fixed commit resolved to
+  whatever was newest that day -- a different Arduino core, a different Xtensa
+  toolchain, a different ArduinoJson. `^7.0.4` had already floated to 7.4.3 in
+  practice. Worse, `map-n-flag` tracked its default branch, so the flag and
+  outline artwork could change under a release build without a byte changing
+  here. Everything is now pinned to what the documented flash and RAM figures
+  were actually measured on: `platformio/espressif32@7.0.1` (Arduino core
+  3.20017.241212, toolchain-xtensa-esp32 8.4.0+2021r2-patch5), TFT_eSPI 2.5.43,
+  ArduinoJson 7.4.3, NimBLE-Arduino 1.4.3, and `map-n-flag` at commit
+  `3c412cb` -- the upstream carries no tags, so the commit is the only
+  immutable handle. Nothing is upgraded; this pins the known-working build so
+  the size figures in `README.md` and `CLAUDE.md` mean something to a
+  contributor who did not measure them. A clean-slate resolution reproduces
+  `env:app` at exactly 2,353,221 bytes flash and 72,588 bytes RAM.
+
 - **The privacy claim no longer overstates itself.** The README, the installer
   page and the About app's credits page each said some form of "the device
   sends nothing anywhere" -- while the same documents described NTP, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Board support beyond the E32R28T-1 is the work in flight. It was held back from
 the installer page and have it work, and a variant that has not been tested on
 real hardware has not met that bar. `docs/PORTING.md` is the checklist.
 
+### Changed
+
+- **The installer's site generator now runs on every pull request.**
+  `tools/gen_site.py` writes the landing page and the esp-web-tools manifests
+  behind the flash button, and until now nothing but the Pages workflow ever
+  executed it -- so a generator failure was found after merge to `main`, as a
+  dead installer rather than a red pull request. It is now a step in the
+  required `verify` job, and deliberately **ungated**: it runs even when the
+  firmware build is skipped, because changes under `site/`, `docs/`, `tools/`
+  and `.github/` are both the ones that gate skips and the ones most likely to
+  break the installer. It needs no PlatformIO and adds seconds.
+
+- **Pages fails fast.** The Pages workflow generated the site *after* building
+  ten firmware environments. Site generation now runs first, so a missing
+  placeholder or an orphaned still is caught in seconds instead of after
+  twenty minutes of compiling. The firmware set it builds is unchanged.
+
 ### Fixed
 
 - **The installer page generates again with more than one board.** Generalising

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ real hardware has not met that bar. `docs/PORTING.md` is the checklist.
 
 ### Changed
 
+- **The privacy claim no longer overstates itself.** The README, the installer
+  page and the About app's credits page each said some form of "the device
+  sends nothing anywhere" -- while the same documents described NTP, the
+  `ip-api.com` time-zone lookup and the BLE beacon a few lines below, and
+  About's own radio page shows the beacon broadcasting live. Nothing about
+  what the firmware does has changed, and the strong claims are all still
+  made: no accounts, no analytics, no telemetry, no personal-data collection.
+  The absolute one is gone, replaced by wording that names the optional
+  exchanges it excepts. On the device, the credits page now points at *What
+  the radios do* rather than restating a promise -- the same derive-rather-
+  than-restate rule as the game list. `tools/check_privacy.py` now fails the
+  build on the absolute forms, and equally on a public document that drops the
+  strong claims instead of correcting them.
+
+- **Contributor build instructions match the tree again.** `CONTRIBUTING.md`
+  claimed `pio run -e app -e bringup -e wifidiag` built "every firmware
+  environment". It omitted `batdiag` for most of the project's life, and once
+  two more boards arrived it was missing seven of ten. The command is now
+  derived from `platformio.ini` the same way `release.yml` derives it, so it
+  cannot drift again, with the default board's four given separately for
+  everyday work.
+
+- **The site's board-porting guidance describes the current architecture.** It
+  said Braino targets one board and pointed at `AGENTS.md`; it now says a board
+  is a profile under `include/boards/<id>.h` plus a `[board_<id>]` section in
+  `platformio.ini`, and links `docs/PORTING.md`. Stale references calling
+  `include/BoardConfig.h` the place pins are defined are corrected in
+  `BOARD_E32R28T-1.md` and `cases/README.md` -- that file selects a profile and
+  static_asserts against it, and holds no pin of its own.
+
 - **The installer's site generator now runs on every pull request.**
   `tools/gen_site.py` writes the landing page and the esp-web-tools manifests
   behind the flash button, and until now nothing but the Pages workflow ever

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,11 +205,29 @@ Build the app:
 pio run
 ```
 
-Build every firmware environment:
+Build every firmware environment. The list is *derived* from `platformio.ini`
+rather than typed out, because typing it out is what went wrong: this section
+said `pio run -e app -e bringup -e wifidiag` for most of the project's life,
+which quietly omitted `batdiag`, and then three more boards arrived and it was
+missing seven. `.github/workflows/release.yml` builds the same set the same
+derived way.
 
 ```bash
-pio run -e app -e bringup -e wifidiag
+pio run $(python -c "import re,io; print(' '.join('-e ' + e for e in re.findall(r'^\[env:(\w+)\]', io.open('platformio.ini', encoding='utf-8').read(), re.M)))")
 ```
+
+That is currently ten environments: an `app`, a `bringup` and a `batdiag` for
+each of the three supported boards, plus the board-independent `wifidiag`. It
+takes a while. For everyday work, the default board's four are usually enough:
+
+```bash
+pio run -e app -e bringup -e batdiag -e wifidiag
+```
+
+Build the whole set before opening a pull request that touches the HAL, a board
+profile, `platformio.ini` or anything else every board shares -- CI builds all
+ten on a push to `main` or `dev`, and a break that only shows up on the third
+board is a break you want to find here.
 
 Before any build, upload or serial monitor session, take the shared board lock.
 It lives in the common git directory so every worktree sees the same lock:
@@ -239,8 +257,22 @@ Run the checks that match your change. For normal firmware work, run:
 python tools/check_catalog.py
 python tools/check_frame_rules.py
 python tools/check_docs.py
-pio run -e app -e bringup -e wifidiag
+python tools/check_boards.py
+python tools/check_privacy.py
+pio run -e app -e bringup -e batdiag -e wifidiag
 ```
+
+Those five checks plus site generation are what CI's required `verify` job runs
+on every pull request, so running them locally is running the gate:
+
+```bash
+python tools/gen_site.py --out /tmp/gume-site-check
+```
+
+`gen_site.py` writes the landing page and the installer's flash manifests. It
+is ungated in CI -- it runs even on a documentation-only pull request, because
+changes under `site/`, `docs/`, `tools/` and `.github/` are the ones most likely
+to break the installer, and they are exactly the ones the firmware build skips.
 
 If a screen layout changed, regenerate screenshots:
 
@@ -348,9 +380,12 @@ To rehearse the packing without tagging anything, run it against a local
 build:
 
 ```bash
-pio run -e app -e bringup -e wifidiag -e batdiag
+pio run $(python -c "import re,io; print(' '.join('-e ' + e for e in re.findall(r'^\[env:(\w+)\]', io.open('platformio.ini', encoding='utf-8').read(), re.M)))")
 python tools/pack_release.py --out dist --strict
 ```
+
+`--strict` wants every environment present, so this needs the full derived
+build above, not the four-environment shorthand.
 
 Afterwards, open the next version on `dev` as a `-SNAPSHOT`, so a board
 flashed from `dev` cannot be mistaken for the release it is ahead of.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,11 +172,26 @@ Keep the branch current — `git fetch upstream && git rebase upstream/dev` —
 because the protection rules will not let a stale branch merge. Leave "allow
 edits by maintainers" ticked so a maintainer can rebase or fix a check for you.
 
-CI runs on pull requests from forks with a read-only token, so `verify` (the
-repository checks, plus a build of every firmware environment when your change
-touches code) will report on your PR without any secret being exposed to it. What CI cannot do is flash a board:
-anything touching hardware, touch, storage or a screen still needs a human with
-the device, so say in the PR what you tested and on which board.
+CI runs on pull requests from forks with a read-only token, so `verify` will
+report on your PR without any secret being exposed to it. That one job covers
+three things, and it is worth knowing which of them your change triggers:
+
+- **The repository checks and site generation always run**, on every pull
+  request, including a documentation-only one. `check_docs`, `check_boards`,
+  `check_catalog`, `check_frame_rules`, `check_privacy` and `gen_site.py` are
+  cheap and are exactly what a docs change can break.
+- **The firmware build is skipped** when a pull request touches only `docs/`,
+  `cases/`, `site/`, `tools/`, `.github/`, Markdown or `LICENSE`.
+- **When it does build, a pull request builds selectively** -- `app` always,
+  plus `bringup` if you touched the HAL or a board profile, `batdiag` for
+  battery files, `wifidiag` for Wi-Fi files. All ten environments are built on
+  a push to `main` or `dev`, which is the safety net rather than the first
+  line of defence. If your change touches something every board shares, build
+  the full derived set locally before opening the PR.
+
+What CI cannot do is flash a board: anything touching hardware, touch, storage
+or a screen still needs a human with the device, so say in the PR what you
+tested and on which board.
 
 Maintainers with push access can branch inside the repository instead of
 forking — the worktree flow below — but the pull request and CI requirements

--- a/README.md
+++ b/README.md
@@ -635,9 +635,10 @@ next boot.
 
 ## Privacy
 
-The device collects nothing and sends nothing anywhere. No accounts, no
-telemetry, no analytics. Scores and mastery data live in the ESP32's own flash
-and never leave it.
+No accounts, analytics, telemetry, or personal-data collection. The optional
+Wi-Fi and Bluetooth LE features make only the limited exchanges described
+below, and each one is listed. Scores and mastery data live in the ESP32's own
+flash and never leave it.
 
 Wi-Fi connects only to reach an NTP server, plus one lookup to `ip-api.com` to
 guess the time zone on first connect (the picker overrides it, and you can skip

--- a/cases/README.md
+++ b/cases/README.md
@@ -3,7 +3,7 @@
 Printable enclosures, one folder per board.
 
 A case is **not required** for a board to be supported. Firmware support is
-decided by `platformio.ini` and `include/BoardConfig.h`, and a board with no
+decided by `platformio.ini` and `include/boards/<id>.h`, and a board with no
 folder here is a perfectly good port. This directory exists because the person
 most likely to build this is someone who has never designed an enclosure and
 does not want to — handing them a bare board with a battery taped to the back

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,13 +5,29 @@ default_envs = app
 ; Everything here is true of Braino! on ANY board. Nothing board-specific may
 ; live in this section -- that is what the [board_*] sections below are for,
 ; and tools/check_boards.py fails the build if the two get mixed up.
+;
+; Every dependency is pinned to an exact version, and the Git one to an
+; immutable commit. Not caret ranges: `^7.0.4` had already floated ArduinoJson
+; to 7.4.3, so two people checking out the same commit a month apart were
+; building different firmware and had no way to tell. The flash figures in
+; README.md and CLAUDE.md are a claim about a specific build, and a range makes
+; that claim unverifiable by anyone but whoever measured it.
+;
+; These are the versions the documented figures were measured against
+; (2,353,221 bytes flash / 72,588 bytes RAM for env:app), not the newest
+; releases. Bump them deliberately, as their own commit, and re-measure.
 lib_deps =
-    bodmer/TFT_eSPI@^2.5.43
-    bblanchon/ArduinoJson@^7.0.4
-    https://github.com/iamankushpandit/map-n-flag.git
+    bodmer/TFT_eSPI@2.5.43
+    bblanchon/ArduinoJson@7.4.3
+    ; No tags upstream, so the commit is the only immutable handle. Tracking
+    ; the default branch meant the artwork tables could change under a release
+    ; build without a single byte changing in this repository. MIT; the
+    ; library ships its own LICENSE and NOTICE.md, and NOTICE.md here records
+    ; the attribution.
+    https://github.com/iamankushpandit/map-n-flag.git#3c412cb5cea4dcc5c696abd7a4db78470a97fbd1
     ; NimBLE rather than the core's Bluedroid stack: advertise-only needs a
     ; fraction of the host, and flash is the scarce resource on huge_app.
-    h2zero/NimBLE-Arduino@^1.4.2
+    h2zero/NimBLE-Arduino@1.4.3
 build_unflags =
     -std=gnu++11
 build_flags =
@@ -27,7 +43,17 @@ build_flags =
 
 [esp32_common]
 ; The MCU side of the target, shared by every environment on an ESP32 board.
-platform = espressif32
+;
+; Pinned, for the same reason the libraries are. A bare `platform = espressif32`
+; resolves to whatever is newest on the day of the build, which silently changes
+; the Arduino core, the Xtensa toolchain and esptool underneath a checkout that
+; has not changed at all -- so a contributor bisecting a bug can be handed a
+; different compiler than the one that produced it. 7.0.1 is the version the
+; README and CLAUDE.md build figures were measured on: Arduino core
+; framework-arduinoespressif32 @ 3.20017.241212 and toolchain-xtensa-esp32 @
+; 8.4.0+2021r2-patch5. Upgrading is a deliberate commit that re-measures those
+; figures, not something that happens to whoever builds next.
+platform = platformio/espressif32@7.0.1
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -149,7 +175,7 @@ build_flags =
 ; capture of a full discharge).
 extends = esp32_common
 build_src_filter = +<battery_diag.cpp>
-lib_deps = bodmer/TFT_eSPI@^2.5.43
+lib_deps = bodmer/TFT_eSPI@2.5.43
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}
@@ -190,7 +216,7 @@ build_flags =
 [env:batdiag_esp32_2432s028r]
 extends = esp32_common
 build_src_filter = +<battery_diag.cpp>
-lib_deps = bodmer/TFT_eSPI@^2.5.43
+lib_deps = bodmer/TFT_eSPI@2.5.43
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}
@@ -221,7 +247,7 @@ build_flags =
 [env:batdiag_esp32_2432s028_st7789]
 extends = esp32_common
 build_src_filter = +<battery_diag.cpp>
-lib_deps = bodmer/TFT_eSPI@^2.5.43
+lib_deps = bodmer/TFT_eSPI@2.5.43
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}

--- a/site/index.template.html
+++ b/site/index.template.html
@@ -277,8 +277,9 @@ footer {
     <p class="note" style="margin-bottom:0">
       Make sure to select the correct board in the dropdown above. Each firmware image
       is built for specific pins and display drivers; flashing the wrong image will
-      result in a blank screen or non-responsive touch. Build from source if you need
-      to support a different board.
+      result in a blank screen or non-responsive touch. To support a board that is not
+      listed, add a profile for it and build from source &mdash;
+      <a href="{{REPO}}/blob/main/docs/PORTING.md">docs/PORTING.md</a> is the checklist.
     </p>
   </div>
 </section>
@@ -320,9 +321,10 @@ footer {
   <h2>Privacy</h2>
   <div class="card">
     <p style="margin-top:0">
-      The device collects nothing and sends nothing anywhere. No accounts, no
-      telemetry, no analytics. Scores and mastery data live in the ESP32's own
-      flash and never leave it.
+      No accounts, analytics, telemetry, or personal-data collection. The
+      optional Wi-Fi and Bluetooth LE features make only the limited exchanges
+      listed below &mdash; that list is the complete one. Scores and mastery
+      data live in the ESP32's own flash and never leave it.
     </p>
     <ul class="tight">
       <li><b>Wi-Fi</b> connects only to reach an NTP server, plus one lookup to
@@ -353,11 +355,21 @@ footer {
   <h2>Help wanted</h2>
   <div class="card">
     <p style="margin-top:0">
-      Braino targets one board properly today. The CYD family has many variants
-      that differ in ways that fail quietly &mdash; different backlight pins,
-      different touch controllers, the same GPIO meaning different things. If
-      you own one and want it supported, <code>AGENTS.md</code> has a written
-      checklist for adding a board.
+      Braino supports three ESP32 touchscreen boards today, and the CYD family
+      has many more variants. They differ in ways that fail quietly &mdash;
+      different backlight pins, different display drivers, the same GPIO
+      meaning different things &mdash; which is why each one is described
+      explicitly rather than guessed at.
+    </p>
+    <p>
+      Adding a board is two files: a profile under
+      <code>include/boards/&lt;id&gt;.h</code> holding the pins, rotations and
+      which peripherals exist, and the matching <code>[board_&lt;id&gt;]</code>
+      section in <code>platformio.ini</code> holding what the display driver
+      must be told at compile time. Nothing under <code>src/</code> names a
+      GPIO. <a href="{{REPO}}/blob/main/docs/PORTING.md">docs/PORTING.md</a> is
+      the full checklist, and it starts with the honest question of whether a
+      given board can run this firmware at all.
     </p>
     <p>
       <strong>Bug reports and code critique are especially welcome.</strong>

--- a/src/games/AboutGame.cpp
+++ b/src/games/AboutGame.cpp
@@ -175,9 +175,17 @@ void AboutGame::renderCredits(Ui::Renderer& tft) {
     drawLine(tft, 88, "State flags: fonttools/region-flags.", 1);
     drawLine(tft, 102, "State outlines: Natural Earth.", 1);
     drawLine(tft, 116, "Capitals: mledoze/countries (ODbL).", 1);
+    /* This page used to make an absolute claim of network silence, which the
+     * radio page two Prevs back disproves live on the same device: Wi-Fi
+     * reaches an NTP server, the time-zone lookup reaches ip-api.com, and the
+     * beacon broadcasts once it is switched on. A claim the firmware itself
+     * contradicts is worse than no claim, because it is the one a player
+     * believes. So point at the page that reads the real state rather than
+     * restating a promise here -- the same derive-do-not-restate rule as the
+     * game list. tools/check_privacy.py now fails on the absolute forms. */
     tft.setTextColor(Ui::text(), Ui::surface());
     drawLine(tft, 142, "No accounts. No tracking.", 1);
-    drawLine(tft, 156, "No data ever leaves the device.", 1);
+    drawLine(tft, 156, "See \"What the radios do\".", 1);
     tft.setTextColor(Ui::muted(), Ui::surface());
     drawLine(tft, 176, "Scores and progress live in this", 1);
     drawLine(tft, 190, "device's own memory.", 1);

--- a/tools/check_privacy.py
+++ b/tools/check_privacy.py
@@ -15,6 +15,17 @@ No unauthorized data transmission is permitted:
 - No location tracking
 - No unauthorized HTTP/UDP/DNS endpoints
 - No dependencies that phone home
+
+It also polices the *wording* of the public privacy claim, which is a separate
+failure mode and the one that actually shipped. The README and the installer
+page both read "The device collects nothing and sends nothing anywhere" while
+going on to describe NTP, the ip-api.com time-zone lookup and the BLE beacon a
+few lines below, and the About app's credits page said "No data ever leaves the
+device" two screens along from a page that shows the beacon broadcasting. A
+privacy claim the firmware itself contradicts is worse than no claim, because it
+is the one a reader believes -- and it hands a critic the easiest possible way
+to discredit a project whose actual privacy posture is strong. The strong claims
+stay; only the absolute ones go.
 """
 
 import os
@@ -222,6 +233,86 @@ def check_file(filepath: Path) -> list:
     return issues
 
 
+# Public-facing documents whose privacy wording is audited below. These are
+# what a reader outside the project actually sees: the repository front page,
+# the installer landing page, the contributor rules, the security policy and
+# the About app on the device itself.
+PUBLIC_DOCS = (
+    "README.md",
+    "site/index.template.html",
+    "CONTRIBUTING.md",
+    "NOTICE.md",
+    "SECURITY.md",
+    "src/games/AboutGame.cpp",
+)
+
+# Absolute claims of network silence. Each is contradicted by the three
+# documented outbound flows, so none may appear in a public document.
+#
+# The patterns are deliberately narrow. "nothing about your device is sent
+# anywhere" on the installer page is about the *browser*, not the firmware, and
+# is true; "Never sent: names, scores, progress." in About is a scoped claim
+# about specific fields and is also true. Neither may be caught here. What is
+# banned is the unqualified form: the device sends nothing, no data ever leaves
+# it, there is no network traffic.
+BANNED_CLAIMS = (
+    (r"collects nothing and sends nothing",
+     'the absolute "collects nothing and sends nothing" claim'),
+    (r"\bsends? nothing anywhere",
+     'the absolute "sends nothing anywhere" claim'),
+    (r"[Nn]o data (?:ever )?leaves the device",
+     'the absolute "no data leaves the device" claim'),
+    (r"[Nn]othing (?:ever )?leaves the device",
+     'the absolute "nothing leaves the device" claim'),
+    (r"[Nn]o network traffic",
+     'the absolute "no network traffic" claim'),
+)
+
+# The replacement claim has to keep its teeth. A document that deleted the false
+# sentence and put nothing in its place would pass the rule above while being
+# less useful than what it replaced -- so the two headline documents must still
+# make the strong (and true) claims, and must still name the flows they except.
+_HEADLINE_CLAIMS = (
+    (r"[Nn]o accounts", "the no-accounts claim"),
+    (r"telemetry", "the no-telemetry claim"),
+    (r"analytics", "the no-analytics claim"),
+    (r"ip-api\.com", "the ip-api.com time-zone lookup it excepts"),
+)
+
+REQUIRED_CLAIMS = {
+    "README.md": _HEADLINE_CLAIMS,
+    "site/index.template.html": _HEADLINE_CLAIMS,
+}
+
+
+def check_public_privacy_claims() -> list:
+    """No public document may claim absolute network silence."""
+    issues = []
+
+    for rel in PUBLIC_DOCS:
+        path = REPO_ROOT / rel
+        if not path.exists():
+            issues.append("%s: listed in PUBLIC_DOCS but missing" % rel)
+            continue
+        content = path.read_text(encoding="utf-8", errors="ignore")
+
+        for line_num, line in enumerate(content.splitlines(), 1):
+            for pattern, description in BANNED_CLAIMS:
+                if re.search(pattern, line):
+                    issues.append(
+                        "%s: Line %d: %s -- the device makes three documented "
+                        "outbound exchanges (NTP, the ip-api.com time-zone "
+                        "lookup, the opt-in BLE beacon). Say what is not "
+                        "collected, and name the exchanges that do happen."
+                        % (rel, line_num, description))
+
+        for pattern, description in REQUIRED_CLAIMS.get(rel, ()):
+            if not re.search(pattern, content):
+                issues.append("%s: no longer states %s" % (rel, description))
+
+    return issues
+
+
 def main():
     """Run the privacy audit on all source files."""
     print("=" * 70)
@@ -256,6 +347,10 @@ def main():
             if lib.lower() in pio_content.lower():
                 all_issues.append(f"platformio.ini: Suspicious dependency: {lib}")
 
+    # The wording of the public claim, which is a different failure from a
+    # rogue endpoint and is not visible anywhere in src/.
+    all_issues.extend(check_public_privacy_claims())
+
     # Print results
     if all_issues:
         print("\n[FAILED] PRIVACY AUDIT FAILED\n")
@@ -272,6 +367,7 @@ def main():
         print("  1. NTP time synchronization")
         print("  2. One-time timezone lookup (ip-api.com)")
         print("  3. BLE beacon (opt-in, device ID + game/score only)")
+        print("Public privacy wording: no absolute network-silence claims.")
         print("\n" + "=" * 70)
         return 0
 


### PR DESCRIPTION
## Summary

Launch-readiness cleanup, scoped to CI protection, reproducibility, and documents that had drifted from the firmware. No product behaviour changes and no renames.

- **Runs `gen_site.py` in required, ungated PR verification.** The generator writes the Pages landing page and the esp-web-tools manifests behind the flash button, and nothing in required CI ever executed it — only the Pages workflow did, on `main`, after merge. It is deliberately *not* behind the firmware-source gate: that gate skips `site/`, `docs/`, `tools/`, `.github/` and Markdown, which are precisely the changes most likely to break the installer. It needs no PlatformIO and adds seconds.
- **Pages fails fast.** Site generation moved ahead of the PlatformIO install and the ten-environment build, so a structural failure costs seconds instead of twenty minutes. The set of environments built is unchanged.
- **Privacy wording is accurate about optional Wi-Fi/BLE traffic**, without weakening the position — and `check_privacy.py` now enforces it.
- **Contributor build guidance matches the tree**, derived from `platformio.ini` rather than typed out.
- **Board-porting guidance describes the current architecture** and links `docs/PORTING.md`.
- **Toolchain and dependencies are pinned** to the known-working build.

## The privacy change, specifically

README, the installer page and About's credits page each claimed some form of *"the device sends nothing anywhere"* — while the same documents described NTP, the `ip-api.com` time-zone lookup and the BLE beacon a few lines below. About was the worst case: its radio page shows the beacon broadcasting, live, two pages away from a credits page claiming nothing is sent.

Nothing about what the firmware does has changed. The strong claims all survive; only the absolute one goes.

> No accounts, analytics, telemetry, or personal-data collection. The optional Wi-Fi and Bluetooth LE features make only the limited exchanges described below, and each one is listed. Scores and mastery data live in the ESP32's own flash and never leave it.

On the device, the credits page now points at *What the radios do* rather than restating a promise — the same derive-rather-than-restate rule the game list follows. `tools/check_privacy.py` gains a wording audit that fails on the absolute forms **and** on a public document that quietly drops the strong claims instead of correcting them. Both directions are tested.

## Reproducibility pins

`fix/repro-builds` turned out to be an abandoned stub — its tip is the old 4.0.0 release commit and it is already an ancestor of `dev`, carrying no reproducibility work. So this was implemented fresh.

`platform = espressif32` was bare and every library carried a caret range, so a checkout of a fixed commit resolved to whatever was newest that day. `^7.0.4` had already floated ArduinoJson to 7.4.3 in practice. `map-n-flag` tracked its default branch, so the artwork tables could change under a release build without a byte changing here.

| Dependency | Pin | Why |
|---|---|---|
| `platformio/espressif32` | `7.0.1` | Arduino core `3.20017.241212`, toolchain `8.4.0+2021r2-patch5` — what the documented figures were measured on |
| `bodmer/TFT_eSPI` | `2.5.43` | Was `^2.5.43`, already resolving here |
| `bblanchon/ArduinoJson` | `7.4.3` | Was `^7.0.4`; had already floated to 7.4.3 |
| `h2zero/NimBLE-Arduino` | `1.4.3` | Was `^1.4.2` |
| `map-n-flag` | `3c412cb` | No upstream tags, so the commit is the only immutable handle |

**Nothing is upgraded.** These are the versions the known-working build resolved to, not the newest releases. That matters here because README and CLAUDE.md publish exact flash and RAM figures and treat drift in them as a defect — a figure measured against an unpinned graph is not reproducible by anyone but whoever measured it, and flash is at 74.8% of the partition.

MIT attribution for `map-n-flag` is untouched.

## Repository housekeeping

- **#7 closed as completed.** Verified stale first: `78fbe7a` is now an ancestor of `main`, `check_frame_rules.py` reports clean against a fresh extract of `origin/main`, and `branches-ignore: [main]` is gone from both branches. The comment says what the present behaviour is, and is explicit that the hardware-verification item was never done and is not being claimed.
- **#5 triaged, deliberately left open.** No rename, and no branding decision made here. The comment separates the two halves: the display name is mechanically renameable via `BRAINO_PRODUCT_NAME`, while the BLE identity is separately constrained — `FAMILY_ID = "Braino"` is 6 characters and the Nearby payload is *exactly* 31 bytes, so any longer family id overflows the advertisement and silently kills Nearby play, and changing `NAME_PREFIX` breaks peer discovery. The structure to decouple a long display name from a short wire id already exists; the two match by coincidence. The issue asks for the owner's decision rather than proposing one.
- **Repository description and topics updated.** Description now names what this is; the game count was verified as 31 against the registry rather than trusted. Topics: `esp32`, `platformio`, `arduino`, `firmware`, `cyd`, `cheap-yellow-display`, `educational-games`, `web-serial`, `embedded`, `ili9341`. Homepage preserved; repository not renamed.

## Explicitly not included

- **#59** — Profiles Add Player / Rename has no visible Cancel
- **#8** — battery percentage bounce / 0% while still running
- **#44** — host-side tests (labels left exactly as they are; it is deliberately good outside-contributor work)
- soak tests, further hardware validation, unrelated product work, broad refactors

#59 and #8 matter before this is described as a polished consumer product for kids. Neither blocks sharing the repository with developers.

## Validation

Everything below was run on this branch. Nothing is inferred.

**Syntax** — all six OK:

```
python -m py_compile tools/check_docs.py tools/check_boards.py tools/check_catalog.py tools/check_frame_rules.py tools/check_privacy.py tools/gen_site.py
```

**Repository checks** — all pass:

| Check | Result |
|---|---|
| `check_docs.py` | `Docs check: clean.` |
| `check_boards.py` | `Board check: clean (3 board(s), 27 profile field(s)).` |
| `check_catalog.py` | `Catalog check: clean.` |
| `check_frame_rules.py` | `Frame rules: clean.` |
| `check_privacy.py` | `[PASSED]` plus `Public privacy wording: no absolute network-silence claims.` |

**The privacy check was tested in both directions.** Re-introducing the old sentence into README made it fail with three findings (both banned patterns, plus the dropped no-analytics claim); reverting made it pass again.

**Site generation**, exactly as CI now runs it:

```
python tools/gen_site.py --out /tmp/gume-site-check --repo "https://github.com/iamankushpandit/Gume"
-> 31 games, 3 build(s), v5.2.0-SNAPSHOT.
```

Output inspected: `index.html` present (47 KB); three manifest directories — `e32r28t1/app`, `esp32_2432s028r/app_esp32_2432s028r`, `esp32_2432s028_st7789/app_esp32_2432s028_st7789`, correct for `dev`'s board set; all three parse as JSON with the four expected parts at the right offsets; 58 screens copied; the new privacy wording present; both `docs/PORTING.md` links resolving to real URLs (confirmed `docs/PORTING.md` exists on `main`); no `BoardConfig.h`, no `AGENTS.md`, no "targets one board", no "sends nothing anywhere" left in the generated page.

**Firmware — all ten environments, the full protected-branch set**, derived from `platformio.ini`, built with `GITHUB_REF_NAME=main`:

```
app                            SUCCESS
bringup                        SUCCESS
batdiag                        SUCCESS
wifidiag                       SUCCESS
app_esp32_2432s028r            SUCCESS
bringup_esp32_2432s028r        SUCCESS
batdiag_esp32_2432s028r        SUCCESS
app_esp32_2432s028_st7789      SUCCESS
bringup_esp32_2432s028_st7789  SUCCESS
batdiag_esp32_2432s028_st7789  SUCCESS
========================= 10 succeeded in 00:17:45 =========================
```

`env:app` — Flash **2,353,221** / 3,145,728 (74.8%), RAM **72,588** / 327,680 (22.2%). Unchanged, and matching README.md and CLAUDE.md exactly, so no figure updates were needed.

**Pins verified from a clean slate:** deleted `.pio/libdeps` and `.pio/build` entirely and rebuilt. All four libraries re-resolved at the pinned versions (`map-n-flag@1.0.0+sha.3c412cb`), and `env:app` came out byte-identical.

**Workflows:** both parse under `yaml.safe_load`. The `verify` job name is unchanged. The `Generate the site and installer manifests` step carries **no** `if:`, confirmed by walking the parsed step list. In Pages, generation is step 4 of 12 — after `setup-python`, before `Cache PlatformIO`, `Install PlatformIO` and `Build firmware`. Firmware gates left where they were; multi-board coverage not reduced.

**Also:** `git diff --check` clean; no `git add -A`; no AI-attribution trailers; the shared board lock was taken before every build and released afterwards.

## Not verified

**Nothing here has been flashed to a board.** The only firmware change is two lines of static text on About's credits page, and neither of that page's generated stills covers it — but per this repo's own rule, a screen change is not proven by CI. Worth a glance on the device before this reaches `main`.

`docs/FRAMEWORK_PLAN.md` still describes `BoardConfig.h` as holding one unit's pins. It is explicitly marked *"Status: proposal. Nothing here is implemented."* and is a historical design argument, so it was left alone rather than falsified — flagging it here rather than quietly editing it.
