### PR TITLE
Correct the 5.2.0 flash figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Two boards sold under the same name can carry different display controllers, so
 the picker asks which variant you have. Flashing the wrong image gives inverted
 colours, dead touch or a blank screen — not an error message.
 
-Flash 2,353,221 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
+Flash 2,353,205 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
 `env:app` for the E32R28T-1.
 
 ### Added
@@ -67,7 +67,13 @@ Flash 2,353,221 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
   immutable handle. Nothing is upgraded; this pins the known-working build so
   the size figures in `README.md` and `CLAUDE.md` mean something to a
   contributor who did not measure them. A clean-slate resolution reproduces
-  `env:app` at exactly 2,353,221 bytes flash and 72,588 bytes RAM.
+  `env:app` at 2,353,205 bytes flash and 72,588 bytes RAM on the machine the
+  documented figures were read from. It is not bit-identical across hosts: the
+  same commit built on the Linux runner comes out 172 bytes smaller in flash
+  and 48 smaller in RAM. Pinning fixes what the build is made of, not which
+  toolchain binary assembles it, and `check_docs.py` compares the documents
+  against your own `.pio` ELF -- so the figures here are a local reading, not a
+  claim about the image CI publishes.
 
 - **The privacy claim no longer overstates itself.** The README, the installer
   page and the About app's credits page each said some form of "the device

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,353,221 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,353,205 / 3,145,728 bytes,
 **74.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,588 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,353,221 / 3,145,728 bytes (**74.8%**) |
+| Flash | 2,353,205 / 3,145,728 bytes (**74.8%**) |
 | RAM | 72,588 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 


### PR DESCRIPTION
`README.md` and `CLAUDE.md` carried 2,353,221 bytes — measured on the tree
*before* the release commit shortened `BRAINO_VERSION` from `5.2.0-SNAPSHOT` to
`5.2.0`. The released tree is **2,353,205**. RAM is unchanged at 72,588 and
neither percentage moves.

This is not cosmetic. `check_docs.py` compares both documents against
`.pio/build/app/firmware.elf` when one exists, so anybody who built `env:app`
and then ran the checks got a failure on a released `main`. CI does not catch it
because the checks run before the build step — there is no ELF to compare
against there.

Also corrected: the reproducible-build entry claimed a clean-slate resolution
reproduces `env:app` "at exactly" that number. It does not travel — the same
commit is 172 bytes smaller in flash and 48 smaller in RAM on the Linux runner
(run 33097303387). Pinning fixes what the build is made of, not which toolchain
binary assembles it. The entry now says so, rather than inviting the next person
to chase an expected discrepancy.

No tag has been pushed, so the release notes lifted from `CHANGELOG.md` have not
been published with the wrong number.

Measured with `GITHUB_REF_NAME=main pio run -e app` on commit 1732f94;
`check_docs.py` clean against that ELF.
