### PR TITLE
Sync dev with main after 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Two boards sold under the same name can carry different display controllers, so
 the picker asks which variant you have. Flashing the wrong image gives inverted
 colours, dead touch or a blank screen — not an error message.
 
-Flash 2,353,221 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
+Flash 2,353,205 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
 `env:app` for the E32R28T-1.
 
 ### Added
@@ -67,7 +67,13 @@ Flash 2,353,221 / 3,145,728 (74.8%), RAM 72,588 / 327,680 (22.2%), measured on
   immutable handle. Nothing is upgraded; this pins the known-working build so
   the size figures in `README.md` and `CLAUDE.md` mean something to a
   contributor who did not measure them. A clean-slate resolution reproduces
-  `env:app` at exactly 2,353,221 bytes flash and 72,588 bytes RAM.
+  `env:app` at 2,353,205 bytes flash and 72,588 bytes RAM on the machine the
+  documented figures were read from. It is not bit-identical across hosts: the
+  same commit built on the Linux runner comes out 172 bytes smaller in flash
+  and 48 smaller in RAM. Pinning fixes what the build is made of, not which
+  toolchain binary assembles it, and `check_docs.py` compares the documents
+  against your own `.pio` ELF -- so the figures here are a local reading, not a
+  claim about the image CI publishes.
 
 - **The privacy claim no longer overstates itself.** The README, the installer
   page and the About app's credits page each said some form of "the device

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,353,221 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,353,205 / 3,145,728 bytes,
 **74.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,588 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,353,205 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,353,221 / 3,145,728 bytes,
 **74.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,588 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -650,6 +650,24 @@ Before tagging, on `main`:
    into the image**, so a figure measured on a feature branch is a few bytes
    out on `main`; measure with `GITHUB_REF_NAME=main pio run -e app`, which is
    what CI does.
+
+   **`BRAINO_VERSION` is in the image too, so measure after the version bump,
+   not before.** Dropping `-SNAPSHOT` is nine characters and moved the 5.2.0
+   figure by 16 bytes, which shipped to `main` wrong because the build was run
+   on the tree as it stood before the release commit. The consequence is that
+   `dev` and `main` legitimately carry different numbers between releases --
+   2,353,221 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   not drift to be reconciled. `check_docs.py` compares each document against
+   whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
+   branch has to state its own figure or the checks fail for anyone who builds
+   it.
+
+   The figure is also not portable across hosts: the same commit is 172 bytes
+   smaller in flash and 48 smaller in RAM on the Linux runner than on the
+   Windows machine these numbers were read from. Pinning the platform and the
+   libraries fixes what the build is made of, not which toolchain binary
+   assembles it. Read the number from your own `pio run`; do not copy one out
+   of a CI log.
 
 The tag and `BRAINO_VERSION` must agree, and the workflow fails if they do
 not. That check exists because a published release cannot be quietly

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,353,205 / 3,145,728 bytes (**74.8%**) |
+| Flash | 2,353,221 / 3,145,728 bytes (**74.8%**) |
 | RAM | 72,588 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,353,221 / 3,145,728 bytes (**74.8%**) |
+| Flash | 2,353,205 / 3,145,728 bytes (**74.8%**) |
 | RAM | 72,588 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 


### PR DESCRIPTION
Brings [#66](https://github.com/iamankushpandit/Gume/pull/66) back from `main`, then re-reads the size line from a build of
*this* branch: **2,353,221** bytes flash, 72,588 RAM.

## Why that differs from main's 2,353,205

`BRAINO_VERSION` is compiled into the image. `5.3.0-SNAPSHOT` is nine
characters longer than `5.2.0`, and the figure moves with it. `dev` and `main`
carrying different numbers between releases is correct, not drift.

It matters because `check_docs.py` compares each document against whatever
`.pio/build/app/firmware.elf` is in the tree it runs from. A branch quoting
another branch's figure fails the checks for everyone who builds it — and
opening a snapshot has never re-measured before, so `dev` has been quietly
failing its own doc check for a whole cycle at a time. CI never saw it because
the checks run before the build step, so there is no ELF there to compare
against.

`CLAUDE.md`'s release section now states both halves — measure *after* the
version bump, and expect the two branches to differ — plus the host caveat: the
same commit is 172 bytes smaller in flash and 48 smaller in RAM on the Linux
runner than on the machine these were read from. Pinning fixes what the build
is made of, not which toolchain binary assembles it.

Checks clean locally, including `check_docs.py` against this branch's own ELF.
