### PR TITLE
Support the Freenove FNK0104B, and teach the board contract about capacitive touch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           # On pushes to main/dev, build all environments (conservative safety net)
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Building all environments (push to main/dev)"
-            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789"
+            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag"
           else
             # On PRs, check which files changed and build selectively
             files=$(gh api --paginate \
@@ -178,7 +178,7 @@ jobs:
           # Build environments with explicit -e flags for check_boards.py verification
           if [ "${{ github.event_name }}" = "push" ]; then
             # On pushes to main/dev: build all environments
-            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789
+            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag
           else
             # On PR: build only affected environments
             ENVS="${{ steps.environments.outputs.envs }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,7 +77,7 @@ jobs:
       # through every net. An environment nobody builds is an environment
       # that is already broken and has not been told yet.
       - name: Build firmware
-        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789
+        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag
 
       # Flash is the scarce resource here (3 MB partition), so put the image
       # size where a reviewer sees it without opening the build log.
@@ -88,7 +88,7 @@ jobs:
             echo
             echo '| Environment | firmware.bin | of 3,145,728 |'
             echo '|---|---:|---:|'
-            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789; do
+            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag; do
               bytes=$(stat -c%s ".pio/build/$env/firmware.bin")
               printf '| %s | %s | %.1f%% |\n' "$env" "$bytes" \
                 "$(python -c "print($bytes / 3145728 * 100)")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ issue template asks for the pin map and its source.
   The battery percentage is correct; the charging verdict is not yet validated
   on this board's charger.
 
+- **Braino makes sounds, on a board whose profile describes a codec.**
+  `beepOk()` and `beepError()` play a rising two-tone and a low double buzz
+  through the ES8311 on the Freenove FNK0104B, as well as pulsing the LED where
+  one exists. `AudioProfile` grew from a single speaker pin to something that
+  can describe a codec: an I2C control address, the five I2S lines and an
+  amplifier enable with its polarity.
+
+  A beep is *rendered* into a static buffer when it is asked for and *fed* to
+  the I2S DMA a slice at a time by `tickAudio()`, which the runtime calls once
+  per frame beside `tickRgb()`. It has to work that way: `beepOk()` is called
+  from game code inside a 20ms frame budget, and playing a 200ms note the way
+  the bring-up probe does would blow that budget on every correct answer in
+  every game. Volume is capped at `AUDIO_VOLUME_MAX = 80` -- a ceiling in the
+  same spirit as `BRIGHTNESS_MIN`, for a handheld held near a child's ears --
+  and the amplifier is powered only while something is playing.
+
+  Boards with a bare `speakerPin` are unchanged: `beep()` is still a stub and
+  the LED pulse is still the whole of the feedback.
+
 - **The board contract describes capacitive touch.** `TouchProfile` carried an
   XPT2046 and nothing else, so a board wiring an I2C controller could not be
   described at all. It now carries a `TouchKind` and both pin sets, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ worth more than any feature here, and the report that does it is welcome from
 anybody who owns one — `docs/PORTING.md` is the checklist, and the board-port
 issue template asks for the pin map and its source.
 
+### Added
+
+- **The Freenove FNK0104B is supported, on real hardware.** A 2.8-inch
+  ESP32-S3 board with the same ILI9341 240x320 panel, an FT6336U *capacitive*
+  touch controller, 16 MB flash and 8 MB PSRAM. It is offered by the web
+  installer and all 31 games run on it. Unlike the two CYD variants, this port
+  was brought up on a device rather than from a published pin map: display,
+  backlight, touch at all four rotations, battery sense and the audio path were
+  each confirmed by measurement.
+
+  Three peripherals are deliberately switched off rather than half-wired, each
+  because the board profile cannot yet describe the hardware: **sound** (an
+  ES8311 codec, not a speaker pin), the **status LED** (one WS2812, not three
+  PWM channels) and the **SD card** (SDMMC, not SPI). Each degrades quietly and
+  each has an issue with the pin map and the measurements needed to finish it.
+  The battery percentage is correct; the charging verdict is not yet validated
+  on this board's charger.
+
+- **The board contract describes capacitive touch.** `TouchProfile` carried an
+  XPT2046 and nothing else, so a board wiring an I2C controller could not be
+  described at all. It now carries a `TouchKind` and both pin sets, and
+  `BoardConfig.h` asserts per arm rather than demanding SPI lines of every
+  board. A capacitive panel reports pixels, so it never enters the calibration
+  wizard -- a screen its owner could not otherwise get past.
+
+- **`pio run -e s3diag`**, a standalone bring-up probe for ESP32-S3 boards:
+  panel, rotation, I2C scan, live touch mapping, battery, and the full audio
+  path including a record-and-playback microphone test. Built alone, in the
+  same spirit as `wifidiag` and `batdiag`.
+
 ### Fixed
 
 - **The profile name entry has a way out.** The keyboard shared by **Add

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,353,221 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,353,841 / 3,145,728 bytes,
 **74.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,588 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -598,6 +598,7 @@ include/boards/           one header per supported board -- the ONLY place
 src/main.cpp              bringup entrypoint + normal app setup/loop
 src/BuildStamp.cpp        which build this is; recompiled every build
 src/wifi_diag.cpp         standalone radio test (env:wifidiag only)
+src/s3_diag.cpp           standalone ESP32-S3 bring-up probe (env:s3diag only)
 src/engine/               Game, LauncherGame, GameCatalog, AppRegistry, NearbyPlay,
                           AppRuntime, AppRuntimeLock, ScoreCatalog, Progress,
                           RecentQuestions, ContentLoader
@@ -656,7 +657,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,353,221 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,353,841 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,353,841 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,353,881 / 3,145,728 bytes,
 **74.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,588 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -657,7 +657,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,353,841 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,353,881 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,353,221 / 3,145,728 bytes (**74.8%**) |
+| Flash | 2,353,841 / 3,145,728 bytes (**74.8%**) |
 | RAM | 72,588 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -814,6 +814,7 @@ src/
   BuildStamp.cpp        branch/commit/build time; rebuilt every build
   wifi_diag.cpp         standalone radio test (env:wifidiag only)
   battery_diag.cpp      standalone battery/ADC calibration tool (env:batdiag only)
+  s3_diag.cpp           standalone ESP32-S3 bring-up probe (env:s3diag only)
   engine/
     AppCapabilities.h   system-app capability flags
     AppRegistry.cpp     authoritative app registry + instance bindings

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ the left.
 The battery **percentage** is correct, but the **charging/discharging verdict**
 is not yet validated on this board's charger — those constants were measured
 against the E32R28T-1's TP4054 ([#74](https://github.com/iamankushpandit/Gume/issues/74)).
+Partition sizing on the 16 MB part and a first-frame time worth checking are
+tracked in [#75](https://github.com/iamankushpandit/Gume/issues/75).
 
 `pio run -e s3diag` is a standalone bring-up probe for this board: panel,
 rotation, I²C scan, live touch, battery, and the full audio path including a

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ written down too, as [open issues](https://github.com/iamankushpandit/Gume/issue
 
 **Board ports.** Braino is developed and tested against the E32R28T-1. Two
 ESP32-2432S028 CYD variants ship as ports built from published pin maps and
-have not been verified on real hardware, and a 4-inch ST7796 variant is in
-progress — if you own any of those, telling us whether it works is the single
+have not been verified on real hardware; the Freenove FNK0104B *has* been
+verified on hardware but ships with three peripherals switched off (see
+[Freenove FNK0104B](#freenove-fnk0104b-esp32-s3)), and a 4-inch ST7796
+variant is in progress — if you own any of those, telling us whether it works is the single
 most useful thing you can send. The CYD family has many variants whose
 differences fail silently — backlight on GPIO21 versus GPIO27, GPIO34 as a
 battery sense here but a light sensor on the ESP32-2432S028R. A board is now described in two
@@ -108,6 +110,35 @@ The picker offers one image per board, and you have to choose the one that
 matches yours: two boards sold under the same name can carry different display
 controllers, and the wrong image gives inverted colours, dead touch or a blank
 screen rather than an error.
+
+### Freenove FNK0104B (ESP32-S3)
+
+**The Freenove FNK0104B** is a 2.8-inch ESP32-S3 board with the same ILI9341
+240×320 panel, an **FT6336U capacitive** touch controller, 16 MB flash and
+8 MB PSRAM. It is flashable from the web installer and every one of the 31
+games works on it. It was brought up on real hardware rather than from a
+published pin map: display, backlight, touch at all four rotations, battery
+sense and the audio path were each confirmed on a device.
+
+Its USB-C is on a short edge, so unlike the other boards no landscape rotation
+puts the socket at the bottom — Braino uses rotation 3, which puts the cable on
+the left.
+
+**Three things do not work yet, and they are switched off rather than broken:**
+
+| Not working | Why | Issue |
+|---|---|---|
+| Sound | The speaker is behind an **ES8311 codec** (I²C + I²S), and `AudioProfile` describes a single speaker pin. The codec itself works — `pio run -e s3diag` plays through it | [#71](https://github.com/iamankushpandit/Gume/issues/71) |
+| Status LED | One **WS2812** addressable pixel on GPIO42; `RgbLedProfile` describes three PWM channels. `beepOk()`/`beepError()` are no-ops and the screen saver loses its rally colour | [#72](https://github.com/iamankushpandit/Gume/issues/72) |
+| SD card | The slot is **SDMMC 4-bit**; `SdProfile` describes an SPI card. Optional SD content is simply not loaded, which everything has defaults for | [#73](https://github.com/iamankushpandit/Gume/issues/73) |
+
+The battery **percentage** is correct, but the **charging/discharging verdict**
+is not yet validated on this board's charger — those constants were measured
+against the E32R28T-1's TP4054 ([#74](https://github.com/iamankushpandit/Gume/issues/74)).
+
+`pio run -e s3diag` is a standalone bring-up probe for this board: panel,
+rotation, I²C scan, live touch, battery, and the full audio path including a
+record-and-playback microphone test.
 
 **The E32R28T-1 / ESP32-32E** 2.8-inch resistive-touch board is the one this
 firmware is developed and tested against — use

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,353,841 / 3,145,728 bytes (**74.8%**) |
+| Flash | 2,353,881 / 3,145,728 bytes (**74.8%**) |
 | RAM | 72,588 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -124,11 +124,10 @@ Its USB-C is on a short edge, so unlike the other boards no landscape rotation
 puts the socket at the bottom — Braino uses rotation 3, which puts the cable on
 the left.
 
-**Three things do not work yet, and they are switched off rather than broken:**
+**Sound works**: `beepOk()` and `beepError()` play through the ES8311 codec, capped at 80% volume. **Two things do not work yet, and they are switched off rather than broken:**
 
 | Not working | Why | Issue |
 |---|---|---|
-| Sound | The speaker is behind an **ES8311 codec** (I²C + I²S), and `AudioProfile` describes a single speaker pin. The codec itself works — `pio run -e s3diag` plays through it | [#71](https://github.com/iamankushpandit/Gume/issues/71) |
 | Status LED | One **WS2812** addressable pixel on GPIO42; `RgbLedProfile` describes three PWM channels. `beepOk()`/`beepError()` are no-ops and the screen saver loses its rally colour | [#72](https://github.com/iamankushpandit/Gume/issues/72) |
 | SD card | The slot is **SDMMC 4-bit**; `SdProfile` describes an SPI card. Optional SD content is simply not loaded, which everything has defaults for | [#73](https://github.com/iamankushpandit/Gume/issues/73) |
 

--- a/include/BoardConfig.h
+++ b/include/BoardConfig.h
@@ -71,14 +71,37 @@ static_assert(BOARD.screenWidth() >= GAME_CANVAS_WIDTH
               "panel is smaller than the canvas the games are drawn on; this "
               "board cannot be supported");
 
-/* Touch is the only input this firmware has. There are no buttons. */
-static_assert(BOARD.touch.cs != PIN_NONE && BOARD.touch.irq != PIN_NONE,
+/* Touch is the only input this firmware has. There are no buttons.
+ *
+ * Which lines a board must bring out depends on its controller kind, so these
+ * assert per arm rather than demanding every line of every board. Asserting
+ * the union would have forced a capacitive board to invent an SPI chip select
+ * -- and a made-up pin that satisfies a checker is worse than a missing one,
+ * because it stops anybody noticing. */
+static_assert(BOARD.touch.kind == TouchKind::ResistiveXpt2046
+                  || BOARD.touch.kind == TouchKind::CapacitiveFt6336u,
+              "board profile does not say which touch controller it wires");
+
+static_assert(!BOARD.touch.isCapacitive()
+                  ? (BOARD.touch.cs != PIN_NONE && BOARD.touch.mosi != PIN_NONE
+                     && BOARD.touch.miso != PIN_NONE && BOARD.touch.sclk != PIN_NONE)
+                  : true,
+              "resistive touch board is missing an XPT2046 bus line");
+static_assert(!BOARD.touch.isCapacitive() ? BOARD.touch.pressureThreshold > 0 : true,
+              "resistive touch board needs a positive pressure threshold");
+
+static_assert(BOARD.touch.isCapacitive()
+                  ? (BOARD.touch.sda != PIN_NONE && BOARD.touch.scl != PIN_NONE
+                     && BOARD.touch.i2cAddress != 0 && BOARD.touch.i2cHz > 0)
+                  : true,
+              "capacitive touch board is missing an I2C line, address or rate");
+
+/* The one thing both kinds owe, and the thing that decides supportability: a
+ * controller at all. `irq` is common to both -- pen-down on the XPT2046, INT
+ * on the FT6336U. */
+static_assert(BOARD.touch.irq != PIN_NONE,
               "board has no touch controller; it is the only input the "
               "firmware has, so this board cannot be supported");
-static_assert(BOARD.touch.mosi != PIN_NONE && BOARD.touch.miso != PIN_NONE
-                  && BOARD.touch.sclk != PIN_NONE,
-              "board profile is missing a touch bus line");
-static_assert(BOARD.touch.pressureThreshold > 0, "touch pressure threshold must be positive");
 static_assert(BOARD.touch.hitSlop >= 0, "touch hit slop cannot be negative");
 
 /* A backlight the firmware can drive. Brightness is a setting with a

--- a/include/BoardProfile.h
+++ b/include/BoardProfile.h
@@ -125,8 +125,31 @@ struct RgbLedProfile {
     bool   commonAnode;
 };
 
+/* How a board makes a sound, if it can.
+ *
+ * `speakerPin` is a bare transducer on a GPIO -- what the CYD boards wire, and
+ * what this struct used to be able to describe on its own. It is stubbed on
+ * every board that has one.
+ *
+ * A codec is a different animal: an I2C control channel plus a five-wire I2S
+ * data path plus a separate amplifier enable, none of which is a "speaker
+ * pin". Describing one as a pin would have meant the firmware toggling a GPIO
+ * that does nothing, which is worse than admitting there is no speaker.
+ *
+ * Unused lines are PIN_NONE, as everywhere else here. `hasCodec()` and
+ * `hasSpeaker()` are separate questions and a board may answer no to both. */
 struct AudioProfile {
-    int8_t speakerPin;
+    int8_t   speakerPin;
+    int8_t   codecI2cAddress;   // 0 when there is no codec
+    int8_t   i2sMclk;
+    int8_t   i2sBclk;
+    int8_t   i2sWordSelect;
+    int8_t   i2sDataOut;        // ESP32 -> codec DAC (speaker)
+    int8_t   i2sDataIn;         // codec ADC -> ESP32 (microphone)
+    int8_t   ampEnablePin;
+    bool     ampEnableActiveLow;
+
+    constexpr bool hasCodec() const { return codecI2cAddress != 0; }
 };
 
 /* What the part has, as distinct from what the PCB wires. `flashBytes` gates

--- a/include/BoardProfile.h
+++ b/include/BoardProfile.h
@@ -55,16 +55,56 @@ struct PanelProfile {
     bool    backlightActiveHigh;
 };
 
-/* XPT2046 resistive touch. `mosi`/`miso`/`sclk` may repeat the display's SPI
- * pins on boards that share the bus; the firmware bit-bangs either way. */
+/* Which kind of touch controller the board wires. This is a property of the
+ * hardware, and it decides more than a pin map: a resistive panel reports an
+ * ADC reading that means nothing until three points have been fitted to it,
+ * while a capacitive controller reports pixels and has nothing to calibrate.
+ * Running the calibration wizard on one is not a degraded experience, it is a
+ * screen the owner cannot get past. */
+enum class TouchKind : uint8_t {
+    ResistiveXpt2046,      // bit-banged SPI, needs the 3-point affine fit
+    CapacitiveFt6336u,     // I2C, reports panel-native pixels directly
+};
+
+/* Touch. One struct covers both kinds because a board has exactly one, and a
+ * discriminated flat record keeps `check_boards.py`'s field-by-label check
+ * working -- a variant type would let a board fill in the wrong arm and still
+ * compile.
+ *
+ * Lines the board's kind does not use are `PIN_NONE`, exactly as an absent
+ * peripheral is elsewhere in this file. `BoardConfig.h` static_asserts the
+ * lines each kind actually needs, so an unfilled one fails at the compiler
+ * rather than at the first press.
+ *
+ * Resistive: `mosi`/`miso`/`sclk` may repeat the display's SPI pins on boards
+ * that share the bus; the firmware bit-bangs either way.
+ *
+ * Capacitive: the controller reports coordinates in the panel's NATIVE
+ * (portrait) frame and knows nothing about `setRotation()`. Rotating them to
+ * match the display is the touch layer's job, and it is not optional -- the
+ * FNK0104B bring-up probe tracked a finger correctly at rotation 0 and not at
+ * any other, which is exactly this. */
 struct TouchProfile {
-    int8_t   mosi;
-    int8_t   miso;
-    int8_t   sclk;
-    int8_t   cs;
-    int8_t   irq;
-    uint16_t pressureThreshold;   // below this, and with IRQ high, it is noise
-    int16_t  hitSlop;             // pixels of forgiveness on every hit test
+    TouchKind kind;
+    int8_t   mosi;                // resistive only
+    int8_t   miso;                // resistive only
+    int8_t   sclk;                // resistive only
+    int8_t   cs;                  // resistive only
+    int8_t   irq;                 // both: pen-down / INT
+    int8_t   sda;                 // capacitive only
+    int8_t   scl;                 // capacitive only
+    int8_t   reset;               // capacitive only; held low then released
+    uint8_t  i2cAddress;          // capacitive only
+    uint32_t i2cHz;               // capacitive only
+    uint16_t pressureThreshold;   // resistive: below this, with IRQ high, noise
+    int16_t  hitSlop;             // both: pixels of forgiveness on a hit test
+
+    constexpr bool isCapacitive() const {
+        return kind == TouchKind::CapacitiveFt6336u;
+    }
+    /* A capacitive panel has nothing to fit, so the wizard must not run and
+     * `hasTouchCalibration()` must answer true without one having been done. */
+    constexpr bool needsCalibration() const { return !isCapacitive(); }
 };
 
 struct SdProfile {

--- a/include/boards/e32r28t1.h
+++ b/include/boards/e32r28t1.h
@@ -2,6 +2,15 @@
 
 #include "BoardProfile.h"
 
+/* Which touch controller this board wires, as a macro so the preprocessor can
+ * act on it. It has to be a macro and not just the profile field: `if
+ * constexpr` does not discard in a non-template function, so a capacitive
+ * branch mentioning Wire links the whole I2C library into a resistive board --
+ * measured at +4,476 bytes of flash for code that can never run, on a budget
+ * already at 75%. The TouchKind below is derived from this macro rather than
+ * stated alongside it, so there is still exactly one statement of the fact. */
+#define GUME_TOUCH_CAPACITIVE 0
+
 /* HOSYOND / LCDWIKI E32R28T-1 (ESP32-32E) -- the 2.8-inch board Braino! ships
  * on. ILI9341 320x240 TFT, XPT2046 resistive touch on its own bit-banged bus,
  * micro-SD on VSPI, RGB status LED, and a TP4054 single-cell charger.
@@ -32,11 +41,19 @@ inline constexpr BoardProfile BOARD = {
      * src/hal/CLAUDE.md for why this is bit-banged rather than a second
      * hardware peripheral. */
     TouchProfile{
+        /* kind               */ (GUME_TOUCH_CAPACITIVE
+                                     ? TouchKind::CapacitiveFt6336u
+                                     : TouchKind::ResistiveXpt2046),
         /* mosi               */ 32,
         /* miso               */ 39,
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+        /* sda                */ PIN_NONE,
+        /* scl                */ PIN_NONE,
+        /* reset              */ PIN_NONE,
+        /* i2cAddress         */ 0,
+        /* i2cHz              */ 0,
         /* pressureThreshold  */ 350,
         /* hitSlop            */ 8,
     },

--- a/include/boards/e32r28t1.h
+++ b/include/boards/e32r28t1.h
@@ -11,6 +11,11 @@
  * stated alongside it, so there is still exactly one statement of the fact. */
 #define GUME_TOUCH_CAPACITIVE 0
 
+/* No audio codec. Same reasoning as GUME_TOUCH_CAPACITIVE above: the
+ * codec path pulls in Wire and driver/i2s.h, and `if constexpr` would
+ * link both into a board that has neither. */
+#define GUME_HAS_AUDIO_CODEC 0
+
 /* HOSYOND / LCDWIKI E32R28T-1 (ESP32-32E) -- the 2.8-inch board Braino! ships
  * on. ILI9341 320x240 TFT, XPT2046 resistive touch on its own bit-banged bus,
  * micro-SD on VSPI, RGB status LED, and a TP4054 single-cell charger.
@@ -81,7 +86,15 @@ inline constexpr BoardProfile BOARD = {
 
     /* The pin exists; audio is stubbed. beepOk()/beepError() pulse the LED. */
     AudioProfile{
-        /* speakerPin */ 26,
+        /* speakerPin          */ 26,
+        /* codecI2cAddress     */ 0,
+        /* i2sMclk             */ PIN_NONE,
+        /* i2sBclk             */ PIN_NONE,
+        /* i2sWordSelect       */ PIN_NONE,
+        /* i2sDataOut          */ PIN_NONE,
+        /* i2sDataIn           */ PIN_NONE,
+        /* ampEnablePin        */ PIN_NONE,
+        /* ampEnableActiveLow  */ false,
     },
 
     /* Battery sense on IO34 (ADC1_CH6, input-only). The vendor manual states

--- a/include/boards/esp32-2432s028.h
+++ b/include/boards/esp32-2432s028.h
@@ -11,6 +11,11 @@
  * stated alongside it, so there is still exactly one statement of the fact. */
 #define GUME_TOUCH_CAPACITIVE 0
 
+/* No audio codec. Same reasoning as GUME_TOUCH_CAPACITIVE above: the
+ * codec path pulls in Wire and driver/i2s.h, and `if constexpr` would
+ * link both into a board that has neither. */
+#define GUME_HAS_AUDIO_CODEC 0
+
 /* Makerfabs / Sunton ESP32-2432S028Rv3 -- a 2.4-inch CYD variant (Rv3/dual-USB).
  * ST7789 240x320 TFT, XPT2046 resistive touch, battery sense divider, RGB LED, LDR.
  *
@@ -79,7 +84,15 @@ inline constexpr BoardProfile BOARD = {
 
     /* Audio is stubbed. beepOk()/beepError() are no-ops on this variant. */
     AudioProfile{
-        /* speakerPin */ PIN_NONE,
+        /* speakerPin          */ PIN_NONE,
+        /* codecI2cAddress     */ 0,
+        /* i2sMclk             */ PIN_NONE,
+        /* i2sBclk             */ PIN_NONE,
+        /* i2sWordSelect       */ PIN_NONE,
+        /* i2sDataOut          */ PIN_NONE,
+        /* i2sDataIn           */ PIN_NONE,
+        /* ampEnablePin        */ PIN_NONE,
+        /* ampEnableActiveLow  */ false,
     },
 
     /* Battery sense on IO35 (ADC1_CH7, input-only). The divider ratio is

--- a/include/boards/esp32-2432s028.h
+++ b/include/boards/esp32-2432s028.h
@@ -2,6 +2,15 @@
 
 #include "BoardProfile.h"
 
+/* Which touch controller this board wires, as a macro so the preprocessor can
+ * act on it. It has to be a macro and not just the profile field: `if
+ * constexpr` does not discard in a non-template function, so a capacitive
+ * branch mentioning Wire links the whole I2C library into a resistive board --
+ * measured at +4,476 bytes of flash for code that can never run, on a budget
+ * already at 75%. The TouchKind below is derived from this macro rather than
+ * stated alongside it, so there is still exactly one statement of the fact. */
+#define GUME_TOUCH_CAPACITIVE 0
+
 /* Makerfabs / Sunton ESP32-2432S028Rv3 -- a 2.4-inch CYD variant (Rv3/dual-USB).
  * ST7789 240x320 TFT, XPT2046 resistive touch, battery sense divider, RGB LED, LDR.
  *
@@ -35,11 +44,19 @@ inline constexpr BoardProfile BOARD = {
     /* touch: a bus of its own, bit-banged rather than using a second
      * hardware peripheral since the TFT owns HSPI. */
     TouchProfile{
+        /* kind               */ (GUME_TOUCH_CAPACITIVE
+                                     ? TouchKind::CapacitiveFt6336u
+                                     : TouchKind::ResistiveXpt2046),
         /* mosi               */ 32,
         /* miso               */ 39,
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+        /* sda                */ PIN_NONE,
+        /* scl                */ PIN_NONE,
+        /* reset              */ PIN_NONE,
+        /* i2cAddress         */ 0,
+        /* i2cHz              */ 0,
         /* pressureThreshold  */ 350,
         /* hitSlop            */ 8,
     },

--- a/include/boards/esp32-2432s028r.h
+++ b/include/boards/esp32-2432s028r.h
@@ -2,6 +2,15 @@
 
 #include "BoardProfile.h"
 
+/* Which touch controller this board wires, as a macro so the preprocessor can
+ * act on it. It has to be a macro and not just the profile field: `if
+ * constexpr` does not discard in a non-template function, so a capacitive
+ * branch mentioning Wire links the whole I2C library into a resistive board --
+ * measured at +4,476 bytes of flash for code that can never run, on a budget
+ * already at 75%. The TouchKind below is derived from this macro rather than
+ * stated alongside it, so there is still exactly one statement of the fact. */
+#define GUME_TOUCH_CAPACITIVE 0
+
 /* Makerfabs / Sunton ESP32-2432S028R -- the original/classic 2.4-inch CYD.
  * Micro-USB connector, ILI9341 240x320 TFT, XPT2046 resistive touch, RGB LED, LDR.
  *
@@ -38,11 +47,19 @@ inline constexpr BoardProfile BOARD = {
     /* touch: a bus of its own, bit-banged rather than using a second
      * hardware peripheral since the TFT owns HSPI. */
     TouchProfile{
+        /* kind               */ (GUME_TOUCH_CAPACITIVE
+                                     ? TouchKind::CapacitiveFt6336u
+                                     : TouchKind::ResistiveXpt2046),
         /* mosi               */ 32,
         /* miso               */ 39,
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+        /* sda                */ PIN_NONE,
+        /* scl                */ PIN_NONE,
+        /* reset              */ PIN_NONE,
+        /* i2cAddress         */ 0,
+        /* i2cHz              */ 0,
         /* pressureThreshold  */ 350,
         /* hitSlop            */ 8,
     },

--- a/include/boards/esp32-2432s028r.h
+++ b/include/boards/esp32-2432s028r.h
@@ -11,6 +11,11 @@
  * stated alongside it, so there is still exactly one statement of the fact. */
 #define GUME_TOUCH_CAPACITIVE 0
 
+/* No audio codec. Same reasoning as GUME_TOUCH_CAPACITIVE above: the
+ * codec path pulls in Wire and driver/i2s.h, and `if constexpr` would
+ * link both into a board that has neither. */
+#define GUME_HAS_AUDIO_CODEC 0
+
 /* Makerfabs / Sunton ESP32-2432S028R -- the original/classic 2.4-inch CYD.
  * Micro-USB connector, ILI9341 240x320 TFT, XPT2046 resistive touch, RGB LED, LDR.
  *
@@ -82,7 +87,15 @@ inline constexpr BoardProfile BOARD = {
 
     /* Audio amplifier input on GPIO26. */
     AudioProfile{
-        /* speakerPin */ 26,
+        /* speakerPin          */ 26,
+        /* codecI2cAddress     */ 0,
+        /* i2sMclk             */ PIN_NONE,
+        /* i2sBclk             */ PIN_NONE,
+        /* i2sWordSelect       */ PIN_NONE,
+        /* i2sDataOut          */ PIN_NONE,
+        /* i2sDataIn           */ PIN_NONE,
+        /* ampEnablePin        */ PIN_NONE,
+        /* ampEnableActiveLow  */ false,
     },
 
     /* Battery sense on IO35 (ADC1_CH7, input-only). Divider ratio is 2:1. */

--- a/include/boards/fnk0104b.h
+++ b/include/boards/fnk0104b.h
@@ -10,6 +10,11 @@
  * it, so there is still exactly one statement of the fact. */
 #define GUME_TOUCH_CAPACITIVE 1
 
+/* This board has an ES8311 codec. Same reasoning as the macro above:
+ * preprocessor, not `if constexpr`, so boards without one carry neither
+ * Wire nor driver/i2s.h. */
+#define GUME_HAS_AUDIO_CODEC 1
+
 /* Freenove FNK0104B -- 2.8-inch ESP32-S3 display board. ILI9341 240x320 IPS
  * panel, FT6336U CAPACITIVE touch over I2C, ES8311 audio codec with a speaker
  * connector, one WS2812 pixel, SDMMC card slot, and an MX1.25 battery header.
@@ -105,14 +110,25 @@ inline constexpr BoardProfile BOARD = {
         /* commonAnode */ false,
     },
 
-    /* There IS real audio here -- an ES8311 codec at I2C 0x18 with I2S on
-     * MCLK 4 / BCLK 5 / DIN 6 / WS 7 / DOUT 8 and an active-LOW amplifier
-     * enable on GPIO1 -- and env:s3diag plays through it. But AudioProfile
-     * describes a single speaker pin, which a codec is not, so this stays
-     * PIN_NONE until the profile can describe one. Claiming a speaker pin the
-     * firmware would then toggle uselessly is worse than admitting none. */
+    /* ES8311 codec on the SAME I2C bus as touch, at 0x18, plus a five-wire
+     * I2S path and an active-LOW amplifier enable on GPIO1.
+     *
+     * There is no bare speaker pin, and there must not be one: the transducer
+     * hangs off the codec's amplifier, not off a GPIO. Three things about this
+     * part were established on hardware with env:s3diag and are easy to get
+     * wrong -- the amplifier enable is active LOW, MCLK must come from the
+     * APLL because 160 MHz will not divide to 6.144 MHz, and the ADC volume
+     * register resets to minimum. See src/hal/BoardFeedback.cpp. */
     AudioProfile{
-        /* speakerPin */ PIN_NONE,
+        /* speakerPin          */ PIN_NONE,
+        /* codecI2cAddress     */ 0x18,
+        /* i2sMclk             */ 4,
+        /* i2sBclk             */ 5,
+        /* i2sWordSelect       */ 7,
+        /* i2sDataOut          */ 8,
+        /* i2sDataIn           */ 6,
+        /* ampEnablePin        */ 1,
+        /* ampEnableActiveLow  */ true,
     },
 
     /* Battery sense on GPIO9 = ADC1_CH8 on the S3, which matters: ADC2 is

--- a/include/boards/fnk0104b.h
+++ b/include/boards/fnk0104b.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "BoardProfile.h"
+
+/* Which touch controller this board wires, as a macro so the preprocessor can
+ * act on it. It has to be a macro and not just the profile field: `if
+ * constexpr` does not discard in a non-template function, so a capacitive
+ * branch mentioning Wire links the whole I2C library into a resistive board.
+ * The TouchKind below is derived from this macro rather than stated alongside
+ * it, so there is still exactly one statement of the fact. */
+#define GUME_TOUCH_CAPACITIVE 1
+
+/* Freenove FNK0104B -- 2.8-inch ESP32-S3 display board. ILI9341 240x320 IPS
+ * panel, FT6336U CAPACITIVE touch over I2C, ES8311 audio codec with a speaker
+ * connector, one WS2812 pixel, SDMMC card slot, and an MX1.25 battery header.
+ *
+ * The A variant is the same board without the touch controller populated. It
+ * cannot run Braino -- touch is the only input this firmware has -- and the
+ * static_asserts in BoardConfig.h are what say so.
+ *
+ * Pins are Freenove's own, cross-checked against the hardware with env:s3diag
+ * rather than trusted: the display setup from
+ * Libraries/FNK0104AB/TFT_eSPI_Setups_v1.3.zip, the touch and audio pins from
+ * Tutorial_With_Touch/Sketches. Chip identity was read off the part itself --
+ * ESP32-S3 rev v0.2, 16 MB quad flash, 8 MB embedded octal PSRAM (N16R8).
+ *
+ * The display's own SPI pins are NOT here: TFT_eSPI is configured entirely
+ * through `-D` flags in platformio.ini and reads them from there. BoardConfig.h
+ * cross-checks the two descriptions so they cannot drift.
+ */
+inline constexpr BoardProfile BOARD = {
+    "Freenove-FNK0104B",
+
+    /* panel.
+     *
+     * This board breaks an assumption the other three share: its USB-C sits on
+     * a SHORT edge, so rotation 0 -- portrait -- is the orientation with the
+     * socket at the bottom, and NO landscape rotation puts it there. Measured
+     * on the device: rot 0 is USB-bottom, rot 1 is USB-right, so rot 3 is
+     * USB-left. 3 is chosen so the cable exits on the left, away from the hand
+     * doing most of the work for a right-handed player. It is an ergonomic
+     * choice between two equally correct values, not a derivation. */
+    PanelProfile{
+        /* nativeWidth          */ 240,
+        /* nativeHeight         */ 320,
+        /* landscapeRotation    */ 3,
+        /* portraitRotation     */ 0,
+        /* backlightPin         */ 45,
+        /* backlightActiveHigh  */ true,
+    },
+
+    /* touch: FT6336U on I2C, SHARED with the ES8311 audio codec at 0x18. The
+     * bus is not private to touch, which matters if anything here ever grows a
+     * long transaction.
+     *
+     * The controller reports the panel's native portrait frame and knows
+     * nothing about setRotation(); BoardTouch.cpp owns the rotation into
+     * screen space. `reset` must be released before the first transaction or a
+     * chip that is present reports as absent. */
+    TouchProfile{
+        /* kind               */ (GUME_TOUCH_CAPACITIVE
+                                     ? TouchKind::CapacitiveFt6336u
+                                     : TouchKind::ResistiveXpt2046),
+        /* mosi               */ PIN_NONE,
+        /* miso               */ PIN_NONE,
+        /* sclk               */ PIN_NONE,
+        /* cs                 */ PIN_NONE,
+        /* irq                */ 17,
+        /* sda                */ 16,
+        /* scl                */ 15,
+        /* reset              */ 18,
+        /* i2cAddress         */ 0x38,
+        /* i2cHz              */ 400000,
+        /* pressureThreshold  */ 0,
+        /* hitSlop            */ 8,
+    },
+
+    /* No SD, deliberately, for now.
+     *
+     * The slot exists, but it is SDMMC 4-bit (CLK 38, CMD 40, D0 39, D1 41,
+     * D2 48, D3 47) and SdProfile describes an SPI card: cs/mosi/miso/sclk.
+     * Half-wiring it would be a lie in the profile. PIN_NONE is a supported
+     * configuration -- sdReady() is false and optional SD content simply is
+     * not loaded, which everything already has defaults for. An SDMMC backend
+     * is its own change. */
+    SdProfile{
+        /* cs    */ PIN_NONE,
+        /* mosi  */ PIN_NONE,
+        /* miso  */ PIN_NONE,
+        /* sclk  */ PIN_NONE,
+        /* spiHz */ 0,
+    },
+
+    /* No RGB LED that this firmware can drive, for now.
+     *
+     * The board has ONE WS2812 addressable pixel on GPIO42 -- a timed
+     * bitstream, not three PWM channels, so RgbLedProfile cannot express it.
+     * PIN_NONE means beepOk()/beepError() become no-ops and the screen saver
+     * loses its rally colour; nothing else changes. A WS2812 driver behind the
+     * same feedback API is its own change. */
+    RgbLedProfile{
+        /* r           */ PIN_NONE,
+        /* g           */ PIN_NONE,
+        /* b           */ PIN_NONE,
+        /* commonAnode */ false,
+    },
+
+    /* There IS real audio here -- an ES8311 codec at I2C 0x18 with I2S on
+     * MCLK 4 / BCLK 5 / DIN 6 / WS 7 / DOUT 8 and an active-LOW amplifier
+     * enable on GPIO1 -- and env:s3diag plays through it. But AudioProfile
+     * describes a single speaker pin, which a codec is not, so this stays
+     * PIN_NONE until the profile can describe one. Claiming a speaker pin the
+     * firmware would then toggle uselessly is worse than admitting none. */
+    AudioProfile{
+        /* speakerPin */ PIN_NONE,
+    },
+
+    /* Battery sense on GPIO9 = ADC1_CH8 on the S3, which matters: ADC2 is
+     * unusable while Wi-Fi is associated and this radio comes up for NTP.
+     * Freenove's own sketch states the divider as x2.0.
+     *
+     * Measured here: 3.93 V with a pack fitted on USB, against 4.09-4.16 V on
+     * USB with NO pack. The no-pack case reads HIGHER, exactly as on the
+     * E32R28T-1 -- so no threshold separates them and this board must not grow
+     * an isBatteryPresent() either. The charge-inference constants in
+     * BoardPower.cpp were tuned against a different charger and have NOT been
+     * validated here. */
+    BatteryProfile{
+        /* adcPin        */ 9,
+        /* dividerRatio  */ 2.0f,
+        /* sensorMaxVolts*/ 4.50f,
+    },
+
+    /* 16 MB part, read off the chip. Partitioned huge_app.csv for now, which
+     * uses 3 MB of it -- consistent with the other boards, and one fewer
+     * variable during bring-up. */
+    MemoryProfile{
+        /* flashBytes */ 16u * 1024u * 1024u,
+    },
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -165,6 +165,31 @@ build_flags =
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
 
+[board_fnk0104b]
+; Freenove FNK0104B, 2.8-inch ESP32-S3 with ILI9341 and FT6336U capacitive
+; touch. Values cross-checked on the hardware with env:s3diag, not merely
+; transcribed: BGR and INVERSION_ON are both correct here, which is an unusual
+; pair and was read off the panel rather than assumed.
+build_flags =
+    -D BOARD_NAME=\"Freenove-FNK0104B\"
+    -D GUME_BOARD_HEADER=\"boards/fnk0104b.h\"
+    -D ILI9341_2_DRIVER=1
+    -D TFT_RGB_ORDER=TFT_BGR
+    -D TFT_INVERSION_ON=1
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D TFT_MISO=13
+    -D TFT_MOSI=11
+    -D TFT_SCLK=12
+    -D TFT_CS=10
+    -D TFT_DC=46
+    -D TFT_RST=-1
+    -D TFT_BL=45
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D USE_HSPI_PORT=1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=16000000
+
 [env:app]
 ; The console, on the 2.8-inch board. A second board is a second stanza of
 ; exactly this shape with a different ${board_*.build_flags}.
@@ -329,3 +354,18 @@ build_flags =
     -D USE_HSPI_PORT=1
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
+
+[env:app_fnk0104b]
+; The console on the Freenove FNK0104B. This board has no SD slot the firmware
+; can use and no LED it can drive (see include/boards/fnk0104b.h); both degrade
+; quietly, which is what PIN_NONE is for.
+extends = esp32s3_common
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+lib_deps = ${common.lib_deps}
+lib_ldf_mode = deep+
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_fnk0104b.build_flags}
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,32 @@ board_build.partitions = huge_app.csv
 ; The script explains why the build time is NOT injected from here.
 extra_scripts = pre:tools/build_stamp.py
 
+[esp32s3_common]
+; The ESP32-S3 side of the target. A separate section from [esp32_common]
+; because `board` names a chip, not a family: an image built for `esp32dev` is
+; Xtensa ESP32 and carries a chip ID that esptool refuses to write to an S3.
+; Nothing in this repository could be flashed to an S3 board before this
+; existed -- there was no "try the existing firmware and see" option.
+;
+; Measured off the Freenove FNK0104B on the bench, not read off a listing:
+; ESP32-S3 (QFN56) rev v0.2, 16 MB quad flash, 8 MB embedded octal PSRAM
+; (AP_3v3), USB-Serial/JTAG. That combination is the N16R8 module, and
+; `memory_type = qio_opi` is how the Arduino core is told about it -- get it
+; wrong and the board boots, runs, and fails at the first PSRAM access.
+platform = platformio/espressif32@7.0.1
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+monitor_rts = 0
+monitor_dtr = 0
+upload_speed = 921600
+board_build.partitions = huge_app.csv
+board_build.flash_mode = qio
+board_build.arduino.memory_type = qio_opi
+board_upload.flash_size = 16MB
+board_build.flash_size = 16MB
+extra_scripts = pre:tools/build_stamp.py
+
 ; ---------------------------------------------------------------------------
 ; Boards. One section per supported board, and it holds ONLY what that board
 ; makes true: its name, the header describing its pins, and the TFT_eSPI macros
@@ -143,7 +169,7 @@ build_flags =
 ; The console, on the 2.8-inch board. A second board is a second stanza of
 ; exactly this shape with a different ${board_*.build_flags}.
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -153,7 +179,7 @@ build_flags =
 
 [env:bringup]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -195,7 +221,7 @@ build_flags =
 [env:app_esp32_2432s028r]
 ; The console on the ESP32-2432S028R (original/classic CYD with ILI9341).
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -205,7 +231,7 @@ build_flags =
 
 [env:bringup_esp32_2432s028r]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -226,7 +252,7 @@ build_flags =
 [env:app_esp32_2432s028_st7789]
 ; The console on the ESP32-2432S028 with ST7789 (Rv3/dual-USB variants).
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -236,7 +262,7 @@ build_flags =
 
 [env:bringup_esp32_2432s028_st7789]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -253,3 +279,53 @@ build_flags =
     ${common.build_flags}
     ${board_esp32_2432s028_st7789.build_flags}
     -D CYD_BATTERY_DIAG
+
+[env:s3diag]
+; Bring-up probe for the Freenove FNK0104B, built ALONE (src/s3_diag.cpp) in
+; the same spirit as wifidiag and batdiag: no Board, no Ui, no watchdog, no
+; frame budget, and -- the point -- no touch calibration wizard. env:bringup
+; calls runTouchCalibration() on a board with no stored calibration, which on
+; a capacitive panel the XPT2046 code cannot read means the first crosshair is
+; a dead end with the display check stranded behind it.
+;
+; This environment deliberately has NO [board_*] section. A board section is a
+; claim of support, and check_boards.py rightly enforces what that claim costs:
+; a web-installer label, an offered firmware and a CI build. Braino cannot yet
+; run on this board -- there is no capacitive touch path -- so making that
+; claim now would advertise a firmware nobody can use. The section arrives when
+; the port does; until then this is a probe, and `s3diag` is listed in
+; check_boards.py's BOARDLESS_ENVS.
+;
+; The pin values below are transcribed from Freenove's own TFT_eSPI setup,
+; Libraries/FNK0104AB/TFT_eSPI_Setups_v1.3.zip ->
+; FNK0104AB_2.8_240x320_ILI9341.h. They are the vendor's claim, and confirming
+; them against the hardware is this environment's whole job.
+;
+; ARDUINO_USB_CDC_ON_BOOT is not optional here. This board has no USB-UART
+; bridge -- the port is the S3's own USB-Serial/JTAG -- so without it Serial
+; goes to the UART0 pins and the probe reports its findings to nobody.
+extends = esp32s3_common
+build_src_filter = +<s3_diag.cpp>
+lib_deps = bodmer/TFT_eSPI@2.5.43
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    -D GUME_S3_DIAG
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ILI9341_2_DRIVER=1
+    -D TFT_RGB_ORDER=TFT_BGR
+    -D TFT_INVERSION_ON=1
+    -D TFT_WIDTH=240
+    -D TFT_HEIGHT=320
+    -D TFT_MISO=13
+    -D TFT_MOSI=11
+    -D TFT_SCLK=12
+    -D TFT_CS=10
+    -D TFT_DC=46
+    -D TFT_RST=-1
+    -D TFT_BL=45
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D USE_HSPI_PORT=1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=16000000

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -163,6 +163,7 @@ void BrainoApp::loop() {
 
     board_.tickTimeSync();
     board_.tickRgb();
+    board_.tickAudio();
     NearbyPlay::tick(board_);
     tickBatteryWarning(nowMs);
 

--- a/src/hal/Board.cpp
+++ b/src/hal/Board.cpp
@@ -43,18 +43,21 @@ void Board::begin() {
 #if GUME_TOUCH_CAPACITIVE
     {
         pinMode(BOARD.touch.irq, INPUT_PULLUP);
-        /* The controller must be brought out of reset before the first
+        /* ASSERT reset here and RELEASE it after the panel comes up.
+         *
+         * The controller must be brought out of reset before the first
          * transaction, or a chip that is present answers nothing and the pins
-         * take the blame. Measured on the FNK0104B: it needs the release plus
-         * a settling delay before it acknowledges its own address. */
+         * take the blame. It needs a hold low, then a settle before it
+         * acknowledges its own address -- but neither has to be a delay().
+         * tft_.init() runs a full panel init sequence between the two halves,
+         * which is tens of milliseconds of real work, and the NVS and profile
+         * setup below covers the settle before the first pollTouch(). Blocking
+         * boot for 320ms to wait for something the boot was going to do anyway
+         * would be waste, and check_frame_rules.py is right to refuse it. */
         if (BOARD.touch.reset != PIN_NONE) {
             pinMode(BOARD.touch.reset, OUTPUT);
             digitalWrite(BOARD.touch.reset, LOW);
-            delay(20);
-            digitalWrite(BOARD.touch.reset, HIGH);
-            delay(300);
         }
-        Wire.begin(BOARD.touch.sda, BOARD.touch.scl, BOARD.touch.i2cHz);
     }
 #else
     {
@@ -74,6 +77,16 @@ void Board::begin() {
     tft_.setTextWrap(false, false);
     tft_.fillScreen(Ui::bg());
 
+#if GUME_TOUCH_CAPACITIVE
+    /* Release the touch controller. The panel init above was its reset pulse;
+     * everything below is its settling time, and the first pollTouch() does
+     * not happen until the loop starts. */
+    if (BOARD.touch.reset != PIN_NONE) {
+        digitalWrite(BOARD.touch.reset, HIGH);
+    }
+    Wire.begin(BOARD.touch.sda, BOARD.touch.scl, BOARD.touch.i2cHz);
+#endif
+
     prefs_.begin("cydkids", false);
     migrateStorageSchema();
     logStorageUsage("boot");
@@ -81,6 +94,7 @@ void Board::begin() {
     loadNtpResyncHours();
     applyBrightness();
     loadTouchCalibration();
+    beginAudio();
     mountSd();
     BleBeacon::begin(bleBeaconEnabled());
 }

--- a/src/hal/Board.cpp
+++ b/src/hal/Board.cpp
@@ -1,5 +1,9 @@
 #include "Board.h"
 
+#if GUME_TOUCH_CAPACITIVE
+#include <Wire.h>
+#endif
+
 #include "BleBeacon.h"
 #include "ui/Ui.h"
 
@@ -33,13 +37,36 @@ void Board::begin() {
         digitalWrite(BOARD.audio.speakerPin, LOW);
     }
 
-    pinMode(BOARD.touch.mosi, OUTPUT);
-    pinMode(BOARD.touch.miso, INPUT);
-    pinMode(BOARD.touch.sclk, OUTPUT);
-    pinMode(BOARD.touch.cs, OUTPUT);
-    pinMode(BOARD.touch.irq, INPUT);
-    digitalWrite(BOARD.touch.cs, HIGH);
-    digitalWrite(BOARD.touch.sclk, LOW);
+    /* Guarded by the preprocessor, not `if constexpr`: in a non-template
+     * function both arms of an `if constexpr` are still compiled, so the
+     * capacitive arm alone dragged Wire into every resistive build. */
+#if GUME_TOUCH_CAPACITIVE
+    {
+        pinMode(BOARD.touch.irq, INPUT_PULLUP);
+        /* The controller must be brought out of reset before the first
+         * transaction, or a chip that is present answers nothing and the pins
+         * take the blame. Measured on the FNK0104B: it needs the release plus
+         * a settling delay before it acknowledges its own address. */
+        if (BOARD.touch.reset != PIN_NONE) {
+            pinMode(BOARD.touch.reset, OUTPUT);
+            digitalWrite(BOARD.touch.reset, LOW);
+            delay(20);
+            digitalWrite(BOARD.touch.reset, HIGH);
+            delay(300);
+        }
+        Wire.begin(BOARD.touch.sda, BOARD.touch.scl, BOARD.touch.i2cHz);
+    }
+#else
+    {
+        pinMode(BOARD.touch.mosi, OUTPUT);
+        pinMode(BOARD.touch.miso, INPUT);
+        pinMode(BOARD.touch.sclk, OUTPUT);
+        pinMode(BOARD.touch.cs, OUTPUT);
+        pinMode(BOARD.touch.irq, INPUT);
+        digitalWrite(BOARD.touch.cs, HIGH);
+        digitalWrite(BOARD.touch.sclk, LOW);
+    }
+#endif
 
     tft_.init();
     tft_.setRotation(BOARD.panel.landscapeRotation);

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -364,7 +364,14 @@ private:
     };
 
     uint16_t readTouchAdc(uint8_t command);
+    /* One dispatcher, two implementations, chosen at compile time from the
+     * board's TouchKind -- so a board carries only the controller it wires. */
     RawTouch readRawTouch();
+#if GUME_TOUCH_CAPACITIVE
+    RawTouch readCapacitiveTouch();
+#else
+    RawTouch readResistiveTouch();
+#endif
     bool waitForStableRaw(int16_t& rawX, int16_t& rawY);
     bool loadTouchCalibration();
     void saveTouchCalibration();

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -136,6 +136,25 @@ public:
 
     void beepOk();
     void beepError();
+
+    /* Codec volume, 0-100.
+     *
+     * AUDIO_VOLUME_MAX is a product decision, and a ceiling rather than a
+     * default -- the mirror image of BRIGHTNESS_MIN below, which floors the
+     * backlight so a player cannot make the screen unreadable. This is a
+     * handheld held close to a young player's ears, and the last fifth of a
+     * small driver is mostly distortion anyway.
+     *
+     * Anything that ever exposes a volume control clamps to this rather than
+     * relabelling 80 as "100%": a control that lies about its range is worse
+     * than one with a shorter range. */
+    static constexpr uint8_t AUDIO_VOLUME_MAX = 80;
+    static constexpr uint8_t AUDIO_VOLUME_DEFAULT = 60;
+
+    /* Feeds queued audio to the I2S DMA without blocking. Called once per
+     * frame from the runtime, beside tickRgb(), and a no-op on a board with no
+     * codec. See BoardFeedback.cpp for why a beep cannot simply be played. */
+    void tickAudio();
     /* ---- Profiles -------------------------------------------------------
      * Scores, best/worst records and spaced-repetition data are stored per
      * player. Every key that goes through getScore/setScore/saveBestScore and
@@ -334,6 +353,10 @@ public:
     void setRgbColor(uint8_t r, uint8_t g, uint8_t b);
     void pulseRgb(uint8_t r, uint8_t g, uint8_t b, uint16_t ms);
     void tickRgb();
+
+    /* Brings up the codec and the I2S stream. Called from begin(); a no-op
+     * where the profile describes no codec. */
+    void beginAudio();
     void setRgbEnabled(bool on);
     bool rgbEnabled();
 

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -366,12 +366,14 @@ private:
     uint16_t readTouchAdc(uint8_t command);
     /* One dispatcher, two implementations, chosen at compile time from the
      * board's TouchKind -- so a board carries only the controller it wires. */
+    /* One dispatcher, two implementations. Both are DECLARED on every board --
+     * an unused member declaration costs nothing, and guarding the declaration
+     * as well as the definition just means the two guards can disagree, which
+     * they promptly did. Only the definitions are compiled conditionally, in
+     * BoardTouch.cpp, so a board still carries just the controller it wires. */
     RawTouch readRawTouch();
-#if GUME_TOUCH_CAPACITIVE
-    RawTouch readCapacitiveTouch();
-#else
     RawTouch readResistiveTouch();
-#endif
+    RawTouch readCapacitiveTouch();
     bool waitForStableRaw(int16_t& rawX, int16_t& rawY);
     bool loadTouchCalibration();
     void saveTouchCalibration();

--- a/src/hal/BoardAccess.h
+++ b/src/hal/BoardAccess.h
@@ -169,6 +169,7 @@ public:
         board_.pulseRgb(r, g, b, ms);
     }
     void tickRgb() { board_.tickRgb(); }
+    void tickAudio() { board_.tickAudio(); }
     void setRgbEnabled(bool on) { board_.setRgbEnabled(on); }
     bool rgbEnabled() { return board_.rgbEnabled(); }
 

--- a/src/hal/BoardFeedback.cpp
+++ b/src/hal/BoardFeedback.cpp
@@ -1,5 +1,11 @@
 #include "Board.h"
 
+#if GUME_HAS_AUDIO_CODEC
+#include <Wire.h>
+#include <driver/i2s.h>
+#include <math.h>
+#endif
+
 #include "BleBeacon.h"
 
 namespace {
@@ -22,18 +28,282 @@ void writeRgbChannel(int8_t pin, uint8_t channel, uint8_t level) {
 }
 }
 
-void Board::beep(uint16_t frequency, uint16_t ms) {
-    (void)frequency;
-    (void)ms;
+/* ------------------------------------------------------------------ audio
+ *
+ * On a board with an audio codec, beep() is real. On a board without one it
+ * stays the no-op it always was and the LED pulse is the whole of the
+ * feedback -- `beepOk()` has never promised a sound.
+ *
+ * WHY THIS IS NOT SIMPLY "PLAY A TONE".
+ *
+ * `beepOk()` is called from game code, in the middle of a frame, and the loop
+ * has a 20ms budget. The bring-up probe in src/s3_diag.cpp plays its tones by
+ * blocking on i2s_write until the whole note has been handed over -- 90 to
+ * 300ms -- which is correct there, because a probe has no frame budget and
+ * nothing else to do. Doing that here would blow the budget by an order of
+ * magnitude on every correct answer in every game, and `Watchdog` would log
+ * the stall.
+ *
+ * So a beep is RENDERED into a static buffer when it is asked for, and FED to
+ * the I2S DMA a slice at a time by tickAudio(), which the runtime calls once
+ * per frame beside tickRgb(). Every i2s_write here is non-blocking: if the
+ * DMA is full the remainder waits for the next frame. A beep therefore costs
+ * a few hundred microseconds in the frame that starts it and almost nothing
+ * after.
+ *
+ * The buffer is static and mono. `CLAUDE.md`'s memory rule is that a fixed
+ * allocation which is occasionally half empty beats anything that grows, and
+ * this device has no compacting heap. Mono halves it; the codec is fed the
+ * same sample on both slots.
+ *
+ * The codec register values, and three findings that are easy to get wrong,
+ * come from bring-up on the Freenove FNK0104B with env:s3diag:
+ *
+ *   - The amplifier enable is ACTIVE LOW. Driving it high gives perfect
+ *     silence from a codec that reports itself correctly configured, which
+ *     looks exactly like a dead codec or an unplugged speaker.
+ *   - MCLK must come from the APLL. The codec is an I2S slave clocked from
+ *     MCLK at 384x the sample rate, and 160MHz does not divide to 6.144MHz.
+ *   - Register 0x17, the ADC volume, resets to minimum. It is only relevant
+ *     to recording, which this firmware does not do, but it is noted here
+ *     because the vendor's own init leaves it unset and the next person to
+ *     add capture will lose an afternoon to it.
+ */
+#if GUME_HAS_AUDIO_CODEC
+namespace {
+constexpr int AUDIO_RATE = 16000;
+
+/* The longest beep the firmware can ask for. beepError() is the long one at
+ * roughly 300ms; the buffer is sized for that plus headroom. 5120 samples of
+ * 16-bit mono is 10KB of static RAM, which on this device is a good trade for
+ * zero heap traffic. */
+constexpr int TONE_MAX_SAMPLES = AUDIO_RATE * 320 / 1000;
+
+int16_t tonePcm[TONE_MAX_SAMPLES];
+int  toneLength = 0;      // samples rendered
+int  toneAt = 0;          // samples already handed to the DMA
+bool codecUp = false;
+bool ampOn = false;
+
+void esWrite(uint8_t reg, uint8_t value) {
+    Wire.beginTransmission(static_cast<uint8_t>(BOARD.audio.codecI2cAddress));
+    Wire.write(reg);
+    Wire.write(value);
+    Wire.endTransmission();
 }
 
+void setAmp(bool on) {
+    if (BOARD.audio.ampEnablePin == PIN_NONE || ampOn == on) return;
+    ampOn = on;
+    const bool low = BOARD.audio.ampEnableActiveLow ? on : !on;
+    digitalWrite(BOARD.audio.ampEnablePin, low ? LOW : HIGH);
+}
+
+/* Append one tone to the render buffer. Amplitude is ramped over 4ms at each
+ * end: on a small driver the click of an abrupt start is louder than the note.
+ * Silently truncates rather than overrunning -- a shortened beep is a far
+ * better failure than a smashed stack. */
+void renderTone(float hz, int ms, float amplitude) {
+    const int want = AUDIO_RATE * ms / 1000;
+    const int room = TONE_MAX_SAMPLES - toneLength;
+    const int n = want < room ? want : room;
+    if (n <= 0) return;
+
+    const int ramp = AUDIO_RATE * 4 / 1000;
+    const float step = 2.0f * PI * hz / AUDIO_RATE;
+    float phase = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        float env = amplitude;
+        if (i < ramp) env *= static_cast<float>(i) / ramp;
+        else if (i > n - ramp) env *= static_cast<float>(n - i) / ramp;
+        tonePcm[toneLength + i] = static_cast<int16_t>(sinf(phase) * 30000.0f * env);
+        phase += step;
+        if (phase > 2.0f * PI) phase -= 2.0f * PI;
+    }
+    toneLength += n;
+}
+
+void renderSilence(int ms) {
+    const int want = AUDIO_RATE * ms / 1000;
+    const int room = TONE_MAX_SAMPLES - toneLength;
+    const int n = want < room ? want : room;
+    for (int i = 0; i < n; ++i) tonePcm[toneLength + i] = 0;
+    if (n > 0) toneLength += n;
+}
+
+void startRender() { toneLength = 0; toneAt = 0; }
+
+void commitRender() {
+    if (toneLength > 0) setAmp(true);
+}
+}  // namespace
+#endif  /* GUME_HAS_AUDIO_CODEC */
+
+void Board::beginAudio() {
+#if GUME_HAS_AUDIO_CODEC
+    if (BOARD.audio.ampEnablePin != PIN_NONE) {
+        pinMode(BOARD.audio.ampEnablePin, OUTPUT);
+        /* Start with the amplifier OFF. It is switched on only while
+         * something is playing, so an idle console is not holding a class-D
+         * amplifier awake on battery. */
+        ampOn = true;
+        setAmp(false);
+    }
+
+    /* The codec shares the touch I2C bus, which Board::begin() has already
+     * brought up -- do not call Wire.begin() again here. */
+    uint8_t v = 0;
+    esWrite(0x00, 0x1F);           /* reset                                */
+    esWrite(0x00, 0x00);
+    esWrite(0x00, 0x80);           /* power on                             */
+    esWrite(0x01, 0x3F);           /* all clocks, MCLK from the MCLK pin   */
+
+    /* Dividers for 6.144MHz MCLK at 16kHz, from the ES8311 coefficient
+     * table: pre_div 3, pre_multi 1, adc/dac_div 1, lrck 0x00FF, bclk_div 4,
+     * osr 0x10. Hardcoded because this firmware plays at exactly one rate. */
+    Wire.beginTransmission(static_cast<uint8_t>(BOARD.audio.codecI2cAddress));
+    Wire.write(0x02);
+    Wire.endTransmission(false);
+    if (Wire.requestFrom(static_cast<int>(BOARD.audio.codecI2cAddress), 1) == 1) {
+        v = Wire.read();
+    }
+    esWrite(0x02, static_cast<uint8_t>((v & 0x07) | (2 << 5) | (1 << 3)));
+    esWrite(0x03, 0x10);
+    esWrite(0x04, 0x10);
+    esWrite(0x05, 0x00);
+    esWrite(0x06, 0x03);
+    esWrite(0x07, 0x00);
+    esWrite(0x08, 0xFF);
+
+    esWrite(0x09, 3 << 2);         /* 16-bit in                            */
+    esWrite(0x0A, 3 << 2);         /* 16-bit out                           */
+    esWrite(0x0D, 0x01);           /* power up analogue                    */
+    esWrite(0x0E, 0x02);
+    esWrite(0x12, 0x00);           /* power up DAC                         */
+    esWrite(0x13, 0x10);           /* enable output drive                  */
+    esWrite(0x37, 0x08);           /* bypass DAC equaliser                 */
+
+    const uint8_t volume = AUDIO_VOLUME_DEFAULT > AUDIO_VOLUME_MAX
+                               ? AUDIO_VOLUME_MAX : AUDIO_VOLUME_DEFAULT;
+    esWrite(0x32, static_cast<uint8_t>((volume * 256 / 100) - 1));
+
+    i2s_config_t cfg = {};
+    cfg.mode = static_cast<i2s_mode_t>(I2S_MODE_MASTER | I2S_MODE_TX);
+    cfg.sample_rate = AUDIO_RATE;
+    cfg.bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT;
+    cfg.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
+    cfg.communication_format = I2S_COMM_FORMAT_STAND_I2S;
+    cfg.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+    cfg.dma_buf_count = 6;
+    cfg.dma_buf_len = 256;
+    cfg.tx_desc_auto_clear = true;
+    cfg.mclk_multiple = I2S_MCLK_MULTIPLE_384;
+    cfg.use_apll = true;           /* 160MHz will not divide to 6.144MHz   */
+
+    if (i2s_driver_install(I2S_NUM_0, &cfg, 0, nullptr) != ESP_OK) {
+        cfg.use_apll = false;
+        if (i2s_driver_install(I2S_NUM_0, &cfg, 0, nullptr) != ESP_OK) {
+            Serial.println("[audio] I2S install failed; console will be silent");
+            return;
+        }
+        Serial.println("[audio] APLL unavailable; MCLK may be off-frequency");
+    }
+
+    i2s_pin_config_t pins = {};
+    pins.mck_io_num = BOARD.audio.i2sMclk;
+    pins.bck_io_num = BOARD.audio.i2sBclk;
+    pins.ws_io_num = BOARD.audio.i2sWordSelect;
+    pins.data_out_num = BOARD.audio.i2sDataOut;
+    pins.data_in_num = I2S_PIN_NO_CHANGE;
+    if (i2s_set_pin(I2S_NUM_0, &pins) != ESP_OK) {
+        Serial.println("[audio] I2S pins rejected; console will be silent");
+        return;
+    }
+
+    i2s_zero_dma_buffer(I2S_NUM_0);
+    codecUp = true;
+    Serial.printf("[audio] codec 0x%02X up at %d Hz, volume %u%%\n",
+                  BOARD.audio.codecI2cAddress, AUDIO_RATE, volume);
+#endif
+}
+
+void Board::tickAudio() {
+#if GUME_HAS_AUDIO_CODEC
+    if (!codecUp) return;
+
+    if (toneAt >= toneLength) {
+        /* Drained. Drop the amplifier so an idle console is not powering it. */
+        if (toneLength > 0) {
+            toneLength = 0;
+            toneAt = 0;
+            setAmp(false);
+        }
+        return;
+    }
+
+    /* Non-blocking on purpose: whatever the DMA will take this frame, it
+     * takes; the rest waits. A frame must never be spent waiting on audio. */
+    int16_t frame[128 * 2];
+    while (toneAt < toneLength) {
+        const int remaining = toneLength - toneAt;
+        const int n = remaining < 128 ? remaining : 128;
+        for (int i = 0; i < n; ++i) {
+            frame[i * 2] = tonePcm[toneAt + i];
+            frame[i * 2 + 1] = tonePcm[toneAt + i];
+        }
+        size_t written = 0;
+        if (i2s_write(I2S_NUM_0, frame, n * 2 * sizeof(int16_t), &written, 0) != ESP_OK
+                || written == 0) {
+            break;
+        }
+        toneAt += static_cast<int>(written / (2 * sizeof(int16_t)));
+        if (written < n * 2 * sizeof(int16_t)) break;   /* DMA full */
+    }
+#endif
+}
+
+void Board::beep(uint16_t frequency, uint16_t ms) {
+#if GUME_HAS_AUDIO_CODEC
+    if (!codecUp) return;
+    startRender();
+    renderTone(static_cast<float>(frequency), ms, 0.6f);
+    commitRender();
+#else
+    (void)frequency;
+    (void)ms;
+#endif
+}
+
+/* The two beeps are the ones bring-up settled on in src/s3_diag.cpp: a rising
+ * two-tone for yes, a low double buzz for no. They differ in pitch, length AND
+ * shape, so they stay distinguishable to a player who is not listening
+ * carefully -- which is every player. */
 void Board::beepOk() {
     pulseRgb(0, 255, 40, 450);
+#if GUME_HAS_AUDIO_CODEC
+    if (codecUp) {
+        startRender();
+        renderTone(880.0f, 90, 0.55f);
+        renderTone(1320.0f, 110, 0.55f);
+        commitRender();
+        return;
+    }
+#endif
     beep(1175, 55);
 }
 
 void Board::beepError() {
     pulseRgb(255, 0, 0, 450);
+#if GUME_HAS_AUDIO_CODEC
+    if (codecUp) {
+        startRender();
+        renderTone(160.0f, 120, 0.7f);
+        renderSilence(40);
+        renderTone(160.0f, 140, 0.7f);
+        commitRender();
+        return;
+    }
+#endif
     beep(220, 120);
 }
 

--- a/src/hal/BoardTouch.cpp
+++ b/src/hal/BoardTouch.cpp
@@ -88,6 +88,7 @@ void Board::saveTouchCalibration() {
     prefs_.putBytes("touchCal", &cal_, sizeof(TouchCalibration));
 }
 
+#if !GUME_TOUCH_CAPACITIVE
 uint16_t Board::readTouchAdc(uint8_t command) {
     uint16_t raw = 0;
     digitalWrite(BOARD.touch.cs, LOW);
@@ -124,6 +125,8 @@ uint16_t Board::readTouchAdc(uint8_t command) {
  * that reads a pressure only ever compares it against a threshold. Reporting
  * a constant above every threshold is honest about that, where reporting 0
  * would make a real press look like noise. */
+#endif  /* !GUME_TOUCH_CAPACITIVE -- end of the XPT2046 sampling half */
+
 #if GUME_TOUCH_CAPACITIVE
 Board::RawTouch Board::readCapacitiveTouch() {
     RawTouch touch;
@@ -153,6 +156,7 @@ Board::RawTouch Board::readCapacitiveTouch() {
 }
 #endif
 
+#if !GUME_TOUCH_CAPACITIVE
 Board::RawTouch Board::readResistiveTouch() {
     RawTouch touch;
     const uint16_t z1 = readTouchAdc(CMD_READ_Z1);
@@ -182,6 +186,8 @@ Board::RawTouch Board::readResistiveTouch() {
     touch.pressure = pressure;
     return touch;
 }
+
+#endif  /* !GUME_TOUCH_CAPACITIVE -- end of the XPT2046 half */
 
 Board::RawTouch Board::readRawTouch() {
 #if GUME_TOUCH_CAPACITIVE

--- a/src/hal/BoardTouch.cpp
+++ b/src/hal/BoardTouch.cpp
@@ -1,11 +1,20 @@
 #include "Board.h"
 
 #include <math.h>
+#if GUME_TOUCH_CAPACITIVE
+#include <Wire.h>
+#endif
 #include "Watchdog.h"
 #include "ui/Ui.h"
 
 namespace {
 constexpr uint32_t TOUCH_CAL_MAGIC = 0x43594431UL;
+
+/* FT6336U. Only the four registers this firmware needs; the part has many
+ * more and none of them are wanted. TD_STATUS is followed directly by the
+ * first touch point, so one 5-byte read gets the count and the coordinates
+ * without a second transaction per frame. */
+constexpr uint8_t FT_REG_TD_STATUS = 0x02;
 constexpr uint8_t CMD_READ_X = 0xD0;
 constexpr uint8_t CMD_READ_Y = 0x90;
 constexpr uint8_t CMD_READ_Z1 = 0xB0;
@@ -49,7 +58,16 @@ bool computeAffine(const int16_t raw[3][2], const int16_t screen[3][2], Board::T
 }
 
 bool Board::hasTouchCalibration() const {
+    /* A capacitive controller reports pixels; there is nothing to fit, so it
+     * is always "calibrated". This is not a convenience -- every caller that
+     * sees false offers or forces the wizard, and on this panel that wizard
+     * cannot be completed. Answering honestly here is what keeps a first boot
+     * from being a screen the owner cannot get past. */
+#if GUME_TOUCH_CAPACITIVE
+    return true;
+#else
     return cal_.magic == TOUCH_CAL_MAGIC;
+#endif
 }
 
 bool Board::loadTouchCalibration() {
@@ -94,7 +112,48 @@ uint16_t Board::readTouchAdc(uint8_t command) {
     return static_cast<uint16_t>((raw >> 3) & 0x0FFF);
 }
 
-Board::RawTouch Board::readRawTouch() {
+/* Read one point from an I2C capacitive controller.
+ *
+ * Returns coordinates in the panel's NATIVE portrait frame, which is what the
+ * chip reports and all it knows -- it has never heard of setRotation(). The
+ * rotation into screen space happens in mapTouch(), deliberately in the same
+ * place the resistive path applies its affine fit, so pollTouch() below sees
+ * one kind of coordinate whatever the board wires.
+ *
+ * `pressure` is synthesised: capacitive contact is binary, and every caller
+ * that reads a pressure only ever compares it against a threshold. Reporting
+ * a constant above every threshold is honest about that, where reporting 0
+ * would make a real press look like noise. */
+#if GUME_TOUCH_CAPACITIVE
+Board::RawTouch Board::readCapacitiveTouch() {
+    RawTouch touch;
+    uint8_t buf[5];
+
+    Wire.beginTransmission(BOARD.touch.i2cAddress);
+    Wire.write(FT_REG_TD_STATUS);
+    if (Wire.endTransmission(false) != 0) {
+        return touch;
+    }
+    if (Wire.requestFrom(static_cast<int>(BOARD.touch.i2cAddress), 5) != 5) {
+        return touch;
+    }
+    for (uint8_t i = 0; i < 5; ++i) {
+        buf[i] = Wire.read();
+    }
+
+    if ((buf[0] & 0x0F) == 0) {
+        return touch;
+    }
+
+    touch.down = true;
+    touch.x = static_cast<int16_t>(((buf[1] & 0x0F) << 8) | buf[2]);
+    touch.y = static_cast<int16_t>(((buf[3] & 0x0F) << 8) | buf[4]);
+    touch.pressure = 0xFFFF;
+    return touch;
+}
+#endif
+
+Board::RawTouch Board::readResistiveTouch() {
     RawTouch touch;
     const uint16_t z1 = readTouchAdc(CMD_READ_Z1);
     const uint16_t z2 = readTouchAdc(CMD_READ_Z2);
@@ -122,6 +181,14 @@ Board::RawTouch Board::readRawTouch() {
     touch.y = static_cast<int16_t>(y / samples);
     touch.pressure = pressure;
     return touch;
+}
+
+Board::RawTouch Board::readRawTouch() {
+#if GUME_TOUCH_CAPACITIVE
+    return readCapacitiveTouch();
+#else
+    return readResistiveTouch();
+#endif
 }
 
 bool Board::waitForStableRaw(int16_t& rawX, int16_t& rawY) {
@@ -158,6 +225,11 @@ bool Board::waitForStableRaw(int16_t& rawX, int16_t& rawY) {
 }
 
 void Board::runTouchCalibration() {
+    /* Reachable from Settings as well as from boot, so refusing here rather
+     * than only at the call sites is what makes it safe. */
+#if GUME_TOUCH_CAPACITIVE
+    return;
+#else
     const Watchdog::Pause wdtPause;
     const uint8_t savedRotation = displayRotation_;
     tft_.setRotation(1);
@@ -210,10 +282,36 @@ void Board::runTouchCalibration() {
 
     tft_.setRotation(savedRotation);
     displayRotation_ = savedRotation;
+#endif
 }
 
 bool Board::mapTouch(const RawTouch& raw, int16_t& x, int16_t& y) const {
-    if (!raw.down || cal_.magic != TOUCH_CAL_MAGIC) {
+    if (!raw.down) {
+        return false;
+    }
+
+    /* Capacitive: rotate the controller's native portrait coordinates into the
+     * landscape frame the resistive calibration also produces, so pollTouch()'s
+     * rotation switch below serves both without knowing which it has.
+     *
+     * The specific quarter-turn is a property of the panel, not a convention:
+     * it depends on which physical corner the controller calls its origin.
+     * This one was established on hardware rather than derived -- the FNK0104B
+     * probe drew a crosshair through this exact transform and it tracked a
+     * finger at all four rotations, with the opposite handedness available on
+     * a key and demonstrably wrong. See src/s3_diag.cpp. */
+#if GUME_TOUCH_CAPACITIVE
+    {
+        const int16_t lx = raw.y;
+        const int16_t ly = static_cast<int16_t>(BOARD.panel.nativeWidth - 1 - raw.x);
+        x = constrain(lx, static_cast<int16_t>(0),
+                      static_cast<int16_t>(SCREEN_WIDTH - 1));
+        y = constrain(ly, static_cast<int16_t>(0),
+                      static_cast<int16_t>(SCREEN_HEIGHT - 1));
+        return true;
+    }
+#else
+    if (cal_.magic != TOUCH_CAL_MAGIC) {
         return false;
     }
     const float mappedX = cal_.ax * raw.x + cal_.bx * raw.y + cal_.cx;
@@ -221,6 +319,7 @@ bool Board::mapTouch(const RawTouch& raw, int16_t& x, int16_t& y) const {
     x = constrain(static_cast<int16_t>(lroundf(mappedX)), 0, SCREEN_WIDTH - 1);
     y = constrain(static_cast<int16_t>(lroundf(mappedY)), 0, SCREEN_HEIGHT - 1);
     return true;
+#endif
 }
 
 TouchPoint Board::pollTouch() {

--- a/src/hal/CLAUDE.md
+++ b/src/hal/CLAUDE.md
@@ -41,7 +41,16 @@ Deleting a player is a storage operation, not a name-list edit. `removePlayer()`
 
 ### Touch
 
-Bit-banged SPI to the XPT2046 (the TFT owns HSPI). `pollTouch()` averages samples, applies `BOARD.touch.pressureThreshold`, maps through a 3-point affine calibration, and compensates for the active rotation — so game code should never adjust coordinates itself. Calibration persists in NVS behind a magic number; `runTouchCalibration()` re-runs the wizard.
+**Two kinds of controller, one coordinate.** `BOARD.touch.kind` says which the board wires, and `pollTouch()`'s rotation switch is shared by both — game code never adjusts coordinates itself either way.
+
+*Resistive (XPT2046).* Bit-banged SPI (the TFT owns HSPI). `readResistiveTouch()` averages samples and applies `BOARD.touch.pressureThreshold`; `mapTouch()` runs the 3-point affine fit, which persists in NVS behind a magic number. `runTouchCalibration()` re-runs the wizard.
+
+*Capacitive (FT6336U).* I²C. `readCapacitiveTouch()` does one 5-byte read from `TD_STATUS`, which is immediately followed by the first touch point — count and coordinates in a single transaction per frame. Two things about it are load-bearing:
+
+- **It reports the panel's NATIVE portrait frame and has never heard of `setRotation()`.** `mapTouch()` rotates into the same landscape frame the affine fit produces, so everything downstream sees one kind of coordinate. **That quarter-turn is a property of the panel, not a convention** — it depends on which physical corner the controller calls its origin, and it was established on hardware, not derived: `src/s3_diag.cpp` drew a crosshair through this exact transform, tracked a finger at all four rotations, and carried the opposite handedness on a key to show it was wrong.
+- **`hasTouchCalibration()` returns true unconditionally, and `runTouchCalibration()` returns immediately.** There is nothing to fit. This is not a convenience: every caller that sees `false` offers or forces the wizard, and on a capacitive panel that wizard **cannot be completed** — the first crosshair is a screen the owner never gets past. `pressure` is synthesised as `0xFFFF` because capacitive contact is binary and every caller only ever compares it to a threshold; reporting 0 would make a real press look like noise.
+
+**Use `#if GUME_TOUCH_CAPACITIVE`, not `if constexpr`, to separate the two.** In a non-template function both arms of an `if constexpr` are still compiled, so the capacitive arm alone linked Wire into every resistive build — measured at **+4,476 bytes** of flash for code that can never run, on a budget already at 75%. The macro lives in the board header and the profile's `TouchKind` is *derived from it*, so there is still exactly one statement of the fact and the two cannot drift.
 
 `TouchPoint` lives in `TouchTypes.h` and carries `down`, `justPressed`, `justReleased`, `x`, `y`, `pressure`; edge flags come from diffing against `lastTouch_`.
 

--- a/src/hal/CLAUDE.md
+++ b/src/hal/CLAUDE.md
@@ -62,7 +62,7 @@ Panel sleep/wake is observable: `displaySleepTelemetry()` reports sleep count, w
 
 ### RGB LED
 
-LEDC PWM, common anode (inverted drive). `setRgbColor()` holds a colour, `pulseRgb()` shows one briefly, `tickRgb()` fades it and must be called every frame from the main loop. `beepOk()`/`beepError()` are the game-facing wrappers — there is no audio despite the name; the speaker pin is stubbed. Whether the drive is inverted comes from `BOARD.rgb.commonAnode`, not from an assumption in the driver.
+LEDC PWM, common anode (inverted drive). `setRgbColor()` holds a colour, `pulseRgb()` shows one briefly, `tickRgb()` fades it and must be called every frame from the main loop. `beepOk()`/`beepError()` are the game-facing wrappers. On a board whose profile describes an audio codec they now play a real sound as well as pulsing the LED; on a board with only a bare `speakerPin` they remain LED-only and `beep()` is still a stub. Whether the drive is inverted comes from `BOARD.rgb.commonAnode`, not from an assumption in the driver.
 
 The red and green GPIOs are physically crossed on this unit versus the standard pinout. The E32R28T-1 profile already accounts for it (`rgb.r = 16`, `rgb.g = 4`) and it was verified on hardware — leave it alone.
 

--- a/src/s3_diag.cpp
+++ b/src/s3_diag.cpp
@@ -1,0 +1,1058 @@
+/* Freenove FNK0104B bring-up probe -- env:s3diag, built alone.
+ *
+ * This board is not supported yet, and this file is how that gets decided. It
+ * exists because the questions a new board poses cannot be answered from
+ * inside the app, and on this board they cannot be answered by env:bringup
+ * either: that path calls Board::runTouchCalibration() on a board with no
+ * stored calibration, and the wizard is driven by XPT2046 code that a
+ * capacitive panel does not answer. The first crosshair would be a dead end
+ * with the display check stranded behind it.
+ *
+ * So: no Board, no Ui, no watchdog, no frame budget. TFT_eSPI and Wire, and
+ * nothing else that could shape what the hardware appears to be doing.
+ *
+ * Five questions, in the order they block the port:
+ *
+ *   1. Is GPIO45 really the backlight? It is the pin that fails silently --
+ *      a healthy serial log and a black screen looks identical to a dead
+ *      panel, a wrong driver and a bad joint. So the probe BLINKS it on a
+ *      cadence: a screen that pulses is proof, in a way a lit screen is not.
+ *   2. Do the display pins and the ILI9341_2 driver actually drive it?
+ *   3. Are TFT_BGR and TFT_INVERSION_ON both right? Freenove's setup asserts
+ *      both, which is an unusual pair -- the colour bars are labelled so the
+ *      answer is read rather than guessed.
+ *   4. Which rotation puts the USB-C socket at the bottom? That value becomes
+ *      PanelProfile::landscapeRotation. BOOT cycles it.
+ *   5. Is there an FT6336U at 0x38 on SDA 16 / SCL 15, and what coordinate
+ *      space does it report in? That last part is the one a datasheet cannot
+ *      settle, and it decides how TouchProfile has to change.
+ *
+ * Everything it prints is a measurement. Where it states a vendor claim it
+ * says so, because the vendor claim is what is on trial.
+ *
+ * LAYOUT RULE, learned the hard way on the first version of this file.
+ * --------------------------------------------------------------------
+ * A probe whose whole job is to be read at four different rotations must not
+ * be laid out at one of them. The first version positioned text at a fixed
+ * x=16 with fixed row steps, which is fine at 320 wide and runs straight off
+ * the edge at 240 -- and TFT_eSPI does not mark the cut. drawChar() simply
+ * returns once x reaches the viewport edge, so a clipped line looks like a
+ * shorter line, and a reader has no way to tell a truncated battery voltage
+ * from a low one. That is not a cosmetic bug in a diagnostic; it is the
+ * diagnostic lying.
+ *
+ * So every string here goes through fitCentred(), which MEASURES the string
+ * with textWidth() and steps down through the available fonts until it fits
+ * the live tft.width(). Nothing is positioned by a constant that assumes an
+ * orientation, and the frame drawn around the screen edge makes any overrun
+ * visible against it rather than silently absent.
+ */
+
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+#include <Wire.h>
+#include <driver/i2s.h>
+
+/* Freenove's own values, from Libraries/FNK0104AB/TFT_eSPI_Setups_v1.3.zip
+ * and Tutorial_With_Touch/Sketches/Sketch_11.1_Touch. Named here rather than
+ * inlined so a wrong one can be corrected in a single place while probing.
+ *
+ * Note GPIO45 (backlight) and GPIO46 (TFT DC) are ESP32-S3 strapping pins --
+ * sampled at reset, free afterwards. That is fine, and worth knowing before
+ * anyone reads a boot-mode oddity as a display fault. */
+static constexpr int PIN_TOUCH_SDA = 16;
+static constexpr int PIN_TOUCH_SCL = 15;
+static constexpr int PIN_TOUCH_RST = 18;
+static constexpr int PIN_TOUCH_INT = 17;
+static constexpr int PIN_BOOT_KEY  = 0;
+static constexpr int PIN_BATT_ADC  = 9;   /* vendor divider ratio 2.0 */
+
+static constexpr uint8_t FT6336U_ADDR          = 0x38;
+static constexpr uint8_t FT6336U_REG_TD_STATUS = 0x02;
+static constexpr uint8_t FT6336U_REG_CHIP_ID   = 0xA3;
+static constexpr uint8_t FT6336U_REG_FIRMWARE  = 0xA6;
+
+/* ------------------------------------------------------------------- audio
+ *
+ * The speaker is not an amplifier on a pin -- it hangs off an ES8311 codec,
+ * which is the second device the I2C scan found (0x18, sharing the touch bus).
+ * Nothing comes out of it until it has been configured over I2C AND fed a
+ * clocked I2S stream, so "no sound" has several quite different causes and the
+ * probe has to separate them: codec not acknowledging, codec configured but no
+ * stream, stream running but the amplifier disabled, or all three fine and the
+ * speaker not connected. Each is reported separately below.
+ *
+ * Pins are Freenove's, from Tutorial_With_Touch/Sketches/Sketch_07.1_Music.
+ * Their sketch will NOT build here: it uses ESP_I2S.h and Audio.h from Arduino
+ * core 3.x, and this repository pins espressif32@7.0.1, which is core 2.0.17.
+ * So the I2S side is the legacy driver/i2s.h API and the codec is driven by
+ * direct register writes -- the register VALUES are lifted from their es8311.c
+ * rather than invented, because a wrong codec init is silent in exactly the
+ * same way a disconnected speaker is.
+ *
+ * GPIO1 is the power-amplifier enable. It is a separate question from the
+ * codec: the DAC can be running perfectly into a muted amplifier. */
+static constexpr int PIN_I2S_MCLK  = 4;
+static constexpr int PIN_I2S_BCLK  = 5;
+static constexpr int PIN_I2S_DIN   = 6;   /* codec ADC -> ESP32 (microphone) */
+static constexpr int PIN_I2S_WS    = 7;
+static constexpr int PIN_I2S_DOUT  = 8;   /* ESP32 -> codec DAC (speaker)    */
+static constexpr int PIN_PA_ENABLE = 1;
+
+static constexpr uint8_t ES8311_ADDR   = 0x18;
+static constexpr int     AUDIO_RATE    = 16000;
+static constexpr int     AUDIO_MCLK_HZ = AUDIO_RATE * 384;   /* 6.144 MHz */
+
+/* PRODUCT DECISION, 2026-09-01: the firmware will never drive the codec above
+ * 80%. This is a ceiling, not a default -- the same kind of constraint as
+ * Board::BRIGHTNESS_MIN, which floors the backlight so a player cannot make
+ * the screen unreadable. Here the concern points the other way: this is a
+ * handheld held close to a child's ears, and the last 20% of a small driver
+ * is mostly distortion anyway. The probe enforces it too, so nothing
+ * demonstrated on the bench is louder than what the product will ship.
+ *
+ * When audio reaches the app this becomes a named constant beside
+ * BRIGHTNESS_MIN, and any volume slider clamps to it rather than relabelling
+ * 80 as "100%" -- a control that lies about its range is worse than one with
+ * a shorter range. */
+static constexpr int AUDIO_VOLUME_MAX = 80;
+
+/* How long the REC button captures for. Declared up here because draw() paints
+ * the button label and sits above the recorder. */
+static constexpr int ECHO_SECONDS = 5;
+
+static bool  audioReady = false;      /* codec acknowledged and configured */
+static bool  i2sReady   = false;      /* the stream is clocked             */
+static int   audioVolume = 50;        /* 0..AUDIO_VOLUME_MAX, 'v' cycles  */
+static int   micLevel   = 0;          /* 0..100, live                      */
+static int   micPeak    = 0;          /* 0..100, decaying                  */
+static int   echoPeak   = 0;          /* loudest sample of the last record */
+static const char* lastSound = "-";
+static bool paEnabled = true;   /* amp on; the PIN is driven LOW for on */
+static bool audioUsedApll = false;
+static uint8_t adcGainScale = 0x07;   /* reg16, 'g' cycles 0..7 */
+
+/* Where the colour bars ended up last paint. Tapping a bar plays a sound, and
+ * the hit test reads these rather than recomputing the layout -- the same rule
+ * the launcher follows, so the target and the pixels cannot disagree. */
+static int barsX = 0, barsY = 0, barsW = 0, barsH = 0;
+/* The REC button. One rect, used by both the paint and the hit
+ * test, so the target and the pixels cannot drift apart. */
+static int recX = 0, recY = 0, recW = 0, recH = 0;
+static bool echoRequested = false;
+static bool echoBusy = false;
+static constexpr int BAR_COUNT = 5;
+
+static TFT_eSPI tft;
+
+static uint8_t rotation = 1;          /* first guess; BOOT cycles it */
+static uint8_t i2cFound[8];
+static uint8_t i2cCount = 0;
+static bool    touchPresent = false;
+static uint8_t touchChipId = 0;
+static uint8_t touchFirmware = 0;
+static bool    redraw = true;
+
+/* Live touch, in the controller's own coordinates -- deliberately NOT mapped
+ * to the display. What the port needs to know is what the chip reports; any
+ * rotation applied here would hide exactly that. */
+static int  rawX = -1, rawY = -1;
+static int  rawXMin = 9999, rawXMax = -1, rawYMin = 9999, rawYMax = -1;
+static int  touchCount = 0;
+static long touchEvents = 0;
+
+/* Battery, sampled once per redraw and shared by screen and serial so the two
+ * can never disagree -- the first version read the ADC separately in each and
+ * invited exactly that doubt. */
+static float battVolts = 0.0f;
+
+/* Press-edge tracking for the tap-to-play zones. */
+static bool touchDown = false;
+static bool touchWasDown = false;
+
+/* ----------------------------------------------------- the rotation question
+ *
+ * The FT6336U reports in the panel's NATIVE portrait frame and knows nothing
+ * about setRotation(). Something has to rotate its output to match the
+ * display, and that transform is the last unknown in the port -- it is also
+ * the one thing a datasheet cannot settle, because it depends on which
+ * physical corner the panel calls its origin.
+ *
+ * Measured on this board: rot=0 is portrait with USB-C at the bottom, and
+ * rot=1 puts USB-C on the right. That means rot=1 is the board turned a
+ * quarter-turn anticlockwise, so the viewer's top-left corner at rot=1 is the
+ * panel's native top-RIGHT. Everything below follows from that.
+ *
+ * Only rotations 1 and 3 depend on that handedness; 0 and 2 do not. So rather
+ * than assert the derivation, 'm' swaps the two candidate mappings live. If
+ * the crosshair tracks a finger at every rotation in one mode and not the
+ * other, the hardware has answered, and the answer goes into BoardTouch.cpp
+ * having been seen rather than reasoned. */
+static bool altHandedness = false;
+
+static void mapNativeToScreen(int xn, int yn, int& sx, int& sy) {
+    const int W0 = TFT_WIDTH;    /* native portrait width  (240) */
+    const int H0 = TFT_HEIGHT;   /* native portrait height (320) */
+    uint8_t r = rotation;
+    if (altHandedness && (r & 1)) r = (uint8_t)(r ^ 2);   /* swap 1 <-> 3 */
+
+    switch (r) {
+        case 1:  sx = yn;              sy = (W0 - 1) - xn; break;
+        case 2:  sx = (W0 - 1) - xn;   sy = (H0 - 1) - yn; break;
+        case 3:  sx = (H0 - 1) - yn;   sy = xn;            break;
+        default: sx = xn;              sy = yn;            break;
+    }
+}
+
+/* ------------------------------------------------------------------ layout */
+
+/* Fonts this probe may use, largest first. fitCentred() walks down this list. */
+static const uint8_t FONTS[] = { 4, 2, 1 };
+static constexpr int EDGE_MARGIN = 6;   /* px kept clear either side */
+
+static int fontHeight(uint8_t font) { return tft.fontHeight(font); }
+
+/* Draw `text` horizontally centred at `y`, in the largest listed font no
+ * wider than the panel. Returns the height actually used, so callers stack
+ * without assuming a row pitch.
+ *
+ * `maxFont` caps the size for hierarchy (a heading may be big, a detail line
+ * small); the fitting still applies below that cap. If even font 1 does not
+ * fit, it is drawn anyway and reported over serial -- a probe must say when
+ * it cannot show something, never quietly clip it. */
+static int fitCentred(const char* text, int y, uint8_t maxFont, uint16_t colour) {
+    const int limit = tft.width() - 2 * EDGE_MARGIN;
+    uint8_t chosen = FONTS[sizeof(FONTS) - 1];
+    bool fits = false;
+
+    for (size_t i = 0; i < sizeof(FONTS); ++i) {
+        if (FONTS[i] > maxFont) continue;
+        chosen = FONTS[i];
+        if (tft.textWidth(text, chosen) <= limit) { fits = true; break; }
+    }
+    if (!fits) {
+        Serial.printf("[layout] '%s' does not fit %d px even at font 1\n",
+                      text, limit);
+    }
+
+    tft.setTextDatum(MC_DATUM);
+    tft.setTextColor(colour, TFT_BLACK);
+    tft.drawString(text, tft.width() / 2, y + fontHeight(chosen) / 2, chosen);
+    return fontHeight(chosen);
+}
+
+/* Labelled bars. Unlabelled colour bars prove nothing: if BGR and inversion
+ * are both wrong the result is still a plausible-looking spread of colour.
+ * The captions are fitted too -- at 240 wide each bar is only 48 px. */
+static void drawColourBars(int y, int h) {
+    struct Bar { uint16_t colour; const char* name; };
+    static const Bar bars[] = {
+        { TFT_RED,   "RED"   }, { TFT_GREEN, "GREEN" }, { TFT_BLUE,  "BLUE"  },
+        { TFT_WHITE, "WHITE" }, { TFT_BLACK, "BLACK" },
+    };
+    const int n = (int)(sizeof(bars) / sizeof(bars[0]));
+    const int w = tft.width() / n;
+    const int used = w * n;
+    const int left = (tft.width() - used) / 2;   /* centre the whole strip */
+
+    barsX = left; barsY = y; barsW = w; barsH = h;
+
+    tft.setTextDatum(MC_DATUM);
+    for (int i = 0; i < n; ++i) {
+        const int x = left + i * w;
+        tft.fillRect(x, y, w, h, bars[i].colour);
+        tft.setTextColor(bars[i].colour == TFT_WHITE ? TFT_BLACK : TFT_WHITE);
+        /* Caption at font 1 unless it overruns its own bar. */
+        if (tft.textWidth(bars[i].name, 1) <= w - 4) {
+            tft.drawString(bars[i].name, x + w / 2, y + h / 2, 1);
+        }
+    }
+    tft.drawRect(left, y, used, h, TFT_DARKGREY);
+}
+
+static void draw() {
+    const int W = tft.width(), H = tft.height();
+    tft.fillScreen(TFT_BLACK);
+
+    /* A frame one pixel inside the edge. Anything that overruns crosses it,
+     * so clipping becomes visible rather than merely absent. */
+    tft.drawRect(0, 0, W, H, TFT_DARKGREY);
+
+    /* Corner markers prove the driver is addressing the whole panel and not a
+     * window offset by a few pixels -- a classic wrong-driver symptom. */
+    tft.fillRect(1, 1, 12, 12, TFT_YELLOW);
+    tft.fillRect(W - 13, 1, 12, 12, TFT_CYAN);
+    tft.fillRect(1, H - 13, 12, 12, TFT_MAGENTA);
+    tft.fillRect(W - 13, H - 13, 12, 12, TFT_GREEN);
+
+    char line[64];
+
+    /* Build the stack, measure it, then centre it vertically. Doing it in this
+     * order is what makes the same code readable in portrait and landscape
+     * instead of correct in one and off the bottom in the other. */
+    const int barH  = (H >= 300) ? 36 : 28;
+    const int meterH = 10;
+    const int gap   = 4;
+    const int stackH = fontHeight(4) + gap        /* title            */
+                     + fontHeight(2) + gap        /* rotation + size  */
+                     + fontHeight(1) + gap        /* hint             */
+                     + barH          + gap
+                     + fontHeight(2) + gap        /* touch status     */
+                     + fontHeight(1) + gap        /* raw coords       */
+                     + fontHeight(1) + gap        /* seen range       */
+                     + fontHeight(1) + gap        /* audio status     */
+                     + meterH        + gap        /* mic meter        */
+                     + fontHeight(2) + 10 + gap   /* REC button       */
+                     + fontHeight(1) + gap        /* mic numbers      */
+                     + fontHeight(4);             /* battery          */
+    int y = (H - stackH) / 2;
+    if (y < 16) y = 16;                            /* never under the markers */
+
+    y += fitCentred("FNK0104B", y, 4, TFT_WHITE) + gap;
+
+    snprintf(line, sizeof(line), "rot=%u  %dx%d", rotation, W, H);
+    y += fitCentred(line, y, 2, TFT_CYAN) + gap;
+
+    y += fitCentred(altHandedness ? "map B - tap a bar for sound"
+                                  : "map A - tap a bar for sound",
+                    y, 1, TFT_DARKGREY) + gap;
+
+    drawColourBars(y, barH);
+    y += barH + gap;
+
+    uint16_t statusColour;
+    if (touchPresent) {
+        snprintf(line, sizeof(line), "FT6336U id=%02X fw=%02X",
+                 touchChipId, touchFirmware);
+        statusColour = TFT_GREEN;
+    } else if (i2cCount > 0) {
+        snprintf(line, sizeof(line), "I2C ok, no 0x38");
+        statusColour = TFT_ORANGE;
+    } else {
+        snprintf(line, sizeof(line), "I2C SILENT");
+        statusColour = TFT_RED;
+    }
+    y += fitCentred(line, y, 2, statusColour) + gap;
+
+    snprintf(line, sizeof(line), "raw %d,%d  n=%d", rawX, rawY, touchCount);
+    y += fitCentred(line, y, 1, TFT_WHITE) + gap;
+
+    snprintf(line, sizeof(line), "x %d-%d  y %d-%d",
+             rawXMax < 0 ? 0 : rawXMin, rawXMax < 0 ? 0 : rawXMax,
+             rawYMax < 0 ? 0 : rawYMin, rawYMax < 0 ? 0 : rawYMax);
+    y += fitCentred(line, y, 1, TFT_WHITE) + gap;
+
+    /* Audio, stated as three separate facts. "no sound" has four causes and
+     * collapsing them into one label would hide which. */
+    uint16_t audioColour;
+    if (audioReady && i2sReady) {
+        snprintf(line, sizeof(line), "ES8311 ok  vol %d  %s", audioVolume, lastSound);
+        audioColour = TFT_GREEN;
+    } else if (audioReady) {
+        snprintf(line, sizeof(line), "codec ok, I2S FAILED");
+        audioColour = TFT_ORANGE;
+    } else {
+        snprintf(line, sizeof(line), "ES8311 NOT responding");
+        audioColour = TFT_RED;
+    }
+    y += fitCentred(line, y, 1, audioColour) + gap;
+
+    /* Microphone meter. Live bar plus a decaying peak tick, because a clap is
+     * over before the eye finds the bar. */
+    {
+        const int mw = (W * 3) / 4;
+        const int mx = (W - mw) / 2;
+        tft.drawRect(mx, y, mw, meterH, TFT_DARKGREY);
+        const int fill = (mw - 2) * micLevel / 100;
+        if (fill > 0) {
+            tft.fillRect(mx + 1, y + 1, fill, meterH - 2,
+                         micLevel > 80 ? TFT_RED : TFT_CYAN);
+        }
+        if (fill < mw - 2) {
+            tft.fillRect(mx + 1 + fill, y + 1, (mw - 2) - fill, meterH - 2, TFT_BLACK);
+        }
+        const int px = mx + 1 + (mw - 2) * micPeak / 100;
+        tft.drawFastVLine(px, y, meterH, TFT_YELLOW);
+    }
+    y += meterH + gap;
+
+    {
+        const int bw = (W * 2) / 3;
+        const int bh = fontHeight(2) + 10;
+        recX = (W - bw) / 2; recY = y; recW = bw; recH = bh;
+        const uint16_t fill = echoBusy ? TFT_RED : TFT_NAVY;
+        tft.fillRoundRect(recX, recY, recW, recH, 4, fill);
+        tft.drawRoundRect(recX, recY, recW, recH, 4, TFT_WHITE);
+        tft.setTextDatum(MC_DATUM);
+        tft.setTextColor(TFT_WHITE, fill);
+        char label[32];
+        snprintf(label, sizeof(label), echoBusy ? "RECORDING..." : "REC %ds + PLAY",
+                 ECHO_SECONDS);
+        tft.drawString(label, recX + recW / 2, recY + recH / 2, 2);
+    }
+    y += fontHeight(2) + 10 + gap;
+
+    snprintf(line, sizeof(line), "mic %d%%  last peak %d", micLevel, echoPeak);
+    y += fitCentred(line, y, 1, echoPeak > 400 ? TFT_GREEN : TFT_DARKGREY) + gap;
+
+    /* Deliberately large and alone on its line. This is the value that was
+     * misread as "1.x V" when it was clipped, so it gets the room to be
+     * unambiguous. */
+    snprintf(line, sizeof(line), "%.2f V", battVolts);
+    fitCentred(line, y, 4, TFT_YELLOW);
+
+    /* The crosshair is drawn in RAW coordinates on purpose. If it tracks your
+     * finger, the controller's axes already match the display at this
+     * rotation. If it is mirrored or transposed, that mismatch is the thing
+     * the touch layer will have to correct -- and now it is visible. */
+    if (rawX >= 0 && rawY >= 0) {
+        int sx = 0, sy = 0;
+        mapNativeToScreen(rawX, rawY, sx, sy);
+        if (sx >= 0 && sx < W && sy >= 0 && sy < H) {
+            tft.drawFastHLine(0, sy, W, TFT_RED);
+            tft.drawFastVLine(sx, 0, H, TFT_RED);
+            tft.fillCircle(sx, sy, 4, TFT_RED);
+        }
+    }
+}
+
+/* --------------------------------------------------------------- ES8311 */
+
+static bool esWrite(uint8_t reg, uint8_t value) {
+    Wire.beginTransmission(ES8311_ADDR);
+    Wire.write(reg);
+    Wire.write(value);
+    return Wire.endTransmission() == 0;
+}
+
+static bool esRead(uint8_t reg, uint8_t& value) {
+    Wire.beginTransmission(ES8311_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom((int)ES8311_ADDR, 1) != 1) return false;
+    value = Wire.read();
+    return true;
+}
+
+/* Playback level for the record-and-playback test ONLY.
+ *
+ * This deliberately exceeds AUDIO_VOLUME_MAX. The ceiling is a product rule
+ * about a handheld held near a child's ears; this is a bench instrument being
+ * used to judge whether a recording captured anything, and that judgement
+ * needs headroom -- a quiet capture played quietly is indistinguishable from
+ * no capture at all. It applies to this one playback, is restored afterwards,
+ * and must NOT follow the codec driver into the firmware. */
+static constexpr int ECHO_PLAYBACK_VOLUME = 90;
+
+static void es8311SetVolumeRaw(int percent) {
+    if (percent < 0) percent = 0;
+    if (percent > 100) percent = 100;
+    audioVolume = percent;
+    const uint8_t reg32 = percent == 0 ? 0 : (uint8_t)((percent * 256 / 100) - 1);
+    esWrite(0x32, reg32);
+}
+
+static void es8311SetVolume(int percent) {
+    if (percent < 0) percent = 0;
+    if (percent > AUDIO_VOLUME_MAX) percent = AUDIO_VOLUME_MAX;
+    audioVolume = percent;
+    /* Register 0x32 is 0..255 with 0 meaning silence, per es8311.c. */
+    const uint8_t reg32 = percent == 0 ? 0 : (uint8_t)((percent * 256 / 100) - 1);
+    esWrite(0x32, reg32);
+}
+
+/* Dividers for MCLK 6.144 MHz / 16 kHz, taken from es8311.c's coeff_div table:
+ * pre_div 3, pre_multi 1, adc_div 1, dac_div 1, fs_mode 0, lrck 0x00ff,
+ * bclk_div 4, adc_osr 0x10, dac_osr 0x10. Hardcoded rather than table-driven
+ * because the probe runs at exactly one rate and a table would be four more
+ * things that can be wrong. */
+static bool es8311Init() {
+    uint8_t v = 0;
+
+    /* Reset, then power on. */
+    if (!esWrite(0x00, 0x1F)) return false;   /* an ACK here is the codec */
+    delay(20);
+    esWrite(0x00, 0x00);
+    esWrite(0x00, 0x80);
+
+    /* Clock manager: MCLK from the MCLK pin, all clocks enabled. */
+    esWrite(0x01, 0x3F);
+
+    esRead(0x02, v); v &= 0x07; v |= (3 - 1) << 5; v |= 1 << 3; esWrite(0x02, v);
+    esWrite(0x03, (0 << 6) | 0x10);           /* fs_mode | adc_osr */
+    esWrite(0x04, 0x10);                      /* dac_osr           */
+    esWrite(0x05, ((1 - 1) << 4) | (1 - 1));  /* adc_div | dac_div */
+    esRead(0x06, v); v &= 0xE0; v |= (4 - 1); esWrite(0x06, v);   /* bclk_div */
+    esRead(0x07, v); v &= 0xC0; v |= 0x00;    esWrite(0x07, v);   /* lrck_h   */
+    esWrite(0x08, 0xFF);                                          /* lrck_l   */
+
+    /* Slave mode, I2S, 16-bit in and out. */
+    esRead(0x00, v); v &= 0xBF; esWrite(0x00, v);
+    esWrite(0x09, 3 << 2);
+    esWrite(0x0A, 3 << 2);
+
+    esWrite(0x0D, 0x01);   /* power up analogue          */
+    esWrite(0x0E, 0x02);   /* analogue PGA + ADC modulator */
+    esWrite(0x12, 0x00);   /* power up DAC               */
+    esWrite(0x13, 0x10);   /* enable output to drive     */
+    esWrite(0x1C, 0x6A);   /* ADC EQ bypass, DC cancel   */
+    esWrite(0x37, 0x08);   /* DAC EQ bypass              */
+    /* Microphone. reg14 selects the analogue mic and its PGA gain; reg17 is
+     * the ADC VOLUME and reg16 an extra digital scale-up.
+     *
+     * reg17 is the one that bites. It resets to minimum, and the vendor only
+     * sets it inside es8311_microphone_config(), which their own
+     * es8311_codec_init() leaves commented out -- so following their init
+     * faithfully produces a codec that records perfect silence while every
+     * other register reads back correct. Measured here: with reg17 unset, a
+     * 2-second capture peaked at 1 count out of 32767. */
+    esWrite(0x14, 0x1A);        /* analogue mic, max PGA gain   */
+    esWrite(0x17, 0xC8);        /* ADC volume -- NOT a default  */
+    esWrite(0x16, adcGainScale); /* extra digital gain, 0..7    */
+
+    es8311SetVolume(audioVolume);
+
+    /* Read something back: a codec that accepted every write but reports a
+     * reset register of 0 was never really there. */
+    return esRead(0x00, v);
+}
+
+static bool i2sBegin() {
+    i2s_config_t cfg = {};
+    cfg.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_RX);
+    cfg.sample_rate = AUDIO_RATE;
+    cfg.bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT;
+    cfg.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
+    cfg.communication_format = I2S_COMM_FORMAT_STAND_I2S;
+    cfg.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+    cfg.dma_buf_count = 6;
+    cfg.dma_buf_len = 256;
+    cfg.tx_desc_auto_clear = true;
+    cfg.mclk_multiple = I2S_MCLK_MULTIPLE_384;
+
+    /* The codec is an I2S slave taking its clock from MCLK, so MCLK has to be
+     * 6.144 MHz and not approximately that. 160 MHz / 6.144 MHz is 26.04, so
+     * the integer divider cannot hit it -- ask for the APLL, and say plainly
+     * which one we ended up on rather than leaving a silent approximation. */
+    cfg.use_apll = true;
+    audioUsedApll = true;
+    if (i2s_driver_install(I2S_NUM_0, &cfg, 0, nullptr) != ESP_OK) {
+        cfg.use_apll = false;
+        audioUsedApll = false;
+        if (i2s_driver_install(I2S_NUM_0, &cfg, 0, nullptr) != ESP_OK) return false;
+    }
+
+    i2s_pin_config_t pins = {};
+    pins.mck_io_num = PIN_I2S_MCLK;
+    pins.bck_io_num = PIN_I2S_BCLK;
+    pins.ws_io_num = PIN_I2S_WS;
+    pins.data_out_num = PIN_I2S_DOUT;
+    pins.data_in_num = PIN_I2S_DIN;
+    if (i2s_set_pin(I2S_NUM_0, &pins) != ESP_OK) return false;
+
+    i2s_zero_dma_buffer(I2S_NUM_0);
+    return true;
+}
+
+/* One tone. Blocking on purpose: there is no frame budget here and a probe
+ * that plays a note while everything else waits is easier to reason about
+ * than a mixer. Amplitude is ramped in and out over 4 ms so the speaker does
+ * not click, which on a small driver is louder than the tone. */
+static void playTone(float hz, int ms, float amplitude) {
+    if (!i2sReady) return;
+    static int16_t buf[256 * 2];
+    const int total = (AUDIO_RATE * ms) / 1000;
+    const int ramp = AUDIO_RATE * 4 / 1000;
+    float phase = 0.0f;
+    const float step = 2.0f * PI * hz / AUDIO_RATE;
+
+    int done = 0;
+    while (done < total) {
+        const int n = (total - done) > 256 ? 256 : (total - done);
+        for (int i = 0; i < n; ++i) {
+            const int at = done + i;
+            float env = amplitude;
+            if (at < ramp) env *= (float)at / ramp;
+            else if (at > total - ramp) env *= (float)(total - at) / ramp;
+            const int16_t s = (int16_t)(sinf(phase) * 32000.0f * env);
+            phase += step;
+            if (phase > 2.0f * PI) phase -= 2.0f * PI;
+            buf[i * 2] = s;
+            buf[i * 2 + 1] = s;
+        }
+        size_t written = 0;
+        i2s_write(I2S_NUM_0, buf, n * 2 * sizeof(int16_t), &written, portMAX_DELAY);
+        done += n;
+    }
+}
+
+static void playSilence(int ms) {
+    if (!i2sReady) return;
+    static int16_t buf[128 * 2] = {0};
+    int total = (AUDIO_RATE * ms) / 1000;
+    while (total > 0) {
+        const int n = total > 128 ? 128 : total;
+        size_t written = 0;
+        i2s_write(I2S_NUM_0, buf, n * 2 * sizeof(int16_t), &written, portMAX_DELAY);
+        total -= n;
+    }
+}
+
+/* Five deliberately different sounds. Different in PITCH, LENGTH and SHAPE,
+ * not just frequency -- a speaker with a broken solder joint can pass a single
+ * mid tone and fail everything else, and a resonance can flatter one note. */
+static void playSound(int which) {
+    switch (which) {
+        case 0:  /* OK: rising two-tone */
+            lastSound = "OK chirp";
+            playTone(880, 90, 0.6f); playTone(1320, 110, 0.6f);
+            break;
+        case 1:  /* Error: low buzz */
+            lastSound = "error buzz";
+            playTone(160, 140, 0.8f); playSilence(40); playTone(160, 200, 0.8f);
+            break;
+        case 2:  /* Arpeggio: checks it is not just one resonant note */
+            lastSound = "arpeggio";
+            playTone(523, 90, 0.5f); playTone(659, 90, 0.5f);
+            playTone(784, 90, 0.5f); playTone(1047, 160, 0.5f);
+            break;
+        case 3: { /* Sweep: exposes rattles and dead bands */
+            lastSound = "sweep";
+            for (int f = 200; f <= 4000; f += 200) playTone((float)f, 22, 0.5f);
+            break;
+        }
+        default: /* Quiet tick: proves low amplitude is audible at all */
+            lastSound = "quiet tick";
+            playTone(2000, 40, 0.12f);
+            break;
+    }
+    if (i2sReady) {
+        Serial.printf("[audio] played '%s' vol %d amp %s apll %s\n",
+                      lastSound, audioVolume, paEnabled ? "on" : "off",
+                      audioUsedApll ? "yes" : "no");
+    } else {
+        /* The first version logged "played" unconditionally while playTone()
+         * returned early on a dead stream -- so the log confirmed sound that
+         * never left the chip. A probe may not do that. */
+        Serial.printf("[audio] NOT played (%s): I2S is not running\n", lastSound);
+    }
+    redraw = true;
+}
+
+/* Record, then play it back.
+ *
+ * The level meter answers "is the ADC moving?", which is a weaker question
+ * than it looks: a meter can twitch on noise, on a floating input, or on
+ * bleed from the speaker, and a person watching a bar cannot tell those from
+ * a working microphone. Hearing your own voice come back cannot be faked --
+ * it proves the analogue front end, the codec ADC, the I2S input path, the
+ * I2S output path and the speaker in one gesture.
+ *
+ * Two seconds of mono 16-bit at 16 kHz is 64 KB, kept static. This board has
+ * 8 MB of PSRAM, but a static buffer needs no allocator and cannot fragment
+ * anything -- and the firmware this probe serves has a standing rule against
+ * heap churn, so the probe may as well hold the line too. */
+static constexpr int ECHO_SAMPLES = AUDIO_RATE * ECHO_SECONDS;
+static int16_t echoBuf[ECHO_SAMPLES];
+static bool echoHas = false;
+
+
+static void echoRecord() {
+    if (!i2sReady) { Serial.println("[echo] I2S not running"); return; }
+    Serial.printf("[echo] recording %d s -- speak now\n", ECHO_SECONDS);
+
+    /* Mute the amplifier while recording so the speaker cannot feed itself. */
+    digitalWrite(PIN_PA_ENABLE, HIGH);
+
+    static int16_t frame[256 * 2];
+    int stored = 0;
+    echoPeak = 0;
+    const uint32_t deadline = millis() + (ECHO_SECONDS * 1000) + 1500;
+
+    /* Discard the first buffers: the codec's ADC settles after the amplifier
+     * state changes, and a click at the head sounds like a fault. */
+    for (int i = 0; i < 4; ++i) {
+        size_t junk = 0;
+        i2s_read(I2S_NUM_0, frame, sizeof(frame), &junk, pdMS_TO_TICKS(50));
+    }
+
+    while (stored < ECHO_SAMPLES && millis() < deadline) {
+        size_t got = 0;
+        if (i2s_read(I2S_NUM_0, frame, sizeof(frame), &got,
+                     pdMS_TO_TICKS(200)) != ESP_OK || got == 0) {
+            continue;
+        }
+        const int frames = got / sizeof(int16_t) / 2;
+        for (int i = 0; i < frames && stored < ECHO_SAMPLES; ++i) {
+            const int16_t v = frame[i * 2];      /* left channel only */
+            echoBuf[stored++] = v;
+            const int mag = v < 0 ? -v : v;
+            if (mag > echoPeak) echoPeak = mag;
+        }
+    }
+
+    echoHas = stored > 0;
+    Serial.printf("[echo] captured %d/%d samples, peak %d (%d%% of full scale)\n",
+                  stored, ECHO_SAMPLES, echoPeak, (echoPeak * 100) / 32767);
+    if (echoPeak < 200) {
+        Serial.println("[echo] peak is near zero -- the microphone is not "
+                       "producing signal. That is a mic/codec-ADC fault, not "
+                       "a speaker one.");
+    }
+    digitalWrite(PIN_PA_ENABLE, paEnabled ? LOW : HIGH);
+}
+
+static void echoPlay() {
+    if (!i2sReady || !echoHas) { Serial.println("[echo] nothing recorded"); return; }
+    const int restore = audioVolume;
+    es8311SetVolumeRaw(ECHO_PLAYBACK_VOLUME);
+    Serial.printf("[echo] playing back %d s at %d%% (diagnostic level)\n",
+                  ECHO_SECONDS, ECHO_PLAYBACK_VOLUME);
+    static int16_t frame[256 * 2];
+    int at = 0;
+    while (at < ECHO_SAMPLES) {
+        const int n = (ECHO_SAMPLES - at) > 256 ? 256 : (ECHO_SAMPLES - at);
+        for (int i = 0; i < n; ++i) {
+            frame[i * 2] = echoBuf[at + i];
+            frame[i * 2 + 1] = echoBuf[at + i];
+        }
+        size_t written = 0;
+        i2s_write(I2S_NUM_0, frame, n * 2 * sizeof(int16_t), &written, portMAX_DELAY);
+        at += n;
+    }
+    es8311SetVolumeRaw(restore);
+    Serial.printf("[echo] done, volume back to %d%%\n", audioVolume);
+}
+
+/* Microphone. One short non-blocking read per loop; RMS scaled to 0..100 with
+ * a slowly decaying peak, so a clap registers visibly rather than flickering
+ * for one frame. */
+static void sampleMic() {
+    if (!i2sReady) return;
+    static int16_t buf[128 * 2];
+    size_t got = 0;
+    if (i2s_read(I2S_NUM_0, buf, sizeof(buf), &got, 0) != ESP_OK || got == 0) return;
+
+    const int samples = got / sizeof(int16_t);
+    uint64_t sum = 0;
+    for (int i = 0; i < samples; ++i) {
+        const int32_t s = buf[i];
+        sum += (uint64_t)(s * s);
+    }
+    const float rms = sqrtf((float)sum / samples);
+    int level = (int)(rms * 100.0f / 8000.0f);      /* 8000 ~ a loud voice */
+    if (level > 100) level = 100;
+
+    micLevel = level;
+    if (level > micPeak) micPeak = level;
+}
+
+/* -------------------------------------------------------------- hardware */
+
+static bool readRegs(uint8_t reg, uint8_t* buf, size_t len) {
+    Wire.beginTransmission(FT6336U_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;
+    if (Wire.requestFrom((int)FT6336U_ADDR, (int)len) != (int)len) return false;
+    for (size_t i = 0; i < len; ++i) buf[i] = Wire.read();
+    return true;
+}
+
+static void scanI2c() {
+    i2cCount = 0;
+    Serial.println("[i2c] scanning SDA=16 SCL=15 ...");
+    for (uint8_t addr = 1; addr < 127; ++addr) {
+        Wire.beginTransmission(addr);
+        if (Wire.endTransmission() == 0) {
+            Serial.printf("[i2c]   device at 0x%02X%s\n", addr,
+                          addr == FT6336U_ADDR ? "  <- FT6336U (expected)" : "");
+            if (i2cCount < sizeof(i2cFound)) i2cFound[i2cCount++] = addr;
+        }
+    }
+    if (i2cCount == 0) {
+        Serial.println("[i2c]   NOTHING ANSWERED. Either the pins are wrong or "
+                       "the controller is not populated.");
+    }
+    touchPresent = false;
+    for (uint8_t i = 0; i < i2cCount; ++i) {
+        if (i2cFound[i] == FT6336U_ADDR) touchPresent = true;
+    }
+
+    if (touchPresent) {
+        uint8_t v = 0;
+        if (readRegs(FT6336U_REG_CHIP_ID, &v, 1))  touchChipId = v;
+        if (readRegs(FT6336U_REG_FIRMWARE, &v, 1)) touchFirmware = v;
+        Serial.printf("[touch] FT6336U chip id 0x%02X, firmware 0x%02X\n",
+                      touchChipId, touchFirmware);
+    }
+}
+
+static void pollTouch() {
+    if (!touchPresent) return;
+    uint8_t buf[5];
+    if (!readRegs(FT6336U_REG_TD_STATUS, buf, 5)) return;
+
+    touchCount = buf[0] & 0x0F;
+    if (touchCount == 0) { rawX = rawY = -1; touchDown = false; return; }
+    touchDown = true;
+
+    const int x = ((buf[1] & 0x0F) << 8) | buf[2];
+    const int y = ((buf[3] & 0x0F) << 8) | buf[4];
+    if (x == rawX && y == rawY) return;
+
+    rawX = x; rawY = y;
+    if (x < rawXMin) rawXMin = x;
+    if (x > rawXMax) rawXMax = x;
+    if (y < rawYMin) rawYMin = y;
+    if (y > rawYMax) rawYMax = y;
+    ++touchEvents;
+    Serial.printf("[touch] n=%d raw=(%d,%d)  seen x:%d..%d y:%d..%d\n",
+                  touchCount, x, y, rawXMin, rawXMax, rawYMin, rawYMax);
+    redraw = true;
+}
+
+static void sampleBattery() {
+    battVolts = analogReadMilliVolts(PIN_BATT_ADC) * 2.0f / 1000.0f;
+}
+
+void setup() {
+    Serial.begin(115200);
+    const uint32_t waited = millis();
+    while (!Serial && millis() - waited < 2000) { delay(10); }
+    delay(200);
+
+    Serial.println();
+    Serial.println("=== Freenove FNK0104B bring-up probe (env:s3diag) ===");
+    Serial.printf("[chip] %s rev %d, %u MHz, %u KB free heap, PSRAM %u KB\n",
+                  ESP.getChipModel(), ESP.getChipRevision(),
+                  ESP.getCpuFreqMHz(), ESP.getFreeHeap() / 1024,
+                  ESP.getPsramSize() / 1024);
+    Serial.printf("[flash] %u MB\n", ESP.getFlashChipSize() / (1024 * 1024));
+    Serial.println("[tft] vendor claim: ILI9341_2, BGR, INVERSION_ON, "
+                   "MISO13 MOSI11 SCLK12 CS10 DC46 RST-1 BL45");
+
+    pinMode(PIN_BOOT_KEY, INPUT_PULLUP);
+    pinMode(PIN_TOUCH_INT, INPUT_PULLUP);
+
+    /* Release the touch controller's reset before scanning, or a present chip
+     * reports as absent and we would blame the pins. */
+    pinMode(PIN_TOUCH_RST, OUTPUT);
+    digitalWrite(PIN_TOUCH_RST, LOW);
+    delay(20);
+    digitalWrite(PIN_TOUCH_RST, HIGH);
+    delay(300);
+
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+
+    tft.init();
+    tft.setRotation(rotation);
+    tft.fillScreen(TFT_BLACK);
+
+    Wire.begin(PIN_TOUCH_SDA, PIN_TOUCH_SCL, 400000);
+    scanI2c();
+
+    /* Amplifier enable is its own question: the DAC can be running perfectly
+     * into a muted amplifier, which sounds exactly like a dead codec.
+     *
+     * ACTIVE LOW. Freenove's Sketch_07.1_Music drives this pin LOW once in
+     * setup() and never raises it, so LOW is the enabled state. The first
+     * version of this probe assumed an "enable" is active high, drove it HIGH,
+     * and produced perfect silence with a codec reporting itself configured --
+     * which is exactly the failure this pin was called out to separate. 'p'
+     * toggles it live so the board can confirm rather than the comment. */
+    pinMode(PIN_PA_ENABLE, OUTPUT);
+    digitalWrite(PIN_PA_ENABLE, paEnabled ? LOW : HIGH);
+
+    audioReady = es8311Init();
+    Serial.printf("[audio] ES8311 at 0x18: %s\n",
+                  audioReady ? "configured" : "NO RESPONSE");
+    i2sReady = i2sBegin();
+    Serial.printf("[audio] I2S MCLK=%d BCLK=%d WS=%d DOUT=%d DIN=%d @%d Hz: %s\n",
+                  PIN_I2S_MCLK, PIN_I2S_BCLK, PIN_I2S_WS, PIN_I2S_DOUT,
+                  PIN_I2S_DIN, AUDIO_RATE, i2sReady ? "running" : "FAILED");
+
+    analogReadResolution(12);
+    sampleBattery();
+    draw();
+
+    /* Announce ourselves, so the speaker is tested before anyone touches
+     * anything -- and so a board that boots silent is obvious at once. */
+    if (audioReady && i2sReady) playSound(0);
+    Serial.println("[ready] BOOT = next rotation. Tap a colour bar to play "
+                   "that sound.");
+    Serial.println("[keys]  0-3 rotation, r rescan I2C, b blink backlight, "
+                   "m swap touch map, 1-5 via bars, s sweep, v volume, "
+                   "a re-init audio.");
+}
+
+void loop() {
+    static bool     lastKey = HIGH;
+    static uint32_t lastBlink = 0;
+    static uint32_t lastBeat = 0;
+
+    pollTouch();
+    sampleMic();
+
+    /* Peak decays slowly so a clap stays visible for about a second. */
+    static uint32_t lastPeakDecay = 0;
+    if (millis() - lastPeakDecay > 60) {
+        lastPeakDecay = millis();
+        if (micPeak > micLevel) --micPeak;
+        redraw = true;
+    }
+
+    /* Tap a colour bar to play its sound. The hit test runs on the MAPPED
+     * coordinates, so it is also a live test of the touch transform: if the
+     * wrong bar plays, the mapping is wrong, and that is audible without
+     * looking at the screen. */
+    if (touchDown && !touchWasDown && barsW > 0) {
+        int sx = 0, sy = 0;
+        mapNativeToScreen(rawX, rawY, sx, sy);
+        if (sy >= barsY && sy < barsY + barsH
+                && sx >= barsX && sx < barsX + barsW * BAR_COUNT) {
+            const int which = (sx - barsX) / barsW;
+            /* Flash the bar's outline first. Touch registering and audio
+             * working are two different claims, and with the amplifier muted
+             * the first version could satisfy neither visibly -- so a tap that
+             * lands is now seen even when nothing is heard. */
+            tft.drawRect(barsX + which * barsW, barsY, barsW, barsH, TFT_YELLOW);
+            Serial.printf("[tap] bar %d at mapped (%d,%d)\n", which, sx, sy);
+            playSound(which);
+        } else if (recW > 0 && sx >= recX && sx < recX + recW
+                   && sy >= recY && sy < recY + recH) {
+            /* Only a REQUEST: the test blocks for seconds, and starting it
+             * with a finger still on the glass would record the tap. */
+            echoRequested = true;
+            Serial.println("[echo] REC button pressed");
+        }
+    }
+    touchWasDown = touchDown;
+
+    if (echoRequested && !touchDown) {
+        echoRequested = false;
+        echoBusy = true;
+        draw();                       /* show RECORDING before it blocks */
+        playTone(1200, 80, 0.5f); playSilence(120);
+        playTone(1200, 80, 0.5f); playSilence(120);
+        playTone(1600, 120, 0.5f); playSilence(250);
+        echoRecord();
+        playSilence(200);
+        echoPlay();
+        echoBusy = false;
+        redraw = true;
+    }
+
+    /* BOOT, debounced on the press edge. */
+    const bool key = digitalRead(PIN_BOOT_KEY);
+    if (lastKey == HIGH && key == LOW) {
+        rotation = (rotation + 1) & 3;
+        tft.setRotation(rotation);
+        Serial.printf("[rot] now %u (%dx%d)\n",
+                      rotation, tft.width(), tft.height());
+        redraw = true;
+        delay(120);
+    }
+    lastKey = key;
+
+    if (Serial.available()) {
+        const int c = Serial.read();
+        /* '0'..'3' set the rotation outright. BOOT does the same thing, but
+         * only for someone holding the board -- and the layout has to be
+         * checked at all four, which is not a thing to make a person do by
+         * hand while reading back what fits. */
+        if (c >= '0' && c <= '3') {
+            rotation = (uint8_t)(c - '0');
+            tft.setRotation(rotation);
+            Serial.printf("[rot] now %u (%dx%d)\n",
+                          rotation, tft.width(), tft.height());
+            redraw = true;
+        }
+        if (c == 'm') {
+            altHandedness = !altHandedness;
+            Serial.printf("[map] now %s\n", altHandedness ? "B" : "A");
+            redraw = true;
+        }
+        if (c >= '1' && c <= '5') playSound(c - '1');
+        if (c == 's') playSound(3);
+        if (c == 'v') {
+            /* Top step is the ceiling, not 100 -- see AUDIO_VOLUME_MAX. */
+            static const int steps[] = { 20, 35, 50, 65, AUDIO_VOLUME_MAX };
+            static int at = 2;
+            at = (at + 1) % 5;
+            es8311SetVolume(steps[at]);
+            Serial.printf("[audio] volume %d\n", audioVolume);
+            playSound(4);
+        }
+        if (c == 'a') {
+            audioReady = es8311Init();
+            Serial.printf("[audio] re-init: %s\n", audioReady ? "ok" : "FAILED");
+            redraw = true;
+        }
+        if (c == 'p') {
+            paEnabled = !paEnabled;
+            digitalWrite(PIN_PA_ENABLE, paEnabled ? LOW : HIGH);
+            Serial.printf("[audio] amp %s (GPIO1 driven %s)\n",
+                          paEnabled ? "ENABLED" : "disabled",
+                          paEnabled ? "LOW" : "HIGH");
+            playSound(0);
+        }
+        if (c == 'i') {
+            uint8_t r00 = 0, r32 = 0, r14 = 0;
+            esRead(0x00, r00); esRead(0x32, r32); esRead(0x14, r14);
+            Serial.printf("[status] codec=%d i2s=%d apll=%d amp=%s vol=%d\n",
+                          (int)audioReady, (int)i2sReady, (int)audioUsedApll,
+                          paEnabled ? "on" : "off", audioVolume);
+            Serial.printf("[status] ES8311 reg00=0x%02X reg32=0x%02X reg14=0x%02X\n",
+                          r00, r32, r14);
+            Serial.printf("[status] mic level=%d peak=%d\n", micLevel, micPeak);
+        }
+        if (c == 'e') {
+            /* Three beeps, record, play back. The beeps matter: they tell the
+             * person when to talk, and they prove the speaker still works
+             * immediately before the recording, so a silent playback can only
+             * be the microphone. */
+            playTone(1200, 80, 0.5f); playSilence(120);
+            playTone(1200, 80, 0.5f); playSilence(120);
+            playTone(1600, 120, 0.5f); playSilence(150);
+            echoRecord();
+            playSilence(150);
+            echoPlay();
+            redraw = true;
+        }
+        if (c == 'g') {
+            adcGainScale = (uint8_t)((adcGainScale + 1) & 0x07);
+            esWrite(0x16, adcGainScale);
+            Serial.printf("[audio] ADC gain scale (reg16) = %u\n", adcGainScale);
+        }
+        if (c == 'r') { scanI2c(); redraw = true; }
+        if (c == 'b') {
+            Serial.println("[bl] blinking GPIO45 five times");
+            for (int i = 0; i < 5; ++i) {
+                digitalWrite(TFT_BL, LOW);  delay(150);
+                digitalWrite(TFT_BL, HIGH); delay(150);
+            }
+        }
+    }
+
+    /* A slow backlight pulse. A screen that visibly breathes proves GPIO45 is
+     * the backlight; a screen that is merely lit does not. */
+    if (millis() - lastBlink > 3000) {
+        lastBlink = millis();
+        digitalWrite(TFT_BL, LOW);
+        delay(60);
+        digitalWrite(TFT_BL, HIGH);
+    }
+
+    if (millis() - lastBeat > 1000) {
+        lastBeat = millis();
+        sampleBattery();
+        Serial.printf("[beat] rot=%u %dx%d touch=%s raw=(%d,%d) batt=%.2fV\n",
+                      rotation, tft.width(), tft.height(),
+                      touchPresent ? "0x38" : "none", rawX, rawY, battVolts);
+        redraw = true;
+    }
+
+    if (redraw) { redraw = false; draw(); }
+    delay(10);
+}

--- a/tools/check_boards.py
+++ b/tools/check_boards.py
@@ -48,8 +48,16 @@ BOARD_SPECIFIC_MACRO = re.compile(
 REQUIRED_BOARD_MACROS = ("BOARD_NAME", "GUME_BOARD_HEADER",
                          "TFT_WIDTH", "TFT_HEIGHT", "TFT_BL")
 
-# Environments that build no board peripheral, so they need no board section.
-BOARDLESS_ENVS = ("wifidiag",)
+# Environments that need no [board_*] section.
+#
+# wifidiag builds no board peripheral at all. s3diag is a different case worth
+# stating: it drives a panel, but for a board this firmware cannot yet run on.
+# A [board_*] section is a claim of support, and check_reachable() below is
+# what that claim costs -- a web-installer label, an offered firmware, a CI
+# build. Making it before the capacitive touch path exists would advertise a
+# firmware that boots into a screen nobody can press, which is precisely the
+# outcome BoardProfile.h refuses to allow. The section arrives with the port.
+BOARDLESS_ENVS = ("wifidiag", "s3diag")
 
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -79,6 +79,14 @@ VARIANTS = (
         "note": "The full console for newer 2.4 inch CYD variants (USB-C/dual-USB, ST7789): {count} games, profiles, scores, settings, "
                 "Wi-Fi clock and the BLE beacon.",
     },
+    {
+        "env": "app_fnk0104b",
+        "label": "Braino! (the games) -- Freenove FNK0104B (ESP32-S3, capacitive touch)",
+        "name": "Braino!",
+        "note": "The full console for the Freenove 2.8 inch ESP32-S3 display: {count} games, profiles, scores, settings, "
+                "Wi-Fi clock and the BLE beacon. This board has no SD, no status LED and no sound yet -- "
+                "everything else works. See the README for what is missing and why.",
+    },
 )
 
 # The pin map, screen rotation and touch controller are compile-time constants,
@@ -108,6 +116,11 @@ BOARD_DETAILS = {
         "label": "ESP32-2432S028Rv3 -- 2.4 inch newer CYD variant (ST7789 + XPT2046 resistive touch, USB-C/dual-USB)",
         "chip": "ESP32",
         "buy": "https://www.aliexpress.com/w/wholesale-esp32-2432s028.html",
+    },
+    "fnk0104b": {
+        "label": "Freenove FNK0104B -- 2.8 inch ESP32-S3 (ILI9341 + FT6336U capacitive touch, USB-C)",
+        "chip": "ESP32-S3",
+        "buy": "https://store.freenove.com/products/fnk0104",
     },
 }
 

--- a/tools/pack_release.py
+++ b/tools/pack_release.py
@@ -81,6 +81,8 @@ ENV_BLURBS = {
                 "interfere with the result.",
     "batdiag": "Eight-page battery bring-up and calibration tool, with CSV "
                "over serial for capturing a full discharge.",
+    "s3diag": "Bring-up probe for an unsupported ESP32-S3 board: panel, "
+              "rotation, I2C touch scan and battery divider. Not the console.",
 }
 
 


### PR DESCRIPTION
Adds the **Freenove FNK0104B** as a supported board, and teaches the board contract about capacitive touch so it could be described at all.

This is the first port in this tree brought up on **real hardware** rather than from a published pin map. Display, backlight, touch at all four rotations, battery sense and the full audio path were each confirmed on a device before any value here was written down.

All 31 games run on it. It is offered by the web installer.

## Four commits

| | |
|---|---|
| `cc49937` | Teach the board contract about capacitive touch |
| `d3b40df` | Add an ESP32-S3 bring-up probe (`env:s3diag`) |
| `e96b25d` | Support the Freenove FNK0104B, with three peripherals switched off |
| `015f0f7` | Link the follow-up issues from the README |

Split so the contract change is reviewable on its own — it touches all three existing boards and stands independently of the new hardware.

## The contract change

`TouchProfile` described an XPT2046 and nothing else: five SPI lines and a pressure threshold. It now carries a `TouchKind` and both pin sets, as a **flat discriminated record** rather than a variant — `tools/check_boards.py` verifies fields by their `/* label */` comments, and a variant would let a board fill in the wrong arm and still compile. The checker goes from 27 to 33 fields and confirms all four boards fill every one.

The asserts branch per arm. Asserting the union would have forced a capacitive board to invent an SPI chip select, and a made-up pin that satisfies a checker is worse than a missing one because it stops anybody noticing.

Two capacitive behaviours are load-bearing:

- **`hasTouchCalibration()` returns true unconditionally.** A capacitive panel reports pixels; there is nothing to fit. This is not a convenience — every caller that sees `false` offers or forces the wizard, and on such a panel that wizard **cannot be completed**, so a first boot would be a screen the owner never gets past.
- **The controller reports the panel's native portrait frame** and has never heard of `setRotation()`. `mapTouch()` rotates into the same landscape frame the affine fit produces, so `pollTouch()`'s existing rotation switch serves both — that switch turned out to be exactly consistent already, and no existing code moved. The specific quarter-turn was **demonstrated on the device** at all four rotations, with the opposite handedness available on a key and visibly wrong.

Separation is `#if GUME_TOUCH_CAPACITIVE`, **not `if constexpr`**: in a non-template function both arms still compile, and the capacitive arm alone linked Wire into every resistive build — **+4,476 bytes** of flash for unreachable code, on a budget at 75%. The macro lives in the board header and `TouchKind` derives from it, so the fact is stated once and cannot drift.

## The board, and what does not work

Its USB-C is on a **short** edge, so unlike every other board no landscape rotation puts the socket at the bottom. `landscapeRotation = 3` puts the cable on the left — an ergonomic choice between two equally correct values, not a derivation.

Three peripherals are `PIN_NONE` deliberately, because the profile cannot describe the hardware and half-wiring it would put a lie in the profile:

| Off | Why | Issue |
|---|---|---|
| Sound | ES8311 codec (I²C + I²S), not a speaker pin. **The codec works** — `s3diag` plays through it | #71 |
| Status LED | One WS2812 on GPIO42, not three PWM channels | #72 |
| SD | Slot is SDMMC 4-bit, `SdProfile` describes SPI | #73 |

Battery percentage is correct; the **charging verdict is not validated** on this charger (#74). Partition sizing and a `worst=81ms` first frame are #75. Mic meter noise is #76.

Each issue carries the pin map, the measurements and the constraints needed to finish it without this context.

## Three findings worth keeping

Discovered the hard way while proving the audio path in the probe:

1. **GPIO1 is an active-LOW amplifier enable.** Driving it HIGH gives perfect silence with a codec reporting itself correctly configured.
2. **MCLK needs the APLL** — 160 MHz will not divide to 6.144 MHz.
3. **`reg17` (ADC volume) resets to minimum**, and the vendor sets it only inside a function their own init leaves commented out. Follow their path faithfully and the codec records silence while every register reads back correct. Measured: peak 1 count out of 32767.

## Sizes

Re-measured against a pristine build of `dev` in a throwaway worktree, because the first re-measure was +620 bytes and I would not write a number I could not account for:

```
pristine dev   2,353,817
app            2,353,841   (+24, the touch contract)
app_fnk0104b   2,225,361 / 67,976 RAM
```

`dev`'s documented figure was already stale by ~596 bytes before this branch; README and CLAUDE.md now state the measured value.

## Checks

`check_boards` (4 boards, 33 fields), `check_docs`, `check_catalog` all clean; `gen_site.py` generates 31 games / 4 builds. `ci.yml` and `pages.yml` build `app_fnk0104b` and `s3diag` — **an ESP32-S3 toolchain CI has never fetched, so that is the most likely thing to trip here.**

## Not done

`AUDIO_VOLUME_MAX = 80` is recorded as a product decision — a ceiling in the spirit of `BRIGHTNESS_MIN`, for a handheld held near a child's ears. It is enforced in the probe so nothing demonstrated on the bench is louder than what ships. It becomes a real constant when audio lands (#71).
