### PR TITLE
Support the 4-inch E32R40T (ST7796), measured on hardware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           # On pushes to main/dev, build all environments (conservative safety net)
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Building all environments (push to main/dev)"
-            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag"
+            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag diag4"
           else
             # On PRs, check which files changed and build selectively
             files=$(gh api --paginate \
@@ -178,7 +178,7 @@ jobs:
           # Build environments with explicit -e flags for check_boards.py verification
           if [ "${{ github.event_name }}" = "push" ]; then
             # On pushes to main/dev: build all environments
-            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag
+            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag -e diag4
           else
             # On PR: build only affected environments
             ENVS="${{ steps.environments.outputs.envs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           # On pushes to main/dev, build all environments (conservative safety net)
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "Building all environments (push to main/dev)"
-            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag diag4"
+            ENVS="app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b app_e32r40t s3diag diag4"
           else
             # On PRs, check which files changed and build selectively
             files=$(gh api --paginate \
@@ -178,7 +178,7 @@ jobs:
           # Build environments with explicit -e flags for check_boards.py verification
           if [ "${{ github.event_name }}" = "push" ]; then
             # On pushes to main/dev: build all environments
-            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag -e diag4
+            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e s3diag -e diag4
           else
             # On PR: build only affected environments
             ENVS="${{ steps.environments.outputs.envs }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,7 +77,7 @@ jobs:
       # through every net. An environment nobody builds is an environment
       # that is already broken and has not been told yet.
       - name: Build firmware
-        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag
+        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag -e diag4
 
       # Flash is the scarce resource here (3 MB partition), so put the image
       # size where a reviewer sees it without opening the build log.
@@ -88,7 +88,7 @@ jobs:
             echo
             echo '| Environment | firmware.bin | of 3,145,728 |'
             echo '|---|---:|---:|'
-            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag; do
+            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag diag4; do
               bytes=$(stat -c%s ".pio/build/$env/firmware.bin")
               printf '| %s | %s | %.1f%% |\n' "$env" "$bytes" \
                 "$(python -c "print($bytes / 3145728 * 100)")"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,7 +77,7 @@ jobs:
       # through every net. An environment nobody builds is an environment
       # that is already broken and has not been told yet.
       - name: Build firmware
-        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e s3diag -e diag4
+        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e s3diag -e diag4
 
       # Flash is the scarce resource here (3 MB partition), so put the image
       # size where a reviewer sees it without opening the build log.
@@ -88,7 +88,7 @@ jobs:
             echo
             echo '| Environment | firmware.bin | of 3,145,728 |'
             echo '|---|---:|---:|'
-            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b s3diag diag4; do
+            for env in app bringup batdiag wifidiag app_esp32_2432s028r bringup_esp32_2432s028r batdiag_esp32_2432s028r app_esp32_2432s028_st7789 bringup_esp32_2432s028_st7789 batdiag_esp32_2432s028_st7789 app_fnk0104b app_e32r40t s3diag diag4; do
               bytes=$(stat -c%s ".pio/build/$env/firmware.bin")
               printf '| %s | %s | %.1f%% |\n' "$env" "$bytes" \
                 "$(python -c "print($bytes / 3145728 * 100)")"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,9 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,362,861 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,364,321 / 3,145,728 bytes,
 **74.9%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
-at 72,620 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
+at 72,628 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
 profile-move buffers static. On this device that is a good
 trade every time. Two agents can each add artwork that fits locally and together overflow it. Read the size line from `pio run` and report it when you add data tables or images.
@@ -759,7 +759,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,362,861 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,364,321 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,364,321 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,365,381 / 3,145,728 bytes,
 **74.9%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,628 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -759,7 +759,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,364,321 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,365,381 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,362,577 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,362,861 / 3,145,728 bytes,
 **74.9%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,620 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -759,7 +759,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,362,577 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,362,861 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ pio run -t upload        # build + flash at 460800 baud
 pio device monitor       # serial, 115200 baud
 ```
 
-Three diagnostic environments exist for hardware triage:
+Five diagnostic environments exist for hardware triage:
 - `pio run -e bringup` â€” full tree with `-D CYD_BRINGUP_ONLY`; `main.cpp` compiles a display/touch/SD check instead of the app.
 - `pio run -e wifidiag` â€” builds `src/wifi_diag.cpp` **alone** (`build_src_filter = +<wifi_diag.cpp>`), so no TFT/touch/game code can interfere with the radio test.
 - `pio run -e batdiag` — builds `src/battery_diag.cpp` **alone**, an eight-page
@@ -186,6 +186,23 @@ Three diagnostic environments exist for hardware triage:
   board profile the product does. Its charge-inference constants are still
   copied from `BoardPower.cpp` deliberately, so what it shows is what the
   product will do — **if you change one of those, change both.**
+- `pio run -e s3diag` -- builds `src/s3_diag.cpp` **alone**, a bring-up probe
+  for the Freenove FNK0104B. It skips the touch calibration wizard on purpose:
+  `env:bringup` runs that on a board with no stored calibration, which on a
+  capacitive panel the XPT2046 code cannot read strands the display check
+  behind a dead crosshair.
+- `pio run -e diag4` -- builds `src/diag4.cpp` **alone**, a seven-page bring-up
+  probe for the 4-inch ST7796 board. It exists because every fact that board
+  needs stated in a profile is still a guess, and the three ways of being wrong
+  -- wrong SPI bus, wrong driver, wrong backlight pin -- all produce the same
+  dark screen with a healthy serial log. Page ID reads the controller's ID
+  register back over MISO, which separates them without anything being visible;
+  page BL sweeps candidate backlight pins in both polarities. **It defines
+  neither `TFT_BL` nor `GUME_BOARD_HEADER`, deliberately** -- TFT_eSPI owning
+  the backlight would defeat the sweep, and a probe must not depend on the
+  board profile it exists to produce. Both are boardless envs, listed in
+  `check_boards.py`'s `BOARDLESS_ENVS`, because a `[board_*]` section is a
+  claim of support and neither board is supported yet.
 
 ### Every build is stamped, and the time is not a `-D`
 
@@ -678,6 +695,7 @@ src/main.cpp              bringup entrypoint + normal app setup/loop
 src/BuildStamp.cpp        which build this is; recompiled every build
 src/wifi_diag.cpp         standalone radio test (env:wifidiag only)
 src/s3_diag.cpp           standalone ESP32-S3 bring-up probe (env:s3diag only)
+src/diag4.cpp             standalone 4-inch ST7796 bring-up probe (env:diag4 only)
 src/engine/               Game, LauncherGame, GameCatalog, AppRegistry, NearbyPlay,
                           AppRuntime, AppRuntimeLock, ScoreCatalog, Progress,
                           RecentQuestions, ContentLoader

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Five diagnostic environments exist for hardware triage:
   `env:bringup` runs that on a board with no stored calibration, which on a
   capacitive panel the XPT2046 code cannot read strands the display check
   behind a dead crosshair.
-- `pio run -e diag4` -- builds `src/diag4.cpp` **alone**, a seven-page bring-up
+- `pio run -e diag4` -- builds `src/diag4.cpp` **alone**, a eight-page bring-up
   probe for the 4-inch ST7796 board. It exists because every fact that board
   needs stated in a profile is still a guess, and the three ways of being wrong
   -- wrong SPI bus, wrong driver, wrong backlight pin -- all produce the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,9 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,357,413 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,362,577 / 3,145,728 bytes,
 **74.9%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
-at 72,596 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
+at 72,620 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
 profile-move buffers static. On this device that is a good
 trade every time. Two agents can each add artwork that fits locally and together overflow it. Read the size line from `pio run` and report it when you add data tables or images.
@@ -759,7 +759,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,357,413 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
+   2,362,577 on `5.3.0-SNAPSHOT` against 2,353,205 on `5.2.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-00599c)](platformio.ini)
-[![Flash](https://img.shields.io/badge/flash-74.9%25%20of%203%20MB-yellow)](#build-and-flash)
+[![Flash](https://img.shields.io/badge/flash-75.0%25%20of%203%20MB-yellow)](#build-and-flash)
 [![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen)](#privacy)
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-00599c)](platformio.ini)
-[![Flash](https://img.shields.io/badge/flash-75.1%25%20of%203%20MB-yellow)](#build-and-flash)
+[![Flash](https://img.shields.io/badge/flash-75.2%25%20of%203%20MB-yellow)](#build-and-flash)
 [![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen)](#privacy)
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 
@@ -30,8 +30,8 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,362,861 / 3,145,728 bytes (**74.9%**) |
-| RAM | 72,620 / 327,680 bytes (**22.2%**) |
+| Flash | 2,364,321 / 3,145,728 bytes (**74.9%**) |
+| RAM | 72,628 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
 Contribution workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md), alongside

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,364,321 / 3,145,728 bytes (**74.9%**) |
+| Flash | 2,365,381 / 3,145,728 bytes (**74.9%**) |
 | RAM | 72,628 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ written down too, as [open issues](https://github.com/iamankushpandit/Gume/issue
 ESP32-2432S028 CYD variants ship as ports built from published pin maps and
 have not been verified on real hardware; the Freenove FNK0104B *has* been
 verified on hardware but ships with three peripherals switched off (see
-[Freenove FNK0104B](#freenove-fnk0104b-esp32-s3)), and a 4-inch ST7796
-variant is in progress — if you own any of those, telling us whether it works is the single
+[Freenove FNK0104B](#freenove-fnk0104b-esp32-s3)); the 4-inch **E32R40T**
+has had its panel, backlight and touch confirmed on hardware but ships with four
+peripherals not yet characterised (see [E32R40T](#e32r40t-4-inch-st7796))
+— if you own any of those, telling us whether it works is the single
 most useful thing you can send. The CYD family has many variants whose
 differences fail silently — backlight on GPIO21 versus GPIO27, GPIO34 as a
 battery sense here but a light sensor on the ESP32-2432S028R. A board is now described in two
@@ -144,6 +146,44 @@ tracked in [#75](https://github.com/iamankushpandit/Gume/issues/75).
 `pio run -e s3diag` is a standalone bring-up probe for this board: panel,
 rotation, I²C scan, live touch, battery, and the full audio path including a
 record-and-playback microphone test.
+
+### E32R40T (4-inch ST7796)
+
+**The E32R40T** is the 4-inch board, and it is here for a reason the other
+ports are not: a physically bigger, plainer screen for players who need one.
+Braino stretches the games onto it rather than leaving them small in a corner
+— playable games draw through `Ui::ScaledRenderer`, which maps the fixed
+320×240 game canvas onto the panel's 480×320 and renders text at double glyph
+scale, so text gains on its boxes rather than merely keeping pace.
+
+It is the same reference PCB family as the E32R28T-1 and shares its display bus
+exactly — MISO 12, MOSI 13, SCLK 14, CS 15, DC 2, HSPI at 40 MHz. **One pin
+differs, and it is the one that fails silently: the backlight is GPIO27, not
+GPIO21.** With the wrong value the panel is black while Wi-Fi, BLE, NVS and the
+screen saver all run perfectly, so the serial log looks healthy and it reads as
+a dead screen. Both values were measured rather than assumed — 21 was confirmed
+dark from a clean reset — and `BoardConfig.h` static_asserts the profile
+against `TFT_BL` so they cannot drift apart again.
+
+Touch is an XPT2046 **sharing the display's SPI bus** with its own CS on
+GPIO33, driven through TFT_eSPI's touch extension rather than a bit-banged bus
+of its own. Its IRQ on GPIO36 is wired but **unusable** — an input-only pin
+with no internal pull and no external pull-up fitted, so it floats low and
+reports a permanent false pen-down. The profile says so (`irqUsable`) and the
+firmware gates on pressure alone, which is clean here: idle noise reads 10–20
+and a real press 2000+.
+
+**Four peripherals are switched off rather than broken**, because nobody has
+measured them on this board yet: the SD slot, the RGB LED, the speaker and
+battery sense. They are plausibly wired like the 2.8-inch board's — and
+"plausibly" is exactly the reasoning that produced a backlight pin nobody had
+checked. `PIN_NONE` costs a feature the firmware already does without; a wrong
+pin costs a fictional battery percentage. If you own one and can measure them,
+that is the most useful thing you can send.
+
+`pio run -e diag4` is the standalone bring-up probe for this board: panel
+identity over SPI, a backlight sweep, geometry and colour, rotation, both touch
+wirings, ADC candidates, and a Wi-Fi/BLE coexistence test.
 
 **The E32R28T-1 / ESP32-32E** 2.8-inch resistive-touch board is the one this
 firmware is developed and tested against — use

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-00599c)](platformio.ini)
-[![Flash](https://img.shields.io/badge/flash-75.0%25%20of%203%20MB-yellow)](#build-and-flash)
+[![Flash](https://img.shields.io/badge/flash-75.1%25%20of%203%20MB-yellow)](#build-and-flash)
 [![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen)](#privacy)
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 
@@ -30,8 +30,8 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,357,413 / 3,145,728 bytes (**74.9%**) |
-| RAM | 72,596 / 327,680 bytes (**22.2%**) |
+| Flash | 2,362,577 / 3,145,728 bytes (**74.9%**) |
+| RAM | 72,620 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
 Contribution workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md), alongside

--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ src/
   wifi_diag.cpp         standalone radio test (env:wifidiag only)
   battery_diag.cpp      standalone battery/ADC calibration tool (env:batdiag only)
   s3_diag.cpp           standalone ESP32-S3 bring-up probe (env:s3diag only)
+  diag4.cpp             standalone 4-inch ST7796 bring-up probe (env:diag4 only)
   engine/
     AppCapabilities.h   system-app capability flags
     AppRegistry.cpp     authoritative app registry + instance bindings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,362,577 / 3,145,728 bytes (**74.9%**) |
+| Flash | 2,362,861 / 3,145,728 bytes (**74.9%**) |
 | RAM | 72,620 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/include/BoardProfile.h
+++ b/include/BoardProfile.h
@@ -91,6 +91,22 @@ struct TouchProfile {
     int8_t   sclk;                // resistive only
     int8_t   cs;                  // resistive only
     int8_t   irq;                 // both: pen-down / INT
+    /* Whether that IRQ line can actually be believed.
+     *
+     * It is wired on every board here, and on one of them it is useless: the
+     * 4-inch E32R40T brings it out on GPIO36, an input-only pin with no
+     * internal pull, and populates no external pull-up. It therefore floats
+     * LOW and reports a permanent, false pen-down. The resistive gate accepts
+     * a press when the IRQ is low OR pressure is high, so an unusable IRQ does
+     * not degrade touch -- it defeats it entirely, reporting a touch on every
+     * poll forever.
+     *
+     * This is a property of the board (is the resistor fitted?), not of the
+     * controller, which is why it lives here rather than being inferred. A
+     * board setting this false is telling the firmware to gate on pressure
+     * alone, which is a clean signal on these panels: idle noise reads 10-20
+     * and a real press 2000+. */
+    bool     irqUsable;
     int8_t   sda;                 // capacitive only
     int8_t   scl;                 // capacitive only
     int8_t   reset;               // capacitive only; held low then released

--- a/include/boards/e32r28t1.h
+++ b/include/boards/e32r28t1.h
@@ -54,6 +54,7 @@ inline constexpr BoardProfile BOARD = {
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+/* irqUsable         */ true,
         /* sda                */ PIN_NONE,
         /* scl                */ PIN_NONE,
         /* reset              */ PIN_NONE,

--- a/include/boards/e32r40t.h
+++ b/include/boards/e32r40t.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "BoardProfile.h"
+
+/* Which touch controller this board wires, as a macro so the preprocessor can
+ * act on it -- see e32r28t1.h for why this cannot just be the profile field. */
+#define GUME_TOUCH_CAPACITIVE 0
+
+/* No audio codec. */
+#define GUME_HAS_AUDIO_CODEC 0
+
+/* LCDWIKI E32R40T (ESP32-32E) -- the 4-inch board. ST7796 320x480 panel,
+ * XPT2046 resistive touch sharing the display's SPI bus.
+ *
+ * This board exists in Braino for a specific audience: a 4-inch screen serves
+ * players who need a physically bigger, plainer display than the 2.8-inch
+ * board offers. That is also why the runtime draws playable games through
+ * Ui::ScaledRenderer at textScale 2 rather than merely stretching the layout
+ * -- see AppRuntime.h.
+ *
+ * WHAT IS MEASURED AND WHAT IS NOT
+ *
+ * Measured on hardware with env:diag4, 2026-09-03:
+ *   - ST7796 at 320x480 native, rendering correctly at rotation 3 (480x320
+ *     landscape) with correct colour order: all four corner labels land in
+ *     their corners and the border reaches all four physical edges.
+ *   - The display SPI bus is IDENTICAL to the 2.8-inch board's: MISO 12,
+ *     MOSI 13, SCLK 14, CS 15, DC 2, no reset line, HSPI, 40MHz.
+ *   - The backlight is GPIO27, active high. GPIO21 -- the 2.8-inch board's
+ *     backlight, and the obvious assumption -- was measured DARK twice,
+ *     including from a clean reset with nothing else driven.
+ *
+ * Derived from the earlier feat/st7796-4inch-board port, which ran this panel
+ * and its touch working:
+ *   - Touch is an XPT2046 sharing the display's bus with its own CS on 33.
+ *   - Its IRQ on 36 cannot be used; see irqUsable below.
+ *
+ * NOT characterised, and therefore declared absent rather than guessed:
+ * the SD slot, the RGB LED, the speaker and battery sense. The pins are
+ * plausibly the same as the 2.8-inch board's, and "plausibly" is exactly the
+ * reasoning that produced a backlight pin nobody had checked. PIN_NONE costs
+ * a feature the firmware already knows how to do without; a wrong pin costs a
+ * fictional battery percentage or a fight over a line something else owns.
+ * Fill these in when someone measures them.
+ *
+ * The display's own SPI pins are NOT here: TFT_eSPI is configured through -D
+ * flags in platformio.ini, and BoardConfig.h cross-checks the two descriptions
+ * so they cannot drift.
+ */
+inline constexpr BoardProfile BOARD = {
+    "E32R40T",
+
+    /* panel: 3 is landscape, confirmed by drawing into it. */
+    PanelProfile{
+        /* nativeWidth          */ 320,
+        /* nativeHeight         */ 480,
+        /* landscapeRotation    */ 3,
+        /* portraitRotation     */ 0,
+        /* backlightPin         */ 27,
+        /* backlightActiveHigh  */ true,
+    },
+
+    /* touch: the XPT2046 rides the display's own hardware SPI bus, arbitrated
+     * by its own CS, rather than the separate bit-banged bus the 2.8-inch
+     * board uses. The mosi/miso/sclk below therefore repeat the display's
+     * pins, which TouchProfile explicitly allows.
+     *
+     * irqUsable is false, and it is the field that matters here. GPIO36 is
+     * input-only, has no internal pull, and this board fits no external
+     * pull-up -- so the line floats LOW and reports a permanent false
+     * pen-down. Gating on pressure alone is clean on this panel: idle noise
+     * reads 10-20 and a real press 2000+, so the 350 threshold below sits an
+     * order of magnitude clear of the noise on both sides. */
+    TouchProfile{
+        /* kind               */ (GUME_TOUCH_CAPACITIVE
+                                     ? TouchKind::CapacitiveFt6336u
+                                     : TouchKind::ResistiveXpt2046),
+        /* mosi               */ 13,
+        /* miso               */ 12,
+        /* sclk               */ 14,
+        /* cs                 */ 33,
+        /* irq                */ 36,
+        /* irqUsable          */ false,
+        /* sda                */ PIN_NONE,
+        /* scl                */ PIN_NONE,
+        /* reset              */ PIN_NONE,
+        /* i2cAddress         */ 0,
+        /* i2cHz              */ 0,
+        /* pressureThreshold  */ 350,
+        /* hitSlop            */ 8,
+    },
+
+    /* Not characterised on this board. See the header comment. */
+    SdProfile{
+        /* cs    */ PIN_NONE,
+        /* mosi  */ PIN_NONE,
+        /* miso  */ PIN_NONE,
+        /* sclk  */ PIN_NONE,
+        /* spiHz */ 0,
+    },
+
+    /* Not characterised on this board. beepOk()/beepError() fall back to
+     * doing nothing visible rather than driving lines we have not confirmed. */
+    RgbLedProfile{
+        /* r           */ PIN_NONE,
+        /* g           */ PIN_NONE,
+        /* b           */ PIN_NONE,
+        /* commonAnode */ true,
+    },
+
+    /* Not characterised on this board. */
+    AudioProfile{
+        /* speakerPin          */ PIN_NONE,
+        /* codecI2cAddress     */ 0,
+        /* i2sMclk             */ PIN_NONE,
+        /* i2sBclk             */ PIN_NONE,
+        /* i2sWordSelect       */ PIN_NONE,
+        /* i2sDataOut          */ PIN_NONE,
+        /* i2sDataIn           */ PIN_NONE,
+        /* ampEnablePin        */ PIN_NONE,
+        /* ampEnableActiveLow  */ false,
+    },
+
+    /* Not characterised on this board. A wrong adcPin here would not fail
+     * loudly -- it would report a battery percentage that is pure fiction,
+     * which is worse than showing no badge at all. */
+    BatteryProfile{
+        /* adcPin        */ PIN_NONE,
+        /* dividerRatio  */ 0.0f,
+        /* sensorMaxVolts*/ 0.0f,
+    },
+
+    /* 4 MB part, partitioned huge_app.csv: 3 MB for the app. */
+    MemoryProfile{
+        /* flashBytes */ 4u * 1024u * 1024u,
+    },
+};

--- a/include/boards/e32r40t.h
+++ b/include/boards/e32r40t.h
@@ -95,6 +95,16 @@ inline constexpr BoardProfile BOARD = {
         /* hitSlop            */ 8,
     },
 
+    /* BOOT (IO0), the key the ROM uses to enter serial download mode; read at
+     * runtime as an ordinary input with an internal pull-up. This is the one
+     * fact here that is not a guess about the board's layout: IO0 is the ESP32
+     * strapping pin, so the ROM's own boot behaviour already proves the button
+     * is on it and pulls the line low. */
+    ButtonProfile{
+        /* bootPin   */ 0,
+        /* activeLow */ true,
+    },
+
     /* Not characterised on this board. See the header comment. */
     SdProfile{
         /* cs    */ PIN_NONE,

--- a/include/boards/e32r40t.h
+++ b/include/boards/e32r40t.h
@@ -35,13 +35,18 @@
  *   - Touch is an XPT2046 sharing the display's bus with its own CS on 33.
  *   - Its IRQ on 36 cannot be used; see irqUsable below.
  *
- * NOT characterised, and therefore declared absent rather than guessed:
- * the SD slot, the RGB LED, the speaker and battery sense. The pins are
- * plausibly the same as the 2.8-inch board's, and "plausibly" is exactly the
- * reasoning that produced a backlight pin nobody had checked. PIN_NONE costs
- * a feature the firmware already knows how to do without; a wrong pin costs a
- * fictional battery percentage or a fight over a line something else owns.
- * Fill these in when someone measures them.
+ * INHERITED from the E32R28T-1 rather than measured here: the RGB LED, the
+ * speaker and battery sense. These began as PIN_NONE, which was right while
+ * nothing about the board was known -- but the display bus then turned out to
+ * be identical to the 2.8-inch board's, pin for pin, which makes "same
+ * reference PCB with a bigger panel" evidence rather than hope. Each is
+ * flagged below with what would prove it wrong, because they fail differently:
+ * a wrong LED or speaker pin drives a line something else may own, while a
+ * wrong battery pin reports a percentage that is pure fiction and looks
+ * entirely plausible.
+ *
+ * Still PIN_NONE: the SD slot, which nothing has needed yet and which shares a
+ * bus with the peripheral header.
  *
  * The display's own SPI pins are NOT here: TFT_eSPI is configured through -D
  * flags in platformio.ini, and BoardConfig.h cross-checks the two descriptions
@@ -99,18 +104,26 @@ inline constexpr BoardProfile BOARD = {
         /* spiHz */ 0,
     },
 
-    /* Not characterised on this board. beepOk()/beepError() fall back to
-     * doing nothing visible rather than driving lines we have not confirmed. */
+    /* Inherited from the E32R28T-1, including its crossed red/green lines,
+     * which were verified on that unit rather than assumed. Wrong here shows
+     * up immediately and harmlessly: a beep lights the wrong colour, or an LED
+     * that never goes out (common anode -- a channel lights when driven LOW).
+     * The vendor manual for the 2.8-inch board names IO16/IO17/IO22 instead,
+     * which the E32R28T-1 profile already contradicts on measured grounds; if
+     * this board disagrees with both, measure before believing either. */
     RgbLedProfile{
-        /* r           */ PIN_NONE,
-        /* g           */ PIN_NONE,
-        /* b           */ PIN_NONE,
+        /* r           */ 16,
+        /* g           */ 4,
+        /* b           */ 17,
         /* commonAnode */ true,
     },
 
-    /* Not characterised on this board. */
+    /* Inherited from the E32R28T-1. Audio is stubbed there too -- beepOk()
+     * and beepError() pulse the LED -- so this pin being wrong is quiet in
+     * both senses. If a speaker on GPIO26 stays silent, that is the thing to
+     * measure, not the codec fields below, which this board does not have. */
     AudioProfile{
-        /* speakerPin          */ PIN_NONE,
+        /* speakerPin          */ 26,
         /* codecI2cAddress     */ 0,
         /* i2sMclk             */ PIN_NONE,
         /* i2sBclk             */ PIN_NONE,
@@ -121,13 +134,21 @@ inline constexpr BoardProfile BOARD = {
         /* ampEnableActiveLow  */ false,
     },
 
-    /* Not characterised on this board. A wrong adcPin here would not fail
-     * loudly -- it would report a battery percentage that is pure fiction,
-     * which is worse than showing no badge at all. */
+    /* Inherited from the E32R28T-1: IO34 (ADC1_CH6, input-only) behind the 2:1
+     * divider the vendor manual states plainly -- "the obtained voltage
+     * multiplied by 2 is the actual battery voltage". sensorMaxVolts is a
+     * fault ceiling on the ADC, NOT a pack-present test; like the 2.8-inch
+     * board this one cannot tell a missing pack from a present one.
+     *
+     * This is the one to distrust. A wrong adcPin does not fail loudly -- it
+     * reports a plausible-looking percentage that is fiction. Check it against
+     * a meter before believing the badge, and note GPIO34 is the light sensor
+     * rather than a battery sense on the ESP32-2432S028R, so this family
+     * resemblance does not extend to every CYD. */
     BatteryProfile{
-        /* adcPin        */ PIN_NONE,
-        /* dividerRatio  */ 0.0f,
-        /* sensorMaxVolts*/ 0.0f,
+        /* adcPin        */ 34,
+        /* dividerRatio  */ 2.0f,
+        /* sensorMaxVolts*/ 4.50f,
     },
 
     /* 4 MB part, partitioned huge_app.csv: 3 MB for the app. */

--- a/include/boards/esp32-2432s028.h
+++ b/include/boards/esp32-2432s028.h
@@ -57,6 +57,7 @@ inline constexpr BoardProfile BOARD = {
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+/* irqUsable         */ true,
         /* sda                */ PIN_NONE,
         /* scl                */ PIN_NONE,
         /* reset              */ PIN_NONE,

--- a/include/boards/esp32-2432s028r.h
+++ b/include/boards/esp32-2432s028r.h
@@ -60,6 +60,7 @@ inline constexpr BoardProfile BOARD = {
         /* sclk               */ 25,
         /* cs                 */ 33,
         /* irq                */ 36,
+/* irqUsable         */ true,
         /* sda                */ PIN_NONE,
         /* scl                */ PIN_NONE,
         /* reset              */ PIN_NONE,

--- a/include/boards/fnk0104b.h
+++ b/include/boards/fnk0104b.h
@@ -71,6 +71,7 @@ inline constexpr BoardProfile BOARD = {
         /* sclk               */ PIN_NONE,
         /* cs                 */ PIN_NONE,
         /* irq                */ 17,
+/* irqUsable         */ true,
         /* sda                */ 16,
         /* scl                */ 15,
         /* reset              */ 18,

--- a/platformio.ini
+++ b/platformio.ini
@@ -194,7 +194,7 @@ build_flags =
 ; The console, on the 2.8-inch board. A second board is a second stanza of
 ; exactly this shape with a different ${board_*.build_flags}.
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -204,7 +204,7 @@ build_flags =
 
 [env:bringup]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -246,7 +246,7 @@ build_flags =
 [env:app_esp32_2432s028r]
 ; The console on the ESP32-2432S028R (original/classic CYD with ILI9341).
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -256,7 +256,7 @@ build_flags =
 
 [env:bringup_esp32_2432s028r]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -277,7 +277,7 @@ build_flags =
 [env:app_esp32_2432s028_st7789]
 ; The console on the ESP32-2432S028 with ST7789 (Rv3/dual-USB variants).
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
@@ -287,7 +287,7 @@ build_flags =
 
 [env:bringup_esp32_2432s028_st7789]
 extends = esp32_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 build_unflags = ${common.build_unflags}
 build_flags =
@@ -422,7 +422,7 @@ build_flags =
 ; can use and no LED it can drive (see include/boards/fnk0104b.h); both degrade
 ; quietly, which is what PIN_NONE is for.
 extends = esp32s3_common
-build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp>
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
 lib_deps = ${common.lib_deps}
 lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -190,6 +190,37 @@ build_flags =
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
 
+[board_e32r40t]
+; LCDWIKI E32R40T -- the 4-inch board. Same reference PCB family as the
+; E32R28T-1 above and the same display bus, with a bigger ST7796 panel: the
+; ONLY pin that differs is the backlight, and that one difference is the trap.
+; GPIO21 lights the 2.8-inch board and was measured dark here; 27 is correct
+; and was measured, not assumed. BoardConfig.h static_asserts TFT_BL against
+; the profile, so the two cannot drift apart again.
+build_flags =
+    -D BOARD_NAME=\"E32R40T\"
+    -D GUME_BOARD_HEADER=\"boards/e32r40t.h\"
+    -D ST7796_DRIVER=1
+    -D TFT_WIDTH=320
+    -D TFT_HEIGHT=480
+    -D TFT_MISO=12
+    -D TFT_MOSI=13
+    -D TFT_SCLK=14
+    -D TFT_CS=15
+    -D TFT_DC=2
+    -D TFT_RST=-1
+    -D TFT_BL=27
+    -D TFT_BACKLIGHT_ON=HIGH
+    -D USE_HSPI_PORT=1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=16000000
+    ; Touch shares the display bus with its own CS, so TFT_eSPI's built-in
+    ; touch extension drives it -- TOUCH_CS is what activates that, and
+    ; BoardTouch.cpp switches to it rather than bit-banging pins the display
+    ; driver owns.
+    -D TOUCH_CS=33
+    -D SPI_TOUCH_FREQUENCY=2500000
+
 [env:app]
 ; The console, on the 2.8-inch board. A second board is a second stanza of
 ; exactly this shape with a different ${board_*.build_flags}.
@@ -354,6 +385,22 @@ build_flags =
     -D USE_HSPI_PORT=1
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
+
+[env:app_e32r40t]
+; The console on the 4-inch E32R40T. This board has no SD slot, LED, speaker
+; or battery sense the firmware will use -- not because it lacks them, but
+; because nobody has measured them yet (see include/boards/e32r40t.h); all four
+; degrade rather than fail. Its reason to exist is the panel: 480x320 is a
+; physically bigger, plainer screen for players who need one, and playable
+; games reach it through Ui::ScaledRenderer.
+extends = esp32_common
+build_src_filter = +<*> -<wifi_diag.cpp> -<battery_diag.cpp> -<s3_diag.cpp> -<diag4.cpp>
+lib_deps = ${common.lib_deps}
+lib_ldf_mode = deep+
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    ${board_e32r40t.build_flags}
 
 [env:diag4]
 ; Bring-up probe for the 4-inch ST7796 CYD board, built ALONE (src/diag4.cpp)

--- a/platformio.ini
+++ b/platformio.ini
@@ -387,7 +387,13 @@ build_flags =
 ; whether they are right at all.
 extends = esp32_common
 build_src_filter = +<diag4.cpp>
-lib_deps = bodmer/TFT_eSPI@^2.5.43
+; NimBLE as well as the panel driver, because page RADIO tests Wi-Fi and BLE
+; together and coexistence is a property of the host stack -- proving it with
+; Bluedroid would prove nothing about what Braino actually ships.
+lib_deps =
+    bodmer/TFT_eSPI@^2.5.43
+    h2zero/NimBLE-Arduino@^1.4.2
+lib_ldf_mode = deep+
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -355,6 +355,62 @@ build_flags =
     -D SPI_FREQUENCY=40000000
     -D SPI_READ_FREQUENCY=16000000
 
+[env:diag4]
+; Bring-up probe for the 4-inch ST7796 CYD board, built ALONE (src/diag4.cpp)
+; in the same spirit as wifidiag, batdiag and s3diag. It exists because every
+; fact that board needs stated in a profile header is currently a guess -- the
+; abandoned feat/st7796-4inch-board branch says so in its own comments, calling
+; the display SPI pins an "unverified guess" and the backlight pin a value it
+; was "trying next" -- and all three ways of being wrong (bus, driver,
+; backlight) produce the identical symptom of a dark screen with a healthy
+; serial log.
+;
+; Like s3diag, this deliberately has NO [board_*] section. A board section is a
+; claim of support, and check_boards.py enforces what that claim costs: a
+; web-installer label, an offered firmware and a CI build. Braino cannot run on
+; this board yet -- nothing about it is confirmed -- so the section arrives with
+; the port. Until then this is a probe, and `diag4` is in BOARDLESS_ENVS.
+;
+; Two omissions below are load-bearing, not oversights:
+;
+;   TFT_BL is NOT defined. If TFT_eSPI owned the backlight it would drive the
+;   one pin already under suspicion, and the sweep on page BL could not test
+;   the alternatives. diag4.cpp drives candidates itself, as plain GPIO.
+;
+;   GUME_BOARD_HEADER is NOT defined, so this never includes BoardConfig.h.
+;   There is no profile for this board; producing the numbers that go in one is
+;   the whole job. A probe must not depend on the answer it exists to find.
+;
+; The panel pins below are the branch's guesses, carried over verbatim so the
+; probe tests the actual claim rather than a tidied-up version of it. Page ID
+; reads the controller's ID register back over MISO, which is what tells you
+; whether they are right at all.
+extends = esp32_common
+build_src_filter = +<diag4.cpp>
+lib_deps = bodmer/TFT_eSPI@^2.5.43
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags}
+    -D GUME_DIAG4
+    -D ST7796_DRIVER=1
+    -D TFT_WIDTH=320
+    -D TFT_HEIGHT=480
+    -D TFT_MISO=12
+    -D TFT_MOSI=13
+    -D TFT_SCLK=14
+    -D TFT_CS=15
+    -D TFT_DC=2
+    -D TFT_RST=-1
+    -D USE_HSPI_PORT=1
+    -D SPI_FREQUENCY=40000000
+    -D SPI_READ_FREQUENCY=16000000
+    ; Activates TFT_eSPI's own touch extension, which is what page TOUCH-S
+    ; tests: the claim that this board's XPT2046 shares the display bus rather
+    ; than having its own. Page TOUCH-B tests the opposite wiring on plain
+    ; GPIO, so the two can be told apart by measurement.
+    -D TOUCH_CS=33
+    -D SPI_TOUCH_FREQUENCY=2500000
+
 [env:app_fnk0104b]
 ; The console on the Freenove FNK0104B. This board has no SD slot the firmware
 ; can use and no LED it can drive (see include/boards/fnk0104b.h); both degrade

--- a/src/diag4.cpp
+++ b/src/diag4.cpp
@@ -48,7 +48,7 @@
  *   pio run -e diag4 -t upload && pio device monitor
  *
  * BOOT (IO0) cycles pages. Over serial: 'n' next page, 'p' previous, 'r'
- * re-run the current page, '0'-'6' jump to a page directly.
+ * re-run the current page, '0'-'7' jump to a page directly.
  *
  * Everything reports on serial. Nothing here requires the screen to work,
  * which is the point -- report what you see, including "still dark".
@@ -56,6 +56,11 @@
 
 #include <Arduino.h>
 #include <TFT_eSPI.h>
+#include <WiFi.h>
+#include <esp_system.h>
+#include <esp_heap_caps.h>
+
+#include <NimBLEDevice.h>
 
 // ---------------------------------------------------------------- candidates
 
@@ -103,6 +108,7 @@ enum Page : uint8_t {
     PAGE_TOUCH_SHARED,
     PAGE_TOUCH_BITBANG,
     PAGE_PINS,
+    PAGE_RADIO,
     PAGE_COUNT
 };
 
@@ -114,6 +120,7 @@ const char* const PAGE_NAMES[PAGE_COUNT] = {
     "TOUCH-S  -- touch sharing the display SPI bus",
     "TOUCH-B  -- touch on its own bit-banged bus (2.8-inch wiring)",
     "PINS     -- ADC on candidate battery-sense pins",
+    "RADIO    -- Wi-Fi and BLE, separately and then together",
 };
 
 uint8_t page = PAGE_ID;
@@ -208,6 +215,19 @@ void runBacklightSweep() {
     Serial.println("Filling the panel white first, so a lit backlight is unmistakable.");
     Serial.println("Watch the screen. Report the pin AND polarity that lit it.");
     tft.fillScreen(TFT_WHITE);
+
+    /* Release every candidate before testing any of them. setup() holds 21 and
+     * 27 high so the panel has a chance of being visible on arrival, and
+     * without this the sweep would test 21 while 27 was still driven -- the
+     * screen stays lit throughout and the page cannot tell the two apart. They
+     * are the two pins the sweep most exists to separate, so leaving them held
+     * would defeat the whole page. */
+    for (uint8_t pin : cfg::BACKLIGHT_CANDIDATES) {
+        pinMode(pin, INPUT);
+    }
+    Serial.println("All candidates released -- the panel should now be DARK. If it is");
+    Serial.println("still lit, the backlight is not on any pin in this list.");
+    delay(1500);
 
     for (uint8_t pin : cfg::BACKLIGHT_CANDIDATES) {
         pinMode(pin, OUTPUT);
@@ -433,6 +453,106 @@ void runPinScan() {
     Serial.println("      may be this firmware's own output rather than a sensor.");
 }
 
+
+/* PAGE RADIO -- Wi-Fi and BLE, apart and then together.
+ *
+ * Braino runs both: Wi-Fi for NTP, and an opt-in non-connectable BLE beacon.
+ * On the ESP32 those share one 2.4GHz radio and contend for the same heap, and
+ * the coexistence failure is not a compile error or a scan that returns
+ * nothing -- it is a crash minutes in, under load, which neither env:wifidiag
+ * (Wi-Fi alone) nor a quick app smoke test would ever show.
+ *
+ * So this runs three phases and prints free heap either side of each, and the
+ * page opens with the reset reason: if the board comes back up saying
+ * PANIC/TASK_WDT rather than the reason you flashed it with, the previous run
+ * of this page is what killed it, and the last phase printed is where.
+ *
+ * NimBLE rather than Bluedroid, matching the product -- coexistence behaviour
+ * is a property of the host stack, so testing the other one would prove
+ * nothing about what ships. */
+void reportHeap(const char* label) {
+    Serial.printf("    %-22s free=%7u  min=%7u  largest=%7u\n", label,
+                  static_cast<unsigned>(ESP.getFreeHeap()),
+                  static_cast<unsigned>(ESP.getMinFreeHeap()),
+                  static_cast<unsigned>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
+}
+
+void runRadio() {
+    const esp_reset_reason_t reason = esp_reset_reason();
+    Serial.printf("Reset reason at boot: %d ", static_cast<int>(reason));
+    switch (reason) {
+        case ESP_RST_POWERON: Serial.println("(power-on -- clean)"); break;
+        case ESP_RST_SW: Serial.println("(software reset -- clean)"); break;
+        case ESP_RST_PANIC: Serial.println("(PANIC -- something crashed last run)"); break;
+        case ESP_RST_TASK_WDT: Serial.println("(TASK WATCHDOG -- something hung last run)"); break;
+        case ESP_RST_INT_WDT: Serial.println("(INT WATCHDOG -- something hung last run)"); break;
+        case ESP_RST_BROWNOUT: Serial.println("(BROWNOUT -- power, not software)"); break;
+        default: Serial.println("(other)"); break;
+    }
+    reportHeap("at page entry");
+
+    // ---- Phase 1: Wi-Fi alone -------------------------------------------
+    Serial.println("PHASE 1: Wi-Fi alone (scan).");
+    WiFi.mode(WIFI_STA);
+    WiFi.disconnect(true);
+    delay(200);
+    reportHeap("wifi up");
+    const int found = WiFi.scanNetworks(false, false, false, 200);
+    Serial.printf("    scan found %d network(s)\n", found);
+    const int show = found < 4 ? found : 4;
+    for (int i = 0; i < show; ++i) {
+        Serial.printf("      %-24s ch%-3d %4d dBm\n",
+                      WiFi.SSID(i).c_str(), WiFi.channel(i), WiFi.RSSI(i));
+    }
+    WiFi.scanDelete();
+    reportHeap("after scan");
+    WiFi.mode(WIFI_OFF);
+    delay(200);
+    reportHeap("wifi off");
+
+    // ---- Phase 2: BLE alone ---------------------------------------------
+    Serial.println("PHASE 2: BLE alone (non-connectable advertising).");
+    NimBLEDevice::init("Braino-diag4");
+    reportHeap("nimble init");
+    NimBLEAdvertising* adv = NimBLEDevice::getAdvertising();
+    adv->setScanResponse(false);
+    /* Non-connectable, because the product's beacon is presence-only. A
+     * connectable advertisement would be testing something Braino never does,
+     * and it is the advertising duty cycle that contends with Wi-Fi anyway. */
+    adv->setAdvertisementType(BLE_GAP_CONN_MODE_NON);
+    adv->start();
+    Serial.println("    advertising as \"Braino-diag4\" -- visible to any BLE scanner.");
+    delay(3000);
+    reportHeap("advertising");
+
+    // ---- Phase 3: both at once ------------------------------------------
+    Serial.println("PHASE 3: BOTH -- BLE keeps advertising while Wi-Fi scans repeatedly.");
+    Serial.println("         This is the combination that has crashed before.");
+    WiFi.mode(WIFI_STA);
+    delay(200);
+    reportHeap("wifi up beside ble");
+    for (uint8_t round = 1; round <= 5; ++round) {
+        const int n = WiFi.scanNetworks(false, false, false, 200);
+        Serial.printf("    round %u: scan=%d  advertising=%s\n",
+                      static_cast<unsigned>(round), n,
+                      NimBLEDevice::getAdvertising()->isAdvertising() ? "yes" : "NO -- it stopped");
+        WiFi.scanDelete();
+        reportHeap("after round");
+        delay(500);
+    }
+
+    Serial.println("Survived all five rounds. Tearing down.");
+    NimBLEDevice::getAdvertising()->stop();
+    NimBLEDevice::deinit(true);
+    WiFi.mode(WIFI_OFF);
+    delay(300);
+    reportHeap("both torn down");
+    Serial.println("VERDICT: if you are reading this line, Wi-Fi and BLE coexisted without");
+    Serial.println("         crashing. Compare free at page entry against both torn down --");
+    Serial.println("         a large shortfall is a leak, and on this device fragmentation");
+    Serial.println("         matters more than the total, so watch largest too.");
+}
+
 void runPage() {
     banner(PAGE_NAMES[page]);
     switch (page) {
@@ -443,9 +563,10 @@ void runPage() {
         case PAGE_TOUCH_SHARED: runTouchShared(); break;
         case PAGE_TOUCH_BITBANG: runTouchBitbang(); break;
         case PAGE_PINS: runPinScan(); break;
+        case PAGE_RADIO: runRadio(); break;
         default: break;
     }
-    Serial.println("-- BOOT or 'n' for the next page, 'p' back, 'r' repeat, 0-6 to jump.");
+    Serial.println("-- BOOT or 'n' for the next page, 'p' back, 'r' repeat, 0-7 to jump.");
 }
 
 // ---------------------------------------------------------------- lifecycle
@@ -470,6 +591,30 @@ void setup() {
     digitalWrite(21, HIGH);
     pinMode(27, OUTPUT);
     digitalWrite(27, HIGH);
+
+    /* Clear the panel and say something on it, before any page runs.
+     *
+     * This is not decoration. Page ID -- the page this tool opens on -- reads
+     * registers and prints; it draws nothing. Without this the panel comes up
+     * showing uninitialised GRAM, which is random noise, and a cold boot is
+     * indistinguishable from a broken driver. That cost a real misdiagnosis:
+     * page RADIO panicked, the board rebooted into exactly this state, and the
+     * resulting noise was reported as a "jumbled screen" and very nearly sent
+     * the whole bring-up down a wrong-controller hunt. The panel was correct
+     * the entire time; nothing had drawn on it.
+     *
+     * So: a boot screen that is unmistakably OURS. Anything else on this panel
+     * is the hardware talking, not us. */
+    tft.fillScreen(TFT_BLACK);
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setTextDatum(MC_DATUM);
+    tft.drawString("Braino bring-up probe", tft.width() / 2, tft.height() / 2 - 30, 4);
+    char boot[48];
+    snprintf(boot, sizeof(boot), "%dx%d  rot%d", tft.width(), tft.height(), tft.getRotation());
+    tft.drawString(boot, tft.width() / 2, tft.height() / 2 + 6, 2);
+    tft.drawString("press 2 for the test pattern",
+                   tft.width() / 2, tft.height() / 2 + 34, 2);
+    tft.drawRect(0, 0, tft.width(), tft.height(), TFT_DARKGREY);
 
     runPage();
 }

--- a/src/diag4.cpp
+++ b/src/diag4.cpp
@@ -163,14 +163,32 @@ void runId() {
     Serial.printf("RDDIDIF (0xD3)     : %02X %02X %02X %02X\n", d3[0], d3[1], d3[2], d3[3]);
     Serial.printf("RDDID   (0x04)     : %02X %02X %02X %02X\n", d04[0], d04[1], d04[2], d04[3]);
 
-    const bool idle = (d3[1] == 0x00 && d3[2] == 0x00 && d04[1] == 0x00 && d04[2] == 0x00) ||
-                      (d3[1] == 0xFF && d3[2] == 0xFF && d04[1] == 0xFF && d04[2] == 0xFF);
+    /* Idle means every payload byte is a rail: all 0x00 or all 0xFF, in any
+     * mixture across the two commands. An earlier version of this required
+     * both commands to agree on WHICH rail, and so read 0xD3 = 00 00 00 00
+     * with 0x04 = FF FF FF FF as "something answered". Nothing answered. A
+     * floating MISO does not have to float to the same rail twice. */
+    bool idle = true;
+    for (uint8_t i = 1; i < 4 && idle; ++i) {
+        if (d3[i] != 0x00 && d3[i] != 0xFF) {
+            idle = false;
+        }
+        if (d04[i] != 0x00 && d04[i] != 0xFF) {
+            idle = false;
+        }
+    }
+
     if (idle) {
-        Serial.println("VERDICT: MISO is idle -- nothing answered. Either the SPI pins above");
-        Serial.println("         are wrong for this board, or MISO is not wired back at all");
-        Serial.println("         on this variant (some CYDs leave it unconnected). Try page");
-        Serial.println("         PATTERN: if a correct image appears anyway, the write path");
-        Serial.println("         is fine and only the read path is missing.");
+        Serial.println("VERDICT: MISO is idle -- nothing answered.");
+        Serial.println("         This is INCONCLUSIVE on this board family, not a failure.");
+        Serial.println("         The 2.8in E32R28T-1 drives an identical bus (MISO=12 MOSI=13");
+        Serial.println("         SCLK=14 CS=15 DC=2, HSPI) and works, and CYD boards commonly");
+        Serial.println("         do not wire the panel's MISO back to the MCU at all -- there");
+        Serial.println("         is nothing to read from even when every write lands.");
+        Serial.println("         So this does NOT tell you the pins are wrong. Page PATTERN");
+        Serial.println("         decides it: a correct image means the write path is right and");
+        Serial.println("         only the read path is missing, which costs this firmware");
+        Serial.println("         nothing -- Braino never reads the panel back.");
     } else if (d3[1] == 0x77 && d3[2] == 0x96) {
         Serial.println("VERDICT: ST7796 confirmed. Bus and driver are both right.");
     } else if (d3[1] == 0x93 && d3[2] == 0x41) {

--- a/src/diag4.cpp
+++ b/src/diag4.cpp
@@ -1,0 +1,490 @@
+/* Standalone bring-up probe for the 4-inch ST7796 CYD board.
+ *
+ * ------------------------------------------------------------------------
+ * Why this is a separate firmware
+ * ------------------------------------------------------------------------
+ * Every fact this board needs stated in a profile header is currently a
+ * guess. The abandoned feat/st7796-4inch-board branch says so in its own
+ * comments: the display SPI pins are an "unverified guess that this is the
+ * same reference PCB family with a bigger panel bolted on", and the backlight
+ * is "GPIO21 produced no backlight at all -- trying 27 next".
+ *
+ * Those guesses cannot be checked from inside the app, because all three ways
+ * of being wrong produce the same symptom: a dark screen with a healthy
+ * serial log. Wrong SPI bus, wrong driver and wrong backlight pin are
+ * indistinguishable by eye. So this builds ALONE
+ * (build_src_filter = +<diag4.cpp>, env:diag4), exactly as wifi_diag.cpp does
+ * for the radio and battery_diag.cpp for the ADC.
+ *
+ * Two build decisions here are the whole point of the tool:
+ *
+ *   - TFT_BL is deliberately NOT defined. If TFT_eSPI owned the backlight it
+ *     would drive one pin we already suspect, and page BL could not sweep the
+ *     alternatives. The panel is lit from this file, as plain GPIO, or not at
+ *     all.
+ *   - GUME_BOARD_HEADER is deliberately NOT defined, so this does not include
+ *     BoardConfig.h. There is no profile for this board yet -- producing the
+ *     numbers that go in one is what this firmware is for. It must not depend
+ *     on the answer it exists to find.
+ *
+ * ------------------------------------------------------------------------
+ * The one test that separates the failure modes
+ * ------------------------------------------------------------------------
+ * Page ID reads the controller's identification registers back over MISO.
+ * That answers "are the SPI pins right?" and "which controller is this?" in
+ * one shot, without the backlight working and without anything being visible.
+ * If it reports an ID, the bus is correct and any remaining blankness is the
+ * backlight. If it reports nothing but 0x00 or 0xFF, either the bus is wrong
+ * or MISO is not wired back on this variant.
+ *
+ * This matters more than it sounds: ST7796S accepts most ILI9341 commands, so
+ * a mismatched driver renders a real but mirrored, partly-garbled image rather
+ * than nothing -- which is easy to read as "sort of working" and chase for an
+ * afternoon. The ID register does not have opinions.
+ *
+ * ------------------------------------------------------------------------
+ * Using it
+ * ------------------------------------------------------------------------
+ *   pio run -e diag4 -t upload && pio device monitor
+ *
+ * BOOT (IO0) cycles pages. Over serial: 'n' next page, 'p' previous, 'r'
+ * re-run the current page, '0'-'6' jump to a page directly.
+ *
+ * Everything reports on serial. Nothing here requires the screen to work,
+ * which is the point -- report what you see, including "still dark".
+ */
+
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+
+// ---------------------------------------------------------------- candidates
+
+namespace cfg {
+
+/* Backlight candidates, in the order worth trying. 21 is the E32R28T-1's pin
+ * and the first thing anyone assumes; 27 is the branch's untested guess and a
+ * common alternate on ST7796 CYD variants; the rest are pins these boards are
+ * known to route a backlight to on some revision or other.
+ *
+ * GPIO6-11 are the SPI flash and are excluded on pain of a brick. GPIO34-39
+ * are input-only and cannot drive anything. The display bus (12/13/14/15/2)
+ * is excluded because driving it would fight the driver under test. */
+constexpr uint8_t BACKLIGHT_CANDIDATES[] = {21, 27, 32, 5, 16, 17, 4, 22};
+
+/* Touch on the 2.8-inch board is a separate bit-banged bus. The branch claims
+ * the 4-inch board shares the display's physical SPI pins instead, arbitrated
+ * by its own CS. Page TOUCH-B tests the 2.8-inch wiring so the two can be
+ * told apart by measurement on this unit rather than by inference from a
+ * manufacturer PDF for a similarly-named board. */
+constexpr uint8_t BB_TOUCH_MOSI = 32;
+constexpr uint8_t BB_TOUCH_MISO = 39;
+constexpr uint8_t BB_TOUCH_SCLK = 25;
+constexpr uint8_t BB_TOUCH_CS = 33;
+constexpr uint8_t BB_TOUCH_IRQ = 36;
+
+/* Long enough to look up from the serial log at the panel, short enough that
+ * a full sweep is not a coffee break. */
+constexpr uint32_t BL_DWELL_MS = 2500;
+constexpr uint32_t ROT_DWELL_MS = 3000;
+
+constexpr uint8_t PIN_BOOT = 0;
+
+}  // namespace cfg
+
+// ---------------------------------------------------------------- state
+
+TFT_eSPI tft;
+
+enum Page : uint8_t {
+    PAGE_ID = 0,
+    PAGE_BL,
+    PAGE_PATTERN,
+    PAGE_ROT,
+    PAGE_TOUCH_SHARED,
+    PAGE_TOUCH_BITBANG,
+    PAGE_PINS,
+    PAGE_COUNT
+};
+
+const char* const PAGE_NAMES[PAGE_COUNT] = {
+    "ID       -- who is on the SPI bus, if anyone",
+    "BL       -- sweep every plausible backlight pin",
+    "PATTERN  -- geometry, colour order and mirroring",
+    "ROT      -- which rotation is landscape with USB at the bottom",
+    "TOUCH-S  -- touch sharing the display SPI bus",
+    "TOUCH-B  -- touch on its own bit-banged bus (2.8-inch wiring)",
+    "PINS     -- ADC on candidate battery-sense pins",
+};
+
+uint8_t page = PAGE_ID;
+
+// ---------------------------------------------------------------- helpers
+
+void banner(const char* name) {
+    Serial.println();
+    Serial.println("========================================================");
+    Serial.printf("PAGE %u: %s\n", page, name);
+    Serial.println("========================================================");
+}
+
+// ---------------------------------------------------------------- pages
+
+/* PAGE ID -- the only page that does not care whether anything is visible.
+ *
+ * 0x04 (RDDID) and 0xD3 (RDDIDIF) are the two identification reads these
+ * controllers answer. A working bus gives a stable, non-trivial pattern:
+ * ST7796 answers 0xD3 with 0x77 0x96, ILI9341 with 0x93 0x41. All-0x00 or
+ * all-0xFF means MISO is idle -- nothing is talking back. */
+void runId() {
+    Serial.printf("Driver compiled in : %s\n",
+#if defined(ST7796_DRIVER)
+                  "ST7796_DRIVER"
+#elif defined(ILI9341_2_DRIVER)
+                  "ILI9341_2_DRIVER"
+#else
+                  "(unknown)"
+#endif
+    );
+    Serial.printf("SPI pins           : MISO=%d MOSI=%d SCLK=%d CS=%d DC=%d RST=%d\n",
+                  TFT_MISO, TFT_MOSI, TFT_SCLK, TFT_CS, TFT_DC, TFT_RST);
+    Serial.printf("Declared geometry  : TFT_WIDTH=%d TFT_HEIGHT=%d\n", TFT_WIDTH, TFT_HEIGHT);
+    Serial.printf("Reported by driver : width=%d height=%d (rotation %d)\n",
+                  tft.width(), tft.height(), tft.getRotation());
+
+    uint8_t d3[4];
+    uint8_t d04[4];
+    for (uint8_t i = 0; i < 4; ++i) {
+        d3[i] = tft.readcommand8(0xD3, i);
+    }
+    for (uint8_t i = 0; i < 4; ++i) {
+        d04[i] = tft.readcommand8(0x04, i);
+    }
+
+    Serial.printf("RDDIDIF (0xD3)     : %02X %02X %02X %02X\n", d3[0], d3[1], d3[2], d3[3]);
+    Serial.printf("RDDID   (0x04)     : %02X %02X %02X %02X\n", d04[0], d04[1], d04[2], d04[3]);
+
+    const bool idle = (d3[1] == 0x00 && d3[2] == 0x00 && d04[1] == 0x00 && d04[2] == 0x00) ||
+                      (d3[1] == 0xFF && d3[2] == 0xFF && d04[1] == 0xFF && d04[2] == 0xFF);
+    if (idle) {
+        Serial.println("VERDICT: MISO is idle -- nothing answered. Either the SPI pins above");
+        Serial.println("         are wrong for this board, or MISO is not wired back at all");
+        Serial.println("         on this variant (some CYDs leave it unconnected). Try page");
+        Serial.println("         PATTERN: if a correct image appears anyway, the write path");
+        Serial.println("         is fine and only the read path is missing.");
+    } else if (d3[1] == 0x77 && d3[2] == 0x96) {
+        Serial.println("VERDICT: ST7796 confirmed. Bus and driver are both right.");
+    } else if (d3[1] == 0x93 && d3[2] == 0x41) {
+        Serial.println("VERDICT: ILI9341, NOT ST7796. This panel is a different controller");
+        Serial.println("         than assumed -- change the driver flag before anything else.");
+    } else {
+        Serial.println("VERDICT: something answered, but it is neither ST7796 (77 96) nor");
+        Serial.println("         ILI9341 (93 41). Report these bytes -- the controller needs");
+        Serial.println("         identifying before a profile can be written.");
+    }
+}
+
+/* PAGE BL -- the sweep. Both polarities per pin, because the backlight
+ * transistor is driven active-low on some of these boards and active-high on
+ * others, and guessing the polarity wrong looks exactly like a wrong pin. */
+void runBacklightSweep() {
+    Serial.println("Filling the panel white first, so a lit backlight is unmistakable.");
+    Serial.println("Watch the screen. Report the pin AND polarity that lit it.");
+    tft.fillScreen(TFT_WHITE);
+
+    for (uint8_t pin : cfg::BACKLIGHT_CANDIDATES) {
+        pinMode(pin, OUTPUT);
+        Serial.printf("  GPIO%-2u  HIGH ... ", pin);
+        Serial.flush();
+        digitalWrite(pin, HIGH);
+        delay(cfg::BL_DWELL_MS);
+        Serial.print("LOW ... ");
+        Serial.flush();
+        digitalWrite(pin, LOW);
+        delay(cfg::BL_DWELL_MS);
+        Serial.println("next");
+        // Released, so the next candidate is tested on its own.
+        pinMode(pin, INPUT);
+    }
+    Serial.println("Sweep complete. If NOTHING lit the panel at any point, the backlight is");
+    Serial.println("not on any of these pins -- or the panel is not being driven at all,");
+    Serial.println("which page ID would already have told you.");
+    Serial.println("Once you know the pin, say so: pages PATTERN and ROT need the light on.");
+}
+
+/* PAGE PATTERN -- built so a WRONG result is diagnosable, not merely visible.
+ *
+ * Corner labels catch mirroring and 180-degree flips; named colour blocks
+ * catch a BGR/RGB swap; the border catches an off-by-one geometry or an
+ * addressable area smaller than the panel. A garbled-but-present image is the
+ * signature of ST7796S accepting ILI9341 commands. */
+void runPattern() {
+    Serial.printf("Drawing into %dx%d at rotation %d.\n",
+                  tft.width(), tft.height(), tft.getRotation());
+    Serial.println("Report: are all four corner labels present and the right way round?");
+    Serial.println("        is RED actually red (a BGR swap would show it blue)?");
+    Serial.println("        does the white border touch all four physical edges?");
+
+    const int16_t w = tft.width();
+    const int16_t h = tft.height();
+
+    tft.fillScreen(TFT_BLACK);
+    tft.drawRect(0, 0, w, h, TFT_WHITE);
+
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    tft.setTextDatum(TL_DATUM);
+    tft.drawString("TL", 6, 6, 4);
+    tft.setTextDatum(TR_DATUM);
+    tft.drawString("TR", w - 6, 6, 4);
+    tft.setTextDatum(BL_DATUM);
+    tft.drawString("BL", 6, h - 6, 4);
+    tft.setTextDatum(BR_DATUM);
+    tft.drawString("BR", w - 6, h - 6, 4);
+
+    /* Named blocks: the label says what the colour should be, so a swap is
+     * self-evident from a photograph with nothing to compare against. */
+    struct Swatch {
+        uint16_t colour;
+        const char* name;
+    };
+    const Swatch swatches[] = {
+        {TFT_RED, "RED"},
+        {TFT_GREEN, "GREEN"},
+        {TFT_BLUE, "BLUE"},
+        {TFT_YELLOW, "YELLOW"},
+    };
+    const int16_t bw = w / 4;
+    const int16_t by = h / 2 - 30;
+    tft.setTextDatum(MC_DATUM);
+    for (uint8_t i = 0; i < 4; ++i) {
+        tft.fillRect(i * bw, by, bw, 60, swatches[i].colour);
+        tft.setTextColor(TFT_BLACK, swatches[i].colour);
+        tft.drawString(swatches[i].name, i * bw + bw / 2, by + 30, 2);
+    }
+
+    tft.setTextColor(TFT_WHITE, TFT_BLACK);
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%dx%d rot%d", w, h, tft.getRotation());
+    tft.drawString(buf, w / 2, by - 40, 4);
+}
+
+/* PAGE ROT -- resolves landscapeRotation, which is a physical fact about
+ * where the USB socket is and cannot be derived from anything else. */
+void runRotationSweep() {
+    Serial.println("Cycling rotations 0-3. Report the number that reads upright with the");
+    Serial.println("USB socket at the BOTTOM -- that is this board's landscapeRotation.");
+    const uint8_t entry = tft.getRotation();
+    for (uint8_t r = 0; r < 4; ++r) {
+        tft.setRotation(r);
+        tft.fillScreen(TFT_NAVY);
+        tft.setTextColor(TFT_WHITE, TFT_NAVY);
+        tft.setTextDatum(MC_DATUM);
+        char buf[24];
+        snprintf(buf, sizeof(buf), "ROT %u", r);
+        tft.drawString(buf, tft.width() / 2, tft.height() / 2 - 20, 4);
+        snprintf(buf, sizeof(buf), "%dx%d", tft.width(), tft.height());
+        tft.drawString(buf, tft.width() / 2, tft.height() / 2 + 20, 2);
+        // Should point at the USB edge when r is the right one.
+        tft.drawString("vvv  USB HERE  vvv", tft.width() / 2, tft.height() - 24, 2);
+        Serial.printf("  rotation %u -> %dx%d\n", r, tft.width(), tft.height());
+        delay(cfg::ROT_DWELL_MS);
+    }
+    tft.setRotation(entry);
+    Serial.printf("Restored rotation %u.\n", entry);
+}
+
+/* PAGE TOUCH-S -- the branch's claim, tested. TFT_eSPI's built-in touch
+ * extension drives the XPT2046 over the display's own SPI bus, arbitrated by
+ * TOUCH_CS. Sane values that MOVE with the press are the confirmation; a
+ * frozen number or a constant 0/4095 is not. */
+void runTouchShared() {
+#if defined(TOUCH_CS)
+    Serial.printf("XPT2046 over the shared display bus, CS=%d. Press the panel.\n", TOUCH_CS);
+    Serial.println("Looking for raw x/y that change with WHERE you press. 10 seconds.");
+    const uint32_t until = millis() + 10000;
+    uint16_t samples = 0;
+    while (millis() < until) {
+        uint16_t rx = 0;
+        uint16_t ry = 0;
+        if (tft.getTouchRaw(&rx, &ry)) {
+            Serial.printf("  raw x=%4u y=%4u z=%4u\n", rx, ry, tft.getTouchRawZ());
+            ++samples;
+            delay(120);
+        }
+        delay(10);
+    }
+    Serial.printf("%u sample(s) in 10s.\n", samples);
+    if (samples == 0) {
+        Serial.println("VERDICT: nothing. Either touch is NOT on the shared bus on this unit,");
+        Serial.println("         or TOUCH_CS is wrong. Try page TOUCH-B.");
+    } else {
+        Serial.println("VERDICT: the shared-bus wiring responds. Confirm the numbers tracked");
+        Serial.println("         your finger rather than sitting still.");
+    }
+#else
+    Serial.println("Not built with TOUCH_CS -- nothing to test on this page.");
+#endif
+}
+
+/* Minimal XPT2046 exchange on plain GPIO, matching how the 2.8-inch board is
+ * driven. Kept here rather than shared with the HAL on purpose: this file must
+ * not depend on the board abstraction it exists to inform. */
+uint16_t bbTransfer(uint8_t command) {
+    digitalWrite(cfg::BB_TOUCH_CS, LOW);
+    for (int8_t i = 7; i >= 0; --i) {
+        digitalWrite(cfg::BB_TOUCH_MOSI, (command >> i) & 1);
+        digitalWrite(cfg::BB_TOUCH_SCLK, HIGH);
+        delayMicroseconds(1);
+        digitalWrite(cfg::BB_TOUCH_SCLK, LOW);
+        delayMicroseconds(1);
+    }
+    uint16_t value = 0;
+    for (uint8_t i = 0; i < 16; ++i) {
+        digitalWrite(cfg::BB_TOUCH_SCLK, HIGH);
+        delayMicroseconds(1);
+        value = static_cast<uint16_t>((value << 1) | digitalRead(cfg::BB_TOUCH_MISO));
+        digitalWrite(cfg::BB_TOUCH_SCLK, LOW);
+        delayMicroseconds(1);
+    }
+    digitalWrite(cfg::BB_TOUCH_CS, HIGH);
+    return static_cast<uint16_t>(value >> 4);  // 12-bit result, left-aligned in 16.
+}
+
+/* PAGE TOUCH-B -- the 2.8-inch board's wiring: a separate bit-banged bus.
+ * Between this page and TOUCH-S, "shared" versus "separate" becomes a
+ * measurement on this unit instead of an assumption. */
+void runTouchBitbang() {
+    Serial.printf("XPT2046 on its own bus: MOSI=%u MISO=%u SCLK=%u CS=%u IRQ=%u\n",
+                  cfg::BB_TOUCH_MOSI, cfg::BB_TOUCH_MISO, cfg::BB_TOUCH_SCLK,
+                  cfg::BB_TOUCH_CS, cfg::BB_TOUCH_IRQ);
+    Serial.println("Press the panel. 10 seconds.");
+
+    pinMode(cfg::BB_TOUCH_MOSI, OUTPUT);
+    pinMode(cfg::BB_TOUCH_SCLK, OUTPUT);
+    pinMode(cfg::BB_TOUCH_CS, OUTPUT);
+    pinMode(cfg::BB_TOUCH_MISO, INPUT);
+    pinMode(cfg::BB_TOUCH_IRQ, INPUT);
+    digitalWrite(cfg::BB_TOUCH_CS, HIGH);
+    digitalWrite(cfg::BB_TOUCH_SCLK, LOW);
+
+    const uint32_t until = millis() + 10000;
+    uint16_t hits = 0;
+    while (millis() < until) {
+        const uint16_t z1 = bbTransfer(0xB1);
+        const uint16_t x = bbTransfer(0x91);
+        const uint16_t y = bbTransfer(0xD1);
+        if (z1 > 200 && z1 < 4000) {
+            Serial.printf("  raw x=%4u y=%4u z=%4u irq=%d\n",
+                          x, y, z1, digitalRead(cfg::BB_TOUCH_IRQ));
+            ++hits;
+            delay(120);
+        }
+        delay(10);
+    }
+    Serial.printf("%u sample(s) in 10s.\n", hits);
+    if (hits == 0) {
+        Serial.println("VERDICT: nothing on the separate bus. If TOUCH-S produced numbers,");
+        Serial.println("         this board shares the display bus, as the branch claimed.");
+    } else {
+        Serial.println("VERDICT: the separate bus responds -- this board is wired like the");
+        Serial.println("         2.8-inch one, and the shared-bus claim is wrong here.");
+    }
+}
+
+/* PAGE PINS -- battery sense is optional hardware, but a profile has to state
+ * either a pin or PIN_NONE, and guessing wrong ships a fictional percentage.
+ * ADC1 only: ADC2 is unusable whenever Wi-Fi is associated. */
+void runPinScan() {
+    Serial.println("ADC1 inputs, averaged. On the E32R28T-1 battery sense is IO34 behind a");
+    Serial.println("2:1 divider, so a charged cell reads about 1900-2100 mV at the pin.");
+    Serial.println("Report which pin MOVES when you unplug the battery.");
+    const uint8_t adc1[] = {32, 33, 34, 35, 36, 39};
+    analogReadResolution(12);
+    for (uint8_t pin : adc1) {
+        uint32_t sum = 0;
+        for (uint8_t i = 0; i < 32; ++i) {
+            sum += analogRead(pin);
+            delayMicroseconds(200);
+        }
+        const uint32_t raw = sum / 32;
+        Serial.printf("  GPIO%-2u  raw=%4u  ~%4u mV at the pin  (~%4u mV before a 2:1 divider)\n",
+                      pin, static_cast<unsigned>(raw),
+                      static_cast<unsigned>((raw * 3300) / 4095),
+                      static_cast<unsigned>((raw * 3300 * 2) / 4095));
+    }
+    Serial.println("NOTE: 32 and 33 double as touch lines on some variants -- a reading there");
+    Serial.println("      may be this firmware's own output rather than a sensor.");
+}
+
+void runPage() {
+    banner(PAGE_NAMES[page]);
+    switch (page) {
+        case PAGE_ID: runId(); break;
+        case PAGE_BL: runBacklightSweep(); break;
+        case PAGE_PATTERN: runPattern(); break;
+        case PAGE_ROT: runRotationSweep(); break;
+        case PAGE_TOUCH_SHARED: runTouchShared(); break;
+        case PAGE_TOUCH_BITBANG: runTouchBitbang(); break;
+        case PAGE_PINS: runPinScan(); break;
+        default: break;
+    }
+    Serial.println("-- BOOT or 'n' for the next page, 'p' back, 'r' repeat, 0-6 to jump.");
+}
+
+// ---------------------------------------------------------------- lifecycle
+
+void setup() {
+    Serial.begin(115200);
+    delay(600);
+    Serial.println();
+    Serial.println("Braino 4-inch bring-up probe (env:diag4)");
+    Serial.println("Nothing here assumes the screen works. Report what you SEE, including");
+    Serial.println("'still dark' -- that is a result, not a failure to observe one.");
+
+    pinMode(cfg::PIN_BOOT, INPUT_PULLUP);
+
+    tft.init();
+    tft.setRotation(3);
+
+    /* Hold the two most likely backlight pins up front, so the panel has a
+     * chance of being visible before the sweep is reached. Page BL releases
+     * and tests them properly. */
+    pinMode(21, OUTPUT);
+    digitalWrite(21, HIGH);
+    pinMode(27, OUTPUT);
+    digitalWrite(27, HIGH);
+
+    runPage();
+}
+
+void loop() {
+    static bool bootWasDown = false;
+    const bool bootDown = digitalRead(cfg::PIN_BOOT) == LOW;
+    bool advance = false;
+
+    if (bootDown && !bootWasDown) {
+        advance = true;
+    }
+    bootWasDown = bootDown;
+
+    if (Serial.available()) {
+        const int c = Serial.read();
+        if (c == 'n') {
+            advance = true;
+        } else if (c == 'p') {
+            page = static_cast<uint8_t>((page + PAGE_COUNT - 1) % PAGE_COUNT);
+            runPage();
+        } else if (c == 'r') {
+            runPage();
+        } else if (c >= '0' && c < '0' + PAGE_COUNT) {
+            page = static_cast<uint8_t>(c - '0');
+            runPage();
+        }
+    }
+
+    if (advance) {
+        page = static_cast<uint8_t>((page + 1) % PAGE_COUNT);
+        runPage();
+    }
+
+    delay(20);
+}

--- a/src/diag4.cpp
+++ b/src/diag4.cpp
@@ -94,6 +94,21 @@ constexpr uint32_t ROT_DWELL_MS = 3000;
 
 constexpr uint8_t PIN_BOOT = 0;
 
+/* The pin setup() drives to light the panel, and the pin the sweep restores
+ * when it finishes.
+ *
+ * ONE pin, not two. Holding 21 and 27 together lights the panel whichever of
+ * them is really the backlight, which is convenient on arrival and useless as
+ * evidence -- it is exactly why the backlight pin was still unknown after a
+ * full sweep. Driving one at a time turns a 40-second sweep somebody has to
+ * watch continuously into a single glance: lit means this pin, dark means it
+ * is the other one. Override from platformio.ini to test the alternative:
+ *   -D DIAG4_BOOT_BL_PIN=27 */
+#ifndef DIAG4_BOOT_BL_PIN
+#define DIAG4_BOOT_BL_PIN 21
+#endif
+constexpr uint8_t BOOT_BACKLIGHT_PIN = DIAG4_BOOT_BL_PIN;
+
 }  // namespace cfg
 
 // ---------------------------------------------------------------- state
@@ -246,6 +261,15 @@ void runBacklightSweep() {
     Serial.println("Sweep complete. If NOTHING lit the panel at any point, the backlight is");
     Serial.println("not on any of these pins -- or the panel is not being driven at all,");
     Serial.println("which page ID would already have told you.");
+    /* Restore the boot pin. Leaving every candidate released turned the panel
+     * off for good, and the next three pages plus everything after them ran
+     * against a dark screen -- which was then reported, reasonably, as the
+     * board having gone blank. A diagnostic must not leave the thing it is
+     * diagnosing in a worse state than it found it. */
+    pinMode(cfg::BOOT_BACKLIGHT_PIN, OUTPUT);
+    digitalWrite(cfg::BOOT_BACKLIGHT_PIN, HIGH);
+    Serial.printf("Restored GPIO%u HIGH so the panel is usable again.\n",
+                  static_cast<unsigned>(cfg::BOOT_BACKLIGHT_PIN));
     Serial.println("Once you know the pin, say so: pages PATTERN and ROT need the light on.");
 }
 
@@ -584,13 +608,14 @@ void setup() {
     tft.init();
     tft.setRotation(3);
 
-    /* Hold the two most likely backlight pins up front, so the panel has a
-     * chance of being visible before the sweep is reached. Page BL releases
-     * and tests them properly. */
-    pinMode(21, OUTPUT);
-    digitalWrite(21, HIGH);
-    pinMode(27, OUTPUT);
-    digitalWrite(27, HIGH);
+    /* Light the panel from exactly one candidate, so that whether it lights
+     * is itself the answer. See BOOT_BACKLIGHT_PIN. */
+    pinMode(cfg::BOOT_BACKLIGHT_PIN, OUTPUT);
+    digitalWrite(cfg::BOOT_BACKLIGHT_PIN, HIGH);
+    Serial.printf("Backlight: driving GPIO%u HIGH and nothing else.\n",
+                  static_cast<unsigned>(cfg::BOOT_BACKLIGHT_PIN));
+    Serial.println("If the panel is LIT, that pin is the backlight. If it is DARK, it");
+    Serial.println("is not -- rebuild with -D DIAG4_BOOT_BL_PIN=<other> and look again.");
 
     /* Clear the panel and say something on it, before any page runs.
      *

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -1,6 +1,7 @@
 #include "AppRuntime.h"
 
 #include <esp_system.h>
+#include <math.h>
 #include "engine/NearbyPlay.h"
 #include "AppVersion.h"
 #include "BuildStamp.h"
@@ -13,6 +14,9 @@
 
 
 Ui::Renderer& BrainoApp::display() {
+    if (activeAppIsPlayable()) {
+        return scaledRenderer_;
+    }
     return renderer_;
 }
 
@@ -89,6 +93,12 @@ void BrainoApp::drawTopBar(const char* title) {
 
 void BrainoApp::begin() {
     board_.begin();
+    /* Games always render landscape, so the panel's landscape extent is the
+     * physical size their fixed canvas has to fill. SCREEN_WIDTH/HEIGHT are
+     * exactly that -- BoardConfig.h derives them from the profile's panel size
+     * and landscape rotation -- so on a board that is already canvas-sized
+     * this configures a scale of 1.0 and the wrapper becomes a passthrough. */
+    scaledRenderer_.configure(SCREEN_WIDTH, SCREEN_HEIGHT);
     Watchdog::begin();
     if (!board_.hasTouchCalibration()) {
         board_.runTouchCalibration();
@@ -274,7 +284,13 @@ void BrainoApp::loop() {
             renderScreenSaver();
         }
     } else if (activeGame_ != nullptr) {
-        const Rect settingsButton = LauncherLayout::topBarSettingsRect(display().width());
+        /* The top bar -- home, gear, lock, clock, badges -- is drawn through
+         * the raw renderer, because it is shared chrome sized against the real
+         * panel rather than part of any game's canvas. Its hit rects and the
+         * touch coordinates tested against them must therefore stay in that
+         * same physical space, not display()'s, which is scaled while a
+         * playable game is active. */
+        const Rect settingsButton = LauncherLayout::topBarSettingsRect(renderer_.width());
         const Rect homeButton = LauncherLayout::topBarHomeRect();
         const Rect lockButton = activeLockRect();
         /* BOOT is Home. It is consumed here, above the active screen's
@@ -307,6 +323,18 @@ void BrainoApp::loop() {
         } else if (touch.justPressed &&
                    lockButton.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             lockAndSleepNow();
+        } else if (activeAppIsPlayable()) {
+            /* Below the chrome, a playable game hit-tests against its own
+             * fixed canvas, so the physical press has to be mapped back into
+             * that space or every target lands where the content used to be
+             * rather than where it is drawn. The inverse of ScaledRenderer's
+             * transform, and a no-op when the panel is canvas-sized. */
+            TouchPoint gameTouch = touch;
+            gameTouch.x = static_cast<int16_t>(lroundf(
+                touch.x * static_cast<float>(GAME_CANVAS_WIDTH) / SCREEN_WIDTH));
+            gameTouch.y = static_cast<int16_t>(lroundf(
+                touch.y * static_cast<float>(GAME_CANVAS_HEIGHT) / SCREEN_HEIGHT));
+            activeGame_->update(*this, gameTouch);
         } else {
             activeGame_->update(*this, touch);
         }

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -13,6 +13,23 @@
 // the glyph Ui paints into it cannot drift apart.
 
 
+/* Hand every screen the same starting state for text.
+ *
+ * TftRenderer remembers the glyph size it was last given, which is what lets
+ * the launcher ask for larger labels. The cost is that the size outlives the
+ * screen that set it: a playable game drawing through ScaledRenderer sets a
+ * size on every string, and a system app -- which draws through the same
+ * renderer and never asks for a size at all -- would then inherit whatever the
+ * last game left behind. That is not hypothetical; it is why text came out
+ * enlarged in screens that do no scaling of their own.
+ *
+ * Resetting here rather than trusting each screen to tidy up after itself
+ * makes the whole class of fault impossible: any screen wanting something
+ * other than 1x sets it, and no screen can be affected by one that did. */
+void BrainoApp::beginScreenPaint() {
+    renderer_.setTextSize(1);
+}
+
 Ui::Renderer& BrainoApp::display() {
     if (activeAppIsPlayable()) {
         return scaledRenderer_;
@@ -281,6 +298,7 @@ void BrainoApp::loop() {
             exitScreenSaver();
         } else if (nowMs - ssav_lastFrameMs_ >= 40) {
             ssav_lastFrameMs_ = nowMs;
+            beginScreenPaint();
             renderScreenSaver();
         }
     } else if (activeGame_ != nullptr) {
@@ -340,6 +358,7 @@ void BrainoApp::loop() {
         }
         bool repainted = false;
         if (activeGame_ != nullptr && activeGame_->needsRender()) {
+            beginScreenPaint();
             activeGame_->render(*this);
             activeGame_->clearDirty();
             repainted = true;
@@ -490,6 +509,7 @@ void BrainoApp::goHome() {
     applyRotation(rotationForActiveScreen());
     heapAtLaunch_ = ESP.getFreeHeap();
     activeGame_->begin(*this);
+    beginScreenPaint();
     activeGame_->render(*this);
     activeGame_->clearDirty();
 }

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -7,6 +7,7 @@
 #include "engine/LauncherGame.h"
 #include "games/GameInstances.h"
 #include "hal/Board.h"
+#include "ui/ScaledRenderer.h"
 #include "ui/TftRenderer.h"
 #include "ui/Ui.h"
 
@@ -137,12 +138,43 @@ private:
     static constexpr uint32_t BATTERY_REPEAT_MS = 120000;
 
     Board board_;
+    /* Playable games are drawn through scaledRenderer_; system screens draw
+     * through renderer_ directly. See display().
+     *
+     * The split exists because the two kinds of screen solve the size problem
+     * differently. System apps already lay themselves out against the live
+     * tft.width()/height(), so a bigger panel simply gives them more room.
+     * Playable games are authored against the fixed GAME_CANVAS and position
+     * everything by arithmetic on it -- there is no responsive layout to fall
+     * back on, so the canvas is stretched to fill the panel instead.
+     *
+     * textScale=2 is a legibility decision, not a scaling one. Glyph scale in
+     * TFT_eSPI is whole-number only, so on a 480x320 panel the layout grows
+     * ~1.4x while text at scale 2 grows exactly 2x -- text deliberately gains
+     * on its boxes rather than merely keeping up. That is the point: this
+     * board exists to serve players who need a bigger, plainer screen, and
+     * text that only kept pace with the layout would be no easier to read than
+     * on the 2.8in board. The cost is less slack inside tight boxes, which is
+     * a thing to check on the panel rather than reason about. */
     Ui::TftRenderer renderer_{board_.display()};
+    Ui::ScaledRenderer scaledRenderer_{renderer_, /*textScale=*/2};
     ContentLoader content_;
     GameInstances games_;
     LauncherGame launcher_;
     Game* activeGame_ = nullptr;
     const AppDefinition* activeApp_ = nullptr;
+    /* True only while a playable game is the thing on screen.
+     *
+     * view_ == View::Game is load-bearing, not redundant. activeApp_ keeps
+     * pointing at the last-launched game while the saver, sleep or the lock
+     * screen is up -- none of those goes through launch(), so nothing clears
+     * it -- and all three lay themselves out against the real panel like any
+     * other system view. Without the view check they would inherit the scale
+     * of whichever game happened to be open beforehand. */
+    bool activeAppIsPlayable() const {
+        return view_ == View::Game && activeApp_ != nullptr && activeApp_->isCatalogApp();
+    }
+
     View view_ = View::Game;
     uint32_t heapAtLaunch_ = 0;
 

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -17,6 +17,9 @@ public:
     void loop();
 
     Ui::Renderer& display() override;
+
+    /** Reset per-paint renderer state so no screen inherits another's. */
+    void beginScreenPaint();
     Board& board() override;
     bool hasCapability(uint32_t capability) const override;
     bool requireCapability(uint32_t capability, const char* action) override;

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -148,16 +148,27 @@ private:
      * everything by arithmetic on it -- there is no responsive layout to fall
      * back on, so the canvas is stretched to fill the panel instead.
      *
-     * textScale=2 is a legibility decision, not a scaling one. Glyph scale in
-     * TFT_eSPI is whole-number only, so on a 480x320 panel the layout grows
-     * ~1.4x while text at scale 2 grows exactly 2x -- text deliberately gains
-     * on its boxes rather than merely keeping up. That is the point: this
-     * board exists to serve players who need a bigger, plainer screen, and
-     * text that only kept pace with the layout would be no easier to read than
-     * on the 2.8in board. The cost is less slack inside tight boxes, which is
-     * a thing to check on the panel rather than reason about. */
+     * textScale is 1, and the reasoning that said 2 was wrong on hardware.
+     *
+     * The argument for 2 was that this board exists for players who need
+     * bigger, plainer text, so text should gain on its boxes rather than
+     * merely keep pace. The flaw is that glyph scale is whole-number only:
+     * the layout grows ~1.4x here, so 2x is not "a bit bigger", it is 43%
+     * bigger than its box, and text overflowed or was truncated across the
+     * games. A label that does not fit is not more legible.
+     *
+     * The value went untested for a while because TftRenderer::drawString
+     * forced setTextSize(1), so this 2 never reached the panel -- the games
+     * had always drawn at 1x. Fixing that so the launcher could scale its own
+     * text let the 2 through for the first time, and it broke every screen at
+     * once. Two lessons, both worth keeping: a setting that cannot take effect
+     * is not a tested setting, and legibility on this board has to come from
+     * layouts that can carry a larger font, not from multiplying the font
+     * under a layout that cannot. The launcher does it properly -- it grows
+     * its tiles first and only then asks for larger text, and falls back when
+     * the label would not fit. */
     Ui::TftRenderer renderer_{board_.display()};
-    Ui::ScaledRenderer scaledRenderer_{renderer_, /*textScale=*/2};
+    Ui::ScaledRenderer scaledRenderer_{renderer_, /*textScale=*/1};
     ContentLoader content_;
     GameInstances games_;
     LauncherGame launcher_;

--- a/src/engine/AppRuntimeLauncher.cpp
+++ b/src/engine/AppRuntimeLauncher.cpp
@@ -279,18 +279,55 @@ void LauncherGame::render(GameHost& host) {
         const float sx = static_cast<float>(r.w) / (tall ? 108.0f : 145.0f);
         const float sy = static_cast<float>(r.h) / (tall ? 96.0f : 46.0f);
         const float s = sx < sy ? sx : sy;
-        const uint8_t textScale = s >= 1.45f ? 2 : 1;
 
+        /* Ask for the larger font, then check it actually fits -- and take the
+         * smaller one when it does not.
+         *
+         * Deciding on the tile's growth alone was wrong in the wide layout.
+         * A tall tile gives the label the full tile width, but a wide one
+         * spends a third of it on the icon, so the same 2x that reads well
+         * in portrait truncates "Multiplication" to a few characters in
+         * landscape. The tile being bigger says the font may be bigger; only
+         * measuring the actual string says whether it is. Long names fall back
+         * on their own, per tile, with no list of exceptions to maintain. */
+        const int16_t titleRoom = static_cast<int16_t>(tall ? r.w - 8 : r.w * 0.66f - 8);
+        uint8_t textScale = s >= 1.45f ? 2 : 1;
+        if (textScale > 1) {
+            tft.setTextSize(2);
+            if (tft.textWidth(entry.title(), 2) > titleRoom) {
+                textScale = 1;
+            }
+            tft.setTextSize(1);
+        }
+
+        /* Icons scale by WHOLE numbers only, or not at all.
+         *
+         * The tile grows by a fraction -- about 1.37 in portrait here -- and
+         * feeding that to the icon art was wrong. These are drawn shapes, not
+         * bitmaps, but they are built from small integers: 1px strokes, a 17px
+         * radius, triangle vertices a dozen pixels from centre. Multiply those
+         * by 1.37 and each rounds independently: strokes land on 1px in one
+         * place and 2px in another, outlines lose corners, and any lettering
+         * inside stays 1x while its box grows. Tic-Tac-Toe came through it
+         * intact because its features are coarse -- a 34px plate and 30px
+         * strokes have room to absorb a rounding error -- which is exactly why
+         * it looked fixed while the detailed icons did not.
+         *
+         * So: an integer multiple when one fits, otherwise native size, and
+         * centred in the tile either way. The same rule the flags follow. A
+         * crisp icon in a roomy tile reads better than a smeared one that
+         * fills it. */
+        const uint8_t iconScale = (s >= 2.0f) ? 2 : 1;
         Ui::ScaledRenderer icon{tft};
-        icon.setScale(s, s);
+        icon.setScale(static_cast<float>(iconScale), static_cast<float>(iconScale));
 
         char label[24];
         if (tall) {
             const int16_t cxT = static_cast<int16_t>(r.x + r.w / 2);
             const int16_t iconY = static_cast<int16_t>(r.y + r.h * 0.3125f);
             drawLauncherIcon(icon, entry.icon(), r, fill,
-                             static_cast<int16_t>(cxT / s),
-                             static_cast<int16_t>(iconY / s));
+                             static_cast<int16_t>(cxT / iconScale),
+                             static_cast<int16_t>(iconY / iconScale));
             tft.setTextColor(TFT_WHITE, fill);
             tft.setTextDatum(MC_DATUM);
             tft.setTextSize(textScale);
@@ -303,21 +340,36 @@ void LauncherGame::render(GameHost& host) {
             tft.drawString(label, cxT, static_cast<int16_t>(r.y + r.h * 0.906f), 1);
             tft.setTextSize(1);
         } else {
-            const int16_t iconX = static_cast<int16_t>(r.x + r.w * 0.166f);
-            const int16_t iconY = static_cast<int16_t>(r.y + r.h * 0.478f);
+            /* Everything hangs off the tile's own centre line.
+             *
+             * The first version kept the old proportions -- icon at 0.478 of
+             * the height, title at 0.37, subtitle at 0.74 -- which were fine
+             * in a 46px tile and drift visibly in a 69px one: the pair sits
+             * low, and the icon a shade above it, so nothing lines up with
+             * anything. Measuring the text block from the middle outwards
+             * keeps it centred at any tile height, and puts the icon on the
+             * same line rather than near it. */
+            const int16_t midY = static_cast<int16_t>(r.y + r.h / 2);
+            const int16_t iconX = static_cast<int16_t>(r.x + r.w * 0.18f);
             drawLauncherIcon(icon, entry.icon(), r, fill,
-                             static_cast<int16_t>(iconX / s),
-                             static_cast<int16_t>(iconY / s));
-            const int16_t textX = static_cast<int16_t>(r.x + r.w * 0.33f);
-            const int16_t textW = static_cast<int16_t>(r.w - r.w * 0.33f - 6);
+                             static_cast<int16_t>(iconX / iconScale),
+                             static_cast<int16_t>(midY / iconScale));
+
+            /* Title above the line and subtitle below it, each by half its own
+             * height, so the gap between them does not grow with the tile. */
+            const int16_t titleH = static_cast<int16_t>(16 * textScale);
+            const int16_t subH = static_cast<int16_t>(8 * textScale);
+            const int16_t textX = static_cast<int16_t>(r.x + r.w * 0.34f);
+            const int16_t textW = static_cast<int16_t>(r.w - (r.x + r.w * 0.34f - r.x) - 8);
+
             tft.setTextColor(TFT_WHITE, fill);
             tft.setTextDatum(ML_DATUM);
             tft.setTextSize(textScale);
             copyFittedText(tft, entry.title(), label, sizeof(label), textW, 2);
-            tft.drawString(label, textX, static_cast<int16_t>(r.y + r.h * 0.37f), 2);
+            tft.drawString(label, textX, static_cast<int16_t>(midY - subH / 2 - 2), 2);
             tft.setTextColor(Ui::rgb(235, 245, 255), fill);
             copyFittedText(tft, entry.subtitle(), label, sizeof(label), textW, 1);
-            tft.drawString(label, textX, static_cast<int16_t>(r.y + r.h * 0.74f), 1);
+            tft.drawString(label, textX, static_cast<int16_t>(midY + titleH / 2 + 2), 1);
             tft.setTextSize(1);
         }
     }

--- a/src/engine/AppRuntimeLauncher.cpp
+++ b/src/engine/AppRuntimeLauncher.cpp
@@ -7,6 +7,7 @@
 #include "hal/Clock.h"
 #include "hal/Watchdog.h"
 #include "ui/LauncherIcons.h"
+#include "ui/ScaledRenderer.h"
 #include "ui/LauncherLayout.h"
 
 namespace {
@@ -261,34 +262,63 @@ void LauncherGame::render(GameHost& host) {
                                              : Ui::rgb(222, 83, 83));
         Ui::drawButton(tft, r, "", fill, TFT_DARKGREY, TFT_WHITE);
 
+        /* Place the contents as fractions of the tile, and scale them with it.
+         *
+         * These offsets used to be constants -- icon at r.x + 24, title at
+         * r.y + 17 -- which described the old 145x46 tile and nothing else.
+         * Once the grid started dividing the real panel, the tiles grew and
+         * their contents stayed put in the top-left corner of them, which
+         * looked worse than the un-scaled grid had: a big empty box with small
+         * writing in it. The fractions below are the old constants divided by
+         * the old tile size, so the 2.8-inch board gets what it always got.
+         *
+         * The text scale is the whole reason this board is here. A larger
+         * panel that renders the same small label is no easier for the players
+         * this is meant to serve; the tile has to carry bigger writing, not
+         * just more space around it. */
+        const float sx = static_cast<float>(r.w) / (tall ? 108.0f : 145.0f);
+        const float sy = static_cast<float>(r.h) / (tall ? 96.0f : 46.0f);
+        const float s = sx < sy ? sx : sy;
+        const uint8_t textScale = s >= 1.45f ? 2 : 1;
+
+        Ui::ScaledRenderer icon{tft};
+        icon.setScale(s, s);
+
         char label[24];
         if (tall) {
-            drawLauncherIcon(tft, entry.icon(), r, fill,
-                             static_cast<int16_t>(r.x + r.w / 2),
-                             static_cast<int16_t>(r.y + 30));
+            const int16_t cxT = static_cast<int16_t>(r.x + r.w / 2);
+            const int16_t iconY = static_cast<int16_t>(r.y + r.h * 0.3125f);
+            drawLauncherIcon(icon, entry.icon(), r, fill,
+                             static_cast<int16_t>(cxT / s),
+                             static_cast<int16_t>(iconY / s));
             tft.setTextColor(TFT_WHITE, fill);
             tft.setTextDatum(MC_DATUM);
-            const int16_t cxT = static_cast<int16_t>(r.x + r.w / 2);
+            tft.setTextSize(textScale);
             copyFittedText(tft, entry.title(), label, sizeof(label),
                            static_cast<int16_t>(r.w - 8), 2);
-            tft.drawString(label, cxT, static_cast<int16_t>(r.y + 68), 2);
+            tft.drawString(label, cxT, static_cast<int16_t>(r.y + r.h * 0.708f), 2);
             tft.setTextColor(Ui::rgb(235, 245, 255), fill);
             copyFittedText(tft, entry.subtitle(), label, sizeof(label),
                            static_cast<int16_t>(r.w - 8), 1);
-            tft.drawString(label, cxT, static_cast<int16_t>(r.y + 87), 1);
+            tft.drawString(label, cxT, static_cast<int16_t>(r.y + r.h * 0.906f), 1);
+            tft.setTextSize(1);
         } else {
-            drawLauncherIcon(tft, entry.icon(), r, fill,
-                             static_cast<int16_t>(r.x + 24),
-                             static_cast<int16_t>(r.y + 22));
+            const int16_t iconX = static_cast<int16_t>(r.x + r.w * 0.166f);
+            const int16_t iconY = static_cast<int16_t>(r.y + r.h * 0.478f);
+            drawLauncherIcon(icon, entry.icon(), r, fill,
+                             static_cast<int16_t>(iconX / s),
+                             static_cast<int16_t>(iconY / s));
+            const int16_t textX = static_cast<int16_t>(r.x + r.w * 0.33f);
+            const int16_t textW = static_cast<int16_t>(r.w - r.w * 0.33f - 6);
             tft.setTextColor(TFT_WHITE, fill);
             tft.setTextDatum(ML_DATUM);
-            copyFittedText(tft, entry.title(), label, sizeof(label),
-                           static_cast<int16_t>(r.w - 54), 2);
-            tft.drawString(label, r.x + 48, r.y + 17, 2);
+            tft.setTextSize(textScale);
+            copyFittedText(tft, entry.title(), label, sizeof(label), textW, 2);
+            tft.drawString(label, textX, static_cast<int16_t>(r.y + r.h * 0.37f), 2);
             tft.setTextColor(Ui::rgb(235, 245, 255), fill);
-            copyFittedText(tft, entry.subtitle(), label, sizeof(label),
-                           static_cast<int16_t>(r.w - 54), 1);
-            tft.drawString(label, r.x + 48, r.y + 34, 1);
+            copyFittedText(tft, entry.subtitle(), label, sizeof(label), textW, 1);
+            tft.drawString(label, textX, static_cast<int16_t>(r.y + r.h * 0.74f), 1);
+            tft.setTextSize(1);
         }
     }
 

--- a/src/engine/AppRuntimeLauncher.cpp
+++ b/src/engine/AppRuntimeLauncher.cpp
@@ -125,7 +125,7 @@ void LauncherGame::update(GameHost& host, const TouchPoint& touch) {
         if (index >= count) {
             break;
         }
-        if (LauncherLayout::tileRect(slot, mode).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (LauncherLayout::tileRect(slot, mode, lW, lH).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             host.openApp(host.launcherEntry(index));
             return;
         }
@@ -255,7 +255,7 @@ void LauncherGame::render(GameHost& host) {
             break;
         }
         const AppDefinition& entry = host.launcherEntry(index);
-        const Rect r = LauncherLayout::tileRect(slot, mode);
+        const Rect r = LauncherLayout::tileRect(slot, mode, lW, lH);
         const uint16_t fill = slot % 3 == 0 ? Ui::rgb(36, 132, 204)
                             : (slot % 3 == 1 ? Ui::rgb(45, 154, 96)
                                              : Ui::rgb(222, 83, 83));

--- a/src/engine/AppRuntimeLauncher.cpp
+++ b/src/engine/AppRuntimeLauncher.cpp
@@ -250,6 +250,45 @@ void LauncherGame::render(GameHost& host) {
     const uint8_t pageSize = host.launcherPageSize();
     const uint8_t start = page_ * pageSize;
     const uint8_t total = host.launcherEntryCount();
+
+    /* One text size for the whole page, chosen so every label on it fits.
+     *
+     * Deciding per tile produced a grid of mixed sizes -- "Memory" large
+     * beside "Tic-Tac-Toe" small -- which reads as a fault rather than as
+     * fitting, because a grid implies its cells are alike. Worse, the test
+     * only measured the title, so "Math" qualified for 2x and its subtitle
+     * "addition & subtraction" was then quietly truncated to "addition &".
+     *
+     * So: measure BOTH strings of EVERY tile on the page, and take the larger
+     * size only if all of them fit. One tile with a long name holds the page
+     * to 1x, which is the right trade -- uniform and complete beats large and
+     * clipped. */
+    const Rect probe = LauncherLayout::tileRect(0, mode, lW, lH);
+    const float probeS = [&]() {
+        const float px = static_cast<float>(probe.w) / (tall ? 108.0f : 145.0f);
+        const float py = static_cast<float>(probe.h) / (tall ? 96.0f : 46.0f);
+        return px < py ? px : py;
+    }();
+    const int16_t titleRoom =
+        static_cast<int16_t>(tall ? probe.w - 8 : probe.w * 0.66f - 8);
+
+    uint8_t pageTextScale = probeS >= 1.45f ? 2 : 1;
+    if (pageTextScale > 1) {
+        tft.setTextSize(2);
+        for (uint8_t slot = 0; slot < pageSize && pageTextScale > 1; ++slot) {
+            const uint8_t index = start + slot;
+            if (index >= total) {
+                break;
+            }
+            const AppDefinition& e = host.launcherEntry(index);
+            if (tft.textWidth(e.title(), 2) > titleRoom ||
+                tft.textWidth(e.subtitle(), 1) > titleRoom) {
+                pageTextScale = 1;
+            }
+        }
+        tft.setTextSize(1);
+    }
+
     for (uint8_t slot = 0; slot < pageSize; ++slot) {
         const uint8_t index = start + slot;
         if (index >= total) {
@@ -280,25 +319,7 @@ void LauncherGame::render(GameHost& host) {
         const float sy = static_cast<float>(r.h) / (tall ? 96.0f : 46.0f);
         const float s = sx < sy ? sx : sy;
 
-        /* Ask for the larger font, then check it actually fits -- and take the
-         * smaller one when it does not.
-         *
-         * Deciding on the tile's growth alone was wrong in the wide layout.
-         * A tall tile gives the label the full tile width, but a wide one
-         * spends a third of it on the icon, so the same 2x that reads well
-         * in portrait truncates "Multiplication" to a few characters in
-         * landscape. The tile being bigger says the font may be bigger; only
-         * measuring the actual string says whether it is. Long names fall back
-         * on their own, per tile, with no list of exceptions to maintain. */
-        const int16_t titleRoom = static_cast<int16_t>(tall ? r.w - 8 : r.w * 0.66f - 8);
-        uint8_t textScale = s >= 1.45f ? 2 : 1;
-        if (textScale > 1) {
-            tft.setTextSize(2);
-            if (tft.textWidth(entry.title(), 2) > titleRoom) {
-                textScale = 1;
-            }
-            tft.setTextSize(1);
-        }
+        const uint8_t textScale = pageTextScale;
 
         /* Icons scale by WHOLE numbers only, or not at all.
          *

--- a/src/engine/AppRuntimeLock.cpp
+++ b/src/engine/AppRuntimeLock.cpp
@@ -154,7 +154,7 @@ Rect BrainoApp::activeLockRect() {
     if (activeGame_ == &launcher_) {
         return LauncherLayout::lockRect(board_.layoutMode(), renderer_.width());
     }
-    return LauncherLayout::topBarLockRect();
+    return LauncherLayout::topBarLockRect(static_cast<int16_t>(renderer_.width()));
 }
 
 /* The deliberate way in. Everything else here is reached by a timeout; this is

--- a/src/games/CinnamonGame.cpp
+++ b/src/games/CinnamonGame.cpp
@@ -230,7 +230,7 @@ void CinnamonGame::render(AppContext& host) {
         tft.setTextDatum(TL_DATUM);
         tft.drawString(String("Score ") + score_, 10, 36, 2);
         tft.setTextDatum(TR_DATUM);
-        tft.drawString(String("Best ") + bestScore_, SCREEN_WIDTH - 10, 36, 2);
+        tft.drawString(String("Best ") + bestScore_, GAME_CANVAS_WIDTH - 10, 36, 2);
         for (uint8_t i = 0; i < 4; ++i) {
             const bool lit = (litPad_ == i) ||
                              (phase_ == Phase::Failed && i == sequence_[inputIndex_]);
@@ -268,7 +268,7 @@ void CinnamonGame::render(AppContext& host) {
     if (phase_ == Phase::Failed) {
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Bright pad was next", SCREEN_WIDTH / 2, 214, 2);
+        tft.drawString("Bright pad was next", GAME_CANVAS_WIDTH / 2, 214, 2);
     }
     tft.setTextDatum(TL_DATUM);
     Ui::setTheme(savedTheme);

--- a/src/games/CoinFlipGame.cpp
+++ b/src/games/CoinFlipGame.cpp
@@ -18,7 +18,7 @@ constexpr AppMetadata COIN_FLIP_METADATA = {
     true,
 };
 
-constexpr int16_t COIN_CX = SCREEN_WIDTH / 2;
+constexpr int16_t COIN_CX = GAME_CANVAS_WIDTH / 2;
 constexpr int16_t COIN_CY = 116;
 constexpr int16_t COIN_R = 34;
 
@@ -61,7 +61,7 @@ Rect CoinFlipGame::flipRect() const {
 }
 
 Rect CoinFlipGame::activeBand() const {
-    return Rect{0, 78, SCREEN_WIDTH, 118};
+    return Rect{0, 78, GAME_CANVAS_WIDTH, 118};
 }
 
 uint8_t CoinFlipGame::headsCount() const {
@@ -190,7 +190,7 @@ void CoinFlipGame::render(AppContext& host) {
 
         tft.setTextColor(Ui::muted(), Ui::bg());
         tft.setTextDatum(TC_DATUM);
-        tft.drawString("Best of how many?", SCREEN_WIDTH / 2, 34, 1);
+        tft.drawString("Best of how many?", GAME_CANVAS_WIDTH / 2, 34, 1);
 
         for (uint8_t i = 0; i < CHOICES; ++i) {
             const bool on = (i == choice_);
@@ -224,7 +224,7 @@ void CoinFlipGame::render(AppContext& host) {
     // ---- one pip per flip in the round, filled as each lands ----
     const int16_t pitch = 28;
     const int16_t span = static_cast<int16_t>((flips - 1) * pitch);
-    const int16_t px0 = static_cast<int16_t>((SCREEN_WIDTH - span) / 2);
+    const int16_t px0 = static_cast<int16_t>((GAME_CANVAS_WIDTH - span) / 2);
     tft.setTextDatum(MC_DATUM);
     for (uint8_t i = 0; i < flips; ++i) {
         const int16_t px = static_cast<int16_t>(px0 + i * pitch);
@@ -261,6 +261,6 @@ void CoinFlipGame::render(AppContext& host) {
         snprintf(line, sizeof(line), "Tap Flip to spin");
         tft.setTextColor(Ui::muted(), Ui::bg());
     }
-    tft.drawString(line, SCREEN_WIDTH / 2, 187, 2);
+    tft.drawString(line, GAME_CANVAS_WIDTH / 2, 187, 2);
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/ColorMixGame.cpp
+++ b/src/games/ColorMixGame.cpp
@@ -147,7 +147,7 @@ void ColorMixGame::render(AppContext& host) {
     tft.setTextDatum(TL_DATUM);
     tft.drawString(String("Score ") + score_ + "/" + attempts_, 10, 35, 2);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Best ") + bestStreak_, SCREEN_WIDTH - 8, 35, 2);
+    tft.drawString(String("Best ") + bestStreak_, GAME_CANVAS_WIDTH - 8, 35, 2);
     Ui::drawLabel(tft, Rect{10, 52, 300, 18}, "What do you get?", Ui::text(), 2, Align::Center);
 
     const Rect left{56, 78, 60, 44};
@@ -158,7 +158,7 @@ void ColorMixGame::render(AppContext& host) {
     tft.drawRoundRect(right.x, right.y, right.w, right.h, 6, Ui::outline());
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(MC_DATUM);
-    tft.drawString("+", SCREEN_WIDTH / 2, 100, 4);
+    tft.drawString("+", GAME_CANVAS_WIDTH / 2, 100, 4);
     tft.drawString(active_->left, left.x + left.w / 2, left.y + left.h + 12, 1);
     tft.drawString(active_->right, right.x + right.w / 2, right.y + right.h + 12, 1);
 
@@ -178,7 +178,7 @@ void ColorMixGame::render(AppContext& host) {
         tft.fillRoundRect(96, 96, 128, 34, 8, color);
         tft.setTextColor(TFT_BLACK, color);
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(correctFlash_ ? "Correct" : "Try again", SCREEN_WIDTH / 2, 113, 2);
+        tft.drawString(correctFlash_ ? "Correct" : "Try again", GAME_CANVAS_WIDTH / 2, 113, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/CountingGame.cpp
+++ b/src/games/CountingGame.cpp
@@ -124,12 +124,12 @@ void CountingGame::render(AppContext& host) {
      * right-aligned "Score n/m" at the same y started around 213 -- they
      * overlapped. Score and streak now share one small line underneath. */
     tft.setTextDatum(TC_DATUM);
-    tft.drawString("How many objects?", SCREEN_WIDTH / 2, 32, 4);
+    tft.drawString("How many objects?", GAME_CANVAS_WIDTH / 2, 32, 4);
     tft.setTextColor(Ui::muted(), Ui::bg());
     char stats[48];
     snprintf(stats, sizeof(stats), "Score %u/%u   Streak %u   Best %u",
              score_, rounds_, streak_, bestStreak_);
-    tft.drawString(stats, SCREEN_WIDTH / 2, 60, 1);
+    tft.drawString(stats, GAME_CANVAS_WIDTH / 2, 60, 1);
     tft.setTextColor(Ui::text(), Ui::bg());
 
     const Rect area{18, 76, 284, 98};
@@ -164,7 +164,7 @@ void CountingGame::render(AppContext& host) {
     if (answered_) {
         tft.setTextDatum(MC_DATUM);
         tft.setTextColor(selected_ == correctButton_ ? GREEN : RED, Ui::bg());
-        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is the answer", SCREEN_WIDTH / 2, 178, 2);
+        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is the answer", GAME_CANVAS_WIDTH / 2, 178, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/DiceGame.cpp
+++ b/src/games/DiceGame.cpp
@@ -65,13 +65,13 @@ Rect DiceGame::dieRect(uint8_t index) const {
     constexpr int16_t size = 68;
     constexpr int16_t gap = 14;
     const int16_t span = static_cast<int16_t>(count_ * size + (count_ - 1) * gap);
-    const int16_t x0 = static_cast<int16_t>((SCREEN_WIDTH - span) / 2);
+    const int16_t x0 = static_cast<int16_t>((GAME_CANVAS_WIDTH - span) / 2);
     return Rect{static_cast<int16_t>(x0 + index * (size + gap)), 88, size, size};
 }
 
 Rect DiceGame::activeBand() const {
     // Dice (88..156) plus the total line below them, but not the Roll button.
-    return Rect{0, 84, SCREEN_WIDTH, 112};
+    return Rect{0, 84, GAME_CANVAS_WIDTH, 112};
 }
 
 /* Hardware entropy, not Arduino random(): on a dice game the draw is the
@@ -163,7 +163,7 @@ void DiceGame::render(AppContext& host) {
 
         tft.setTextColor(Ui::muted(), Ui::bg());
         tft.setTextDatum(TC_DATUM);
-        tft.drawString("How many dice?", SCREEN_WIDTH / 2, 34, 1);
+        tft.drawString("How many dice?", GAME_CANVAS_WIDTH / 2, 34, 1);
 
         for (uint8_t i = 0; i < MAX_DICE; ++i) {
             const bool on = (i + 1) == count_;
@@ -191,15 +191,15 @@ void DiceGame::render(AppContext& host) {
     tft.setTextDatum(MC_DATUM);
     if (rolling_) {
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("Rolling...", SCREEN_WIDTH / 2, 178, 4);
+        tft.drawString("Rolling...", GAME_CANVAS_WIDTH / 2, 178, 4);
     } else if (thrown_) {
         char line[16];
         snprintf(line, sizeof(line), "Total %u", static_cast<unsigned>(total));
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString(line, SCREEN_WIDTH / 2, 178, 4);
+        tft.drawString(line, GAME_CANVAS_WIDTH / 2, 178, 4);
     } else {
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("Tap Roll to throw", SCREEN_WIDTH / 2, 178, 2);
+        tft.drawString("Tap Roll to throw", GAME_CANVAS_WIDTH / 2, 178, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/FingerCountGame.cpp
+++ b/src/games/FingerCountGame.cpp
@@ -203,7 +203,7 @@ void FingerCountGame::render(AppContext& host) {
 
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String(score_) + "/" + rounds_, SCREEN_WIDTH - 8, 33, 2);
+    tft.drawString(String(score_) + "/" + rounds_, GAME_CANVAS_WIDTH - 8, 33, 2);
 
     const bool done = (phase_ == Phase::Feedback);
     const uint8_t up = raisedCount();
@@ -212,26 +212,26 @@ void FingerCountGame::render(AppContext& host) {
     tft.setTextDatum(MC_DATUM);
     if (mode_ == Mode::Count) {
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString("How many fingers?", SCREEN_WIDTH / 2, 50, 4);
+        tft.drawString("How many fingers?", GAME_CANVAS_WIDTH / 2, 50, 4);
         if (done) {
             tft.setTextColor(lastCorrect_ ? Ui::success() : Ui::error(), Ui::bg());
             tft.drawString(lastCorrect_ ? String("Yes! ") + target_
                                         : String("It was ") + target_,
-                           SCREEN_WIDTH / 2, 78, 2);
+                           GAME_CANVAS_WIDTH / 2, 78, 2);
         } else {
             tft.setTextColor(Ui::muted(), Ui::bg());
-            tft.drawString("Count them, then tap the number", SCREEN_WIDTH / 2, 78, 2);
+            tft.drawString("Count them, then tap the number", GAME_CANVAS_WIDTH / 2, 78, 2);
         }
     } else {
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.drawString(String("Show me ") + target_ + (target_ == 1 ? " finger" : " fingers"),
-                       SCREEN_WIDTH / 2, 50, 4);
+                       GAME_CANVAS_WIDTH / 2, 50, 4);
         if (done) {
             tft.setTextColor(Ui::success(), Ui::bg());
-            tft.drawString("That's it!", SCREEN_WIDTH / 2, 78, 2);
+            tft.drawString("That's it!", GAME_CANVAS_WIDTH / 2, 78, 2);
         } else {
             tft.setTextColor(up == target_ ? Ui::success() : Ui::muted(), Ui::bg());
-            tft.drawString(String("Up: ") + up, SCREEN_WIDTH / 2, 78, 2);
+            tft.drawString(String("Up: ") + up, GAME_CANVAS_WIDTH / 2, 78, 2);
         }
     }
 
@@ -260,7 +260,7 @@ void FingerCountGame::render(AppContext& host) {
     } else {
         tft.setTextColor(Ui::muted(), Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Tap a finger to raise or lower it", SCREEN_WIDTH / 2, 212, 2);
+        tft.drawString("Tap a finger to raise or lower it", GAME_CANVAS_WIDTH / 2, 212, 2);
     }
 
     tft.setTextDatum(TL_DATUM);

--- a/src/games/FlagGame.cpp
+++ b/src/games/FlagGame.cpp
@@ -265,7 +265,7 @@ void FlagGame::render(AppContext& host) {
 
     tft.setTextDatum(TR_DATUM);
     tft.setTextColor(Ui::rgb(255, 200, 0), Ui::bg());
-    tft.drawString(String("+") + capBonus_, SCREEN_WIDTH - 8, 33, 2);
+    tft.drawString(String("+") + capBonus_, GAME_CANVAS_WIDTH - 8, 33, 2);
 
     static const char* const TIER_NAMES[4] = {"", "Easy", "Medium", "Hard"};
     Ui::drawButton(tft, tierRect(), TIER_NAMES[tier_], Ui::panel(), Ui::outline(), Ui::text(), false, 1);
@@ -291,7 +291,7 @@ void FlagGame::render(AppContext& host) {
     tft.drawString(capitalRound
                        ? String("Bonus! Capital of ") + (countryName ? countryName : current_->iso2) + "?"
                        : String("Which country?"),
-                   SCREEN_WIDTH / 2, 176, 2);
+                   GAME_CANVAS_WIDTH / 2, 176, 2);
 
     // --- answers ---------------------------------------------------------
     const bool showingFeedback =

--- a/src/games/FractionGame.cpp
+++ b/src/games/FractionGame.cpp
@@ -259,14 +259,33 @@ void FractionGame::update(AppContext& host, const TouchPoint& touch) {
 }
 
 void FractionGame::fillSlice(Ui::Renderer& tft, int16_t cx, int16_t cy, int16_t radius, float startAngle, float endAngle, uint16_t color) const {
+    /* Pre-correct the radius per axis so the wedge lands on the circle that
+     * fillCircle actually drew.
+     *
+     * The renderer may scale x and y by different amounts -- on a 480x320
+     * panel the game canvas stretches 1.5 across and 1.333 down. fillCircle
+     * takes a single radius and uses the average of the two, so it stays a
+     * circle. These wedge points are computed here in canvas space and then
+     * scaled independently, so without this they land on an ellipse instead:
+     * the fill bulges past the rim at the sides and falls short at the top and
+     * bottom, which is what made the arcs look wrong rather than merely
+     * mis-sized. Dividing by each axis and multiplying by the average puts
+     * both back on the same circle. On a board where the scales are equal --
+     * every board today -- avg/sx and avg/sy are 1 and this is the old code. */
+    const float avg = tft.imageScale();
+    const float sxAxis = tft.imageScaleX();
+    const float syAxis = tft.imageScaleY();
+    const float rx = (sxAxis > 0.0f) ? radius * avg / sxAxis : static_cast<float>(radius);
+    const float ry = (syAxis > 0.0f) ? radius * avg / syAxis : static_cast<float>(radius);
+
     const float step = PI / 24.0f;
     float angle = startAngle;
     while (angle < endAngle) {
         const float next = min(endAngle, angle + step);
-        const int16_t x1 = cx + static_cast<int16_t>(cosf(angle) * radius);
-        const int16_t y1 = cy + static_cast<int16_t>(sinf(angle) * radius);
-        const int16_t x2 = cx + static_cast<int16_t>(cosf(next) * radius);
-        const int16_t y2 = cy + static_cast<int16_t>(sinf(next) * radius);
+        const int16_t x1 = cx + static_cast<int16_t>(cosf(angle) * rx);
+        const int16_t y1 = cy + static_cast<int16_t>(sinf(angle) * ry);
+        const int16_t x2 = cx + static_cast<int16_t>(cosf(next) * rx);
+        const int16_t y2 = cy + static_cast<int16_t>(sinf(next) * ry);
         tft.fillTriangle(cx, cy, x1, y1, x2, y2, color);
         angle = next;
     }

--- a/src/games/FractionGame.cpp
+++ b/src/games/FractionGame.cpp
@@ -290,7 +290,7 @@ void FractionGame::drawPie(Ui::Renderer& tft, int16_t cx, int16_t cy, int16_t ra
 }
 
 void FractionGame::drawTextOptions(Ui::Renderer& tft) const {
-    drawPie(tft, SCREEN_WIDTH / 2, 115, 38, target_);
+    drawPie(tft, GAME_CANVAS_WIDTH / 2, 115, 38, target_);
     for (uint8_t i = 0; i < 4; ++i) {
         uint16_t fill = BLUE;
         uint16_t text = TFT_WHITE;
@@ -310,7 +310,7 @@ void FractionGame::drawPieOptions(Ui::Renderer& tft) const {
     tft.drawRoundRect(96, 74, 128, 30, 6, Ui::outline());
     tft.setTextColor(Ui::text(), Ui::panel());
     tft.setTextDatum(MC_DATUM);
-    tft.drawString(fractionText(target_), SCREEN_WIDTH / 2, 89, 4);
+    tft.drawString(fractionText(target_), GAME_CANVAS_WIDTH / 2, 89, 4);
     for (uint8_t i = 0; i < 4; ++i) {
         const Rect r = pieOptionRect(i);
         bool selected = roundComplete_ ? i == correctButton_ : flashIndex_ == i;
@@ -352,8 +352,8 @@ void FractionGame::render(AppContext& host) {
     tft.drawString(String("Level ") + level(), 8, 35, 2);
     tft.drawString(String("Score ") + score_, 8, 51, 1);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Streak ") + streak_, SCREEN_WIDTH - 8, 35, 2);
-    tft.drawString(String("Best ") + bestStreak_, SCREEN_WIDTH - 8, 51, 1);
+    tft.drawString(String("Streak ") + streak_, GAME_CANVAS_WIDTH - 8, 35, 2);
+    tft.drawString(String("Best ") + bestStreak_, GAME_CANVAS_WIDTH - 8, 51, 1);
 
     const char* prompt = mode_ == Mode::PickText ? "Pick the matching fraction" : (mode_ == Mode::PickPie ? "Pick the matching pie" : "Which fraction is bigger?");
     Ui::drawLabel(tft, Rect{8, 66, 304, 12}, prompt, Ui::muted(), 1, Align::Center);
@@ -373,7 +373,7 @@ void FractionGame::render(AppContext& host) {
     } else if (flashIndex_ >= 0) {
         tft.setTextColor(RED, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Try again", SCREEN_WIDTH / 2, 226, 2);
+        tft.drawString("Try again", GAME_CANVAS_WIDTH / 2, 226, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/MathGame.cpp
+++ b/src/games/MathGame.cpp
@@ -192,8 +192,8 @@ void MathGame::render(AppContext& host) {
     tft.drawString(String("Level ") + level(), 10, 35, 2);
     tft.drawString(String("Correct ") + score_ + "  " + formatSeconds(elapsedSeconds()), 10, 52, 1);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Streak ") + streak_, SCREEN_WIDTH - 10, 35, 2);
-    tft.drawString(bestCorrect_ > 0 ? String("Best ") + bestCorrect_ + " / " + formatSeconds(bestSeconds_) : "Best --", SCREEN_WIDTH - 10, 52, 1);
+    tft.drawString(String("Streak ") + streak_, GAME_CANVAS_WIDTH - 10, 35, 2);
+    tft.drawString(bestCorrect_ > 0 ? String("Best ") + bestCorrect_ + " / " + formatSeconds(bestSeconds_) : "Best --", GAME_CANVAS_WIDTH - 10, 52, 1);
 
     const char symbol = operation_ == Operation::Add ? '+' : '-';
     const String equation = String(left_) + " " + symbol + " " + right_ + " = ?";
@@ -201,7 +201,7 @@ void MathGame::render(AppContext& host) {
     tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
     tft.setTextColor(Ui::text(), Ui::panel());
     tft.setTextDatum(MC_DATUM);
-    tft.drawString(equation, SCREEN_WIDTH / 2, 103, 4);
+    tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
 
     for (uint8_t i = 0; i < 4; ++i) {
         uint16_t fill = BLUE;
@@ -221,11 +221,11 @@ void MathGame::render(AppContext& host) {
     if (answered_) {
         tft.setTextColor(selected_ == correctButton_ ? GREEN : RED, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is correct - tap next", SCREEN_WIDTH / 2, 136, 2);
+        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is correct - tap next", GAME_CANVAS_WIDTH / 2, 136, 2);
     } else {
         tft.setTextColor(YELLOW, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Tap the answer", SCREEN_WIDTH / 2, 136, 2);
+        tft.drawString("Tap the answer", GAME_CANVAS_WIDTH / 2, 136, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/MazeGame.cpp
+++ b/src/games/MazeGame.cpp
@@ -6,7 +6,7 @@ namespace {
 constexpr uint8_t MAZE_COLS = MazeData::COLS;
 constexpr uint8_t MAZE_ROWS = MazeData::ROWS;
 constexpr int16_t CELL = 22;
-constexpr int16_t MAZE_X = (SCREEN_WIDTH - MAZE_COLS * CELL) / 2;
+constexpr int16_t MAZE_X = (GAME_CANVAS_WIDTH - MAZE_COLS * CELL) / 2;
 constexpr int16_t MAZE_Y = TOP_BAR_HEIGHT + 28;
 constexpr uint16_t WALL = 0x4A49;
 constexpr uint16_t PATH = 0xFFFF;
@@ -244,7 +244,7 @@ void MazeGame::update(AppContext& host, const TouchPoint& touch) {
 }
 
 void MazeGame::drawHud(Ui::Renderer& tft) const {
-    tft.fillRect(0, 42, SCREEN_WIDTH, 18, Ui::bg());
+    tft.fillRect(0, 42, GAME_CANVAS_WIDTH, 18, Ui::bg());
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(MC_DATUM);
     char hud[48];
@@ -257,7 +257,7 @@ void MazeGame::drawHud(Ui::Renderer& tft) const {
                  static_cast<unsigned>(levelIndex_ + 1), static_cast<unsigned>(MazeData::COUNT),
                  static_cast<unsigned>(moves_));
     }
-    tft.drawString(hud, SCREEN_WIDTH / 2, 50, 1);
+    tft.drawString(hud, GAME_CANVAS_WIDTH / 2, 50, 1);
 }
 
 void MazeGame::drawMazeCell(Ui::Renderer& tft, uint8_t col, uint8_t row) const {
@@ -314,8 +314,8 @@ void MazeGame::render(AppContext& host) {
         tft.drawRoundRect(58, 86, 204, 58, 8, Ui::success());
         tft.setTextColor(Ui::success(), Ui::panel());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Maze solved!", SCREEN_WIDTH / 2, 106, 4);
-        tft.drawString(levelIndex_ + 1 < MazeData::COUNT ? "Tap for next maze" : "Tap to play again", SCREEN_WIDTH / 2, 132, 2);
+        tft.drawString("Maze solved!", GAME_CANVAS_WIDTH / 2, 106, 4);
+        tft.drawString(levelIndex_ + 1 < MazeData::COUNT ? "Tap for next maze" : "Tap to play again", GAME_CANVAS_WIDTH / 2, 132, 2);
         tft.setTextDatum(TL_DATUM);
     }
 }

--- a/src/games/MemoryGame.cpp
+++ b/src/games/MemoryGame.cpp
@@ -70,13 +70,13 @@ void MemoryGame::newRound(AppContext& host) {
 Rect MemoryGame::cardRect(uint8_t index) const {
     const uint8_t totalCols = config_.cols;
     const uint8_t totalRows = config_.rows;
-    const int16_t maxCellW = (SCREEN_WIDTH - 20 - GRID_GAP * (totalCols - 1)) / totalCols;
-    const int16_t maxCellH = (SCREEN_HEIGHT - GRID_TOP - 4 - GRID_GAP * (totalRows - 1)) / totalRows;
+    const int16_t maxCellW = (GAME_CANVAS_WIDTH - 20 - GRID_GAP * (totalCols - 1)) / totalCols;
+    const int16_t maxCellH = (GAME_CANVAS_HEIGHT - GRID_TOP - 4 - GRID_GAP * (totalRows - 1)) / totalRows;
     const int16_t cell = min<int16_t>(maxCellW, maxCellH);
     const int16_t gridW = totalCols * cell + (totalCols - 1) * GRID_GAP;
     const int16_t gridH = totalRows * cell + (totalRows - 1) * GRID_GAP;
-    const int16_t startX = (SCREEN_WIDTH - gridW) / 2;
-    const int16_t startY = GRID_TOP + (SCREEN_HEIGHT - GRID_TOP - gridH) / 2;
+    const int16_t startX = (GAME_CANVAS_WIDTH - gridW) / 2;
+    const int16_t startY = GRID_TOP + (GAME_CANVAS_HEIGHT - GRID_TOP - gridH) / 2;
     const uint8_t row = index / totalCols;
     const uint8_t col = index % totalCols;
     return Rect{static_cast<int16_t>(startX + col * (cell + GRID_GAP)), static_cast<int16_t>(startY + row * (cell + GRID_GAP)), cell, cell};
@@ -205,8 +205,8 @@ void MemoryGame::render(AppContext& host) {
         tft.drawRoundRect(50, 92, 220, 56, 8, Ui::success());
         tft.setTextColor(Ui::success(), Ui::panel());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("You matched all!", SCREEN_WIDTH / 2, 112, 4);
-        tft.drawString("Tap to play again", SCREEN_WIDTH / 2, 136, 2);
+        tft.drawString("You matched all!", GAME_CANVAS_WIDTH / 2, 112, 4);
+        tft.drawString("Tap to play again", GAME_CANVAS_WIDTH / 2, 136, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/MicrokuGame.cpp
+++ b/src/games/MicrokuGame.cpp
@@ -119,14 +119,14 @@ void MicrokuGame::loadStage(uint8_t stageIndex) {
 Rect MicrokuGame::cellRect(uint8_t row, uint8_t col) const {
     const int16_t cell = size_ == 6 ? 23 : (size_ == 4 ? 32 : 54);
     const int16_t gridSize = cell * size_;
-    const int16_t startX = (SCREEN_WIDTH - gridSize) / 2;
+    const int16_t startX = (GAME_CANVAS_WIDTH - gridSize) / 2;
     const int16_t startY = 58;
     return Rect{static_cast<int16_t>(startX + col * cell), static_cast<int16_t>(startY + row * cell), cell, cell};
 }
 
 Rect MicrokuGame::numberRect(uint8_t value) const {
     const int16_t gap = 4;
-    const int16_t w = (SCREEN_WIDTH - 16 - gap * (size_ - 1)) / size_;
+    const int16_t w = (GAME_CANVAS_WIDTH - 16 - gap * (size_ - 1)) / size_;
     return Rect{static_cast<int16_t>(8 + (value - 1) * (w + gap)), 205, w, 30};
 }
 
@@ -237,7 +237,7 @@ void MicrokuGame::render(AppContext& host) {
     tft.setTextDatum(TL_DATUM);
     tft.drawString(String("Board ") + size_ + "x" + size_, 8, 34, 2);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(bestSize_ > 0 ? String("Best ") + bestSize_ + "x" + bestSize_ : "Best --", SCREEN_WIDTH - 8, 34, 2);
+    tft.drawString(bestSize_ > 0 ? String("Best ") + bestSize_ + "x" + bestSize_ : "Best --", GAME_CANVAS_WIDTH - 8, 34, 2);
     Ui::drawLabel(tft, Rect{24, 46, 272, 16}, message_, message_ == "Try again" ? RED : Ui::text(), 1, Align::Center);
 
     for (uint8_t row = 0; row < size_; ++row) {
@@ -283,8 +283,8 @@ void MicrokuGame::render(AppContext& host) {
         tft.drawRoundRect(62, 93, 196, 48, 8, Ui::success());
         tft.setTextColor(Ui::success(), Ui::panel());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Microku solved", SCREEN_WIDTH / 2, 111, 4);
-        tft.drawString(stageIndex_ + 1 < STAGE_COUNT ? "Tap next" : "Tap restart", SCREEN_WIDTH / 2, 134, 2);
+        tft.drawString("Microku solved", GAME_CANVAS_WIDTH / 2, 111, 4);
+        tft.drawString(stageIndex_ + 1 < STAGE_COUNT ? "Tap next" : "Tap restart", GAME_CANVAS_WIDTH / 2, 134, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/MoneyGame.cpp
+++ b/src/games/MoneyGame.cpp
@@ -416,7 +416,7 @@ void MoneyGame::drawMake(Ui::Renderer& tft) const {
     drawCoinGroup(tft, Rect{18, 82, 284, 54}, makeCoins_, makeCount_);
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(MC_DATUM);
-    tft.drawString(String("Make ") + centsText(target_) + "   Built " + centsText(built_), SCREEN_WIDTH / 2, 70, 2);
+    tft.drawString(String("Make ") + centsText(target_) + "   Built " + centsText(built_), GAME_CANVAS_WIDTH / 2, 70, 2);
 
     const uint8_t allowed = allowedCoinCount();
     for (uint8_t i = 0; i < allowed; ++i) {
@@ -455,8 +455,8 @@ void MoneyGame::render(AppContext& host) {
     tft.drawString(String("Level ") + level(), 8, 35, 2);
     tft.drawString(String("Score ") + score_, 8, 51, 1);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Streak ") + streak_, SCREEN_WIDTH - 8, 35, 2);
-    tft.drawString(String("Best ") + bestStreak_, SCREEN_WIDTH - 8, 51, 1);
+    tft.drawString(String("Streak ") + streak_, GAME_CANVAS_WIDTH - 8, 35, 2);
+    tft.drawString(String("Best ") + bestStreak_, GAME_CANVAS_WIDTH - 8, 51, 1);
 
     if (mode_ != Mode::Make) {
         Ui::drawLabel(tft, Rect{8, 58, 304, 12}, modeName(), Ui::muted(), 1, Align::Center);
@@ -473,8 +473,8 @@ void MoneyGame::render(AppContext& host) {
         tft.drawRoundRect(32, 82, 256, 56, 6, Ui::outline());
         tft.setTextColor(Ui::text(), Ui::surface());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(String("Price ") + centsText(price_), SCREEN_WIDTH / 2, 99, 2);
-        tft.drawString(String("Pay ") + centsText(paid_), SCREEN_WIDTH / 2, 123, 2);
+        tft.drawString(String("Price ") + centsText(price_), GAME_CANVAS_WIDTH / 2, 99, 2);
+        tft.drawString(String("Pay ") + centsText(paid_), GAME_CANVAS_WIDTH / 2, 123, 2);
         drawOptions(tft);
     }
 
@@ -485,7 +485,7 @@ void MoneyGame::render(AppContext& host) {
     } else if (flashIndex_ >= 0) {
         tft.setTextColor(RED, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Try again", SCREEN_WIDTH / 2, 226, 2);
+        tft.drawString("Try again", GAME_CANVAS_WIDTH / 2, 226, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/MultiplicationGame.cpp
+++ b/src/games/MultiplicationGame.cpp
@@ -183,15 +183,15 @@ void MultiplicationGame::render(AppContext& host) {
     tft.drawString(String("Level ") + level(), 10, 35, 2);
     tft.drawString(String("Score ") + score_, 10, 52, 1);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Streak ") + streak_, SCREEN_WIDTH - 10, 35, 2);
-    tft.drawString(bestStreak_ > 0 ? String("Best ") + bestStreak_ : "Best --", SCREEN_WIDTH - 10, 52, 1);
+    tft.drawString(String("Streak ") + streak_, GAME_CANVAS_WIDTH - 10, 35, 2);
+    tft.drawString(bestStreak_ > 0 ? String("Best ") + bestStreak_ : "Best --", GAME_CANVAS_WIDTH - 10, 52, 1);
 
     const String equation = String(left_) + " x " + right_ + " = ?";
     tft.fillRoundRect(26, 76, 268, 54, 8, Ui::panel());
     tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
     tft.setTextColor(Ui::text(), Ui::panel());
     tft.setTextDatum(MC_DATUM);
-    tft.drawString(equation, SCREEN_WIDTH / 2, 103, 4);
+    tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
 
     for (uint8_t i = 0; i < 4; ++i) {
         uint16_t fill = BLUE;
@@ -211,11 +211,11 @@ void MultiplicationGame::render(AppContext& host) {
     if (answered_) {
         tft.setTextColor(selected_ == correctButton_ ? GREEN : RED, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is correct - tap next", SCREEN_WIDTH / 2, 136, 2);
+        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Green is correct - tap next", GAME_CANVAS_WIDTH / 2, 136, 2);
     } else {
         tft.setTextColor(YELLOW, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Tap the product", SCREEN_WIDTH / 2, 136, 2);
+        tft.drawString("Tap the product", GAME_CANVAS_WIDTH / 2, 136, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/NumberLineGame.cpp
+++ b/src/games/NumberLineGame.cpp
@@ -115,7 +115,7 @@ void NumberLineGame::render(AppContext& host) {
 
     tft.setTextDatum(TR_DATUM);
     tft.setTextColor(Ui::text(), Ui::bg());
-    tft.drawString(String(score_) + "/" + rounds_, SCREEN_WIDTH - 8, 34, 2);
+    tft.drawString(String(score_) + "/" + rounds_, GAME_CANVAS_WIDTH - 8, 34, 2);
 
     // Equation display
     const uint8_t curPos = (phase_ == Phase::Pause) ? n1_
@@ -125,18 +125,18 @@ void NumberLineGame::render(AppContext& host) {
     tft.setTextDatum(MC_DATUM);
     if (phase_ == Phase::Feedback && lastCorrect_) {
         tft.setTextColor(Ui::success(), Ui::bg());
-        tft.drawString(String(n1_) + (isAdd_ ? " + " : " - ") + n2_ + " = " + answer, SCREEN_WIDTH/2, 52, 4);
+        tft.drawString(String(n1_) + (isAdd_ ? " + " : " - ") + n2_ + " = " + answer, GAME_CANVAS_WIDTH/2, 52, 4);
     } else {
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString(String(n1_) + (isAdd_ ? " + " : " - ") + n2_ + " = ?", SCREEN_WIDTH/2, 52, 4);
+        tft.drawString(String(n1_) + (isAdd_ ? " + " : " - ") + n2_ + " = ?", GAME_CANVAS_WIDTH/2, 52, 4);
     }
 
     // Instruction
     tft.setTextColor(Ui::muted(), Ui::bg());
     if (phase_ == Phase::Pause) {
-        tft.drawString(isAdd_ ? "Watch the frog jump right!" : "Watch the frog jump left!", SCREEN_WIDTH/2, 78, 2);
+        tft.drawString(isAdd_ ? "Watch the frog jump right!" : "Watch the frog jump left!", GAME_CANVAS_WIDTH/2, 78, 2);
     } else if (phase_ == Phase::Jumping) {
-        tft.drawString(String("Jump ") + animStep_ + " of " + n2_, SCREEN_WIDTH/2, 78, 2);
+        tft.drawString(String("Jump ") + animStep_ + " of " + n2_, GAME_CANVAS_WIDTH/2, 78, 2);
     }
 
     // Jump arcs (show previous jumps)

--- a/src/games/ObjectAddGame.cpp
+++ b/src/games/ObjectAddGame.cpp
@@ -195,7 +195,7 @@ void ObjectAddGame::render(AppContext& host) {
     char scoreText[16];
     snprintf(scoreText, sizeof(scoreText), "%u/%u",
              static_cast<unsigned>(score_), static_cast<unsigned>(rounds_));
-    tft.drawString(scoreText, SCREEN_WIDTH - 8, 34, 2);
+    tft.drawString(scoreText, GAME_CANVAS_WIDTH - 8, 34, 2);
 
     const char* shapeName = (shape_ % 4 == 0) ? "circles" :
                             (shape_ % 4 == 1) ? "squares" :
@@ -273,13 +273,13 @@ void ObjectAddGame::render(AppContext& host) {
     // "= ?" while animating, buttons when question/feedback
     if (phase_ == Phase::Showing || phase_ == Phase::AnimIn || phase_ == Phase::Flashing) {
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("= ?", SCREEN_WIDTH / 2, 162, 4);
+        tft.drawString("= ?", GAME_CANVAS_WIDTH / 2, 162, 4);
     }
     if (phase_ == Phase::Question || phase_ == Phase::Feedback) {
         if (op_ == OpType::Subtract) {
             tft.setTextColor(Ui::muted(), Ui::bg());
             tft.setTextDatum(MC_DATUM);
-            tft.drawString("How many are left?", SCREEN_WIDTH / 2, 162, 1);
+            tft.drawString("How many are left?", GAME_CANVAS_WIDTH / 2, 162, 1);
         }
         for (uint8_t i = 0; i < 4; ++i) {
             uint16_t fill = OBJ_BTN;

--- a/src/games/OddOneOutGame.cpp
+++ b/src/games/OddOneOutGame.cpp
@@ -184,7 +184,7 @@ void OddOneOutGame::render(AppContext& host) {
     tft.setTextDatum(TL_DATUM);
     tft.drawString(String("Score ") + score_, 10, 35, 2);
     tft.setTextDatum(TR_DATUM);
-    tft.drawString(String("Best ") + bestStreak_, SCREEN_WIDTH - 8, 35, 2);
+    tft.drawString(String("Best ") + bestStreak_, GAME_CANVAS_WIDTH - 8, 35, 2);
     Ui::drawLabel(tft, Rect{8, 52, 304, 16}, "Tap the one that is different", Ui::muted(), 1, Align::Center);
 
     for (uint8_t i = 0; i < 9; ++i) {
@@ -196,7 +196,7 @@ void OddOneOutGame::render(AppContext& host) {
         tft.fillRoundRect(84, 196, 152, 30, 8, color);
         tft.setTextColor(TFT_BLACK, color);
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(flashCorrect_ ? "Correct" : "Try again", SCREEN_WIDTH / 2, 211, 2);
+        tft.drawString(flashCorrect_ ? "Correct" : "Try again", GAME_CANVAS_WIDTH / 2, 211, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/PercentCircleGame.cpp
+++ b/src/games/PercentCircleGame.cpp
@@ -178,14 +178,33 @@ void PercentCircleGame::markWrong() {
 }
 
 void PercentCircleGame::fillSlice(Ui::Renderer& tft, int16_t cx, int16_t cy, int16_t radius, float startAngle, float endAngle, uint16_t color) const {
+    /* Pre-correct the radius per axis so the wedge lands on the circle that
+     * fillCircle actually drew.
+     *
+     * The renderer may scale x and y by different amounts -- on a 480x320
+     * panel the game canvas stretches 1.5 across and 1.333 down. fillCircle
+     * takes a single radius and uses the average of the two, so it stays a
+     * circle. These wedge points are computed here in canvas space and then
+     * scaled independently, so without this they land on an ellipse instead:
+     * the fill bulges past the rim at the sides and falls short at the top and
+     * bottom, which is what made the arcs look wrong rather than merely
+     * mis-sized. Dividing by each axis and multiplying by the average puts
+     * both back on the same circle. On a board where the scales are equal --
+     * every board today -- avg/sx and avg/sy are 1 and this is the old code. */
+    const float avg = tft.imageScale();
+    const float sxAxis = tft.imageScaleX();
+    const float syAxis = tft.imageScaleY();
+    const float rx = (sxAxis > 0.0f) ? radius * avg / sxAxis : static_cast<float>(radius);
+    const float ry = (syAxis > 0.0f) ? radius * avg / syAxis : static_cast<float>(radius);
+
     const float step = PI / 24.0f;
     float angle = startAngle;
     while (angle < endAngle) {
         const float next = min(endAngle, angle + step);
-        const int16_t x1 = cx + static_cast<int16_t>(cosf(angle) * radius);
-        const int16_t y1 = cy + static_cast<int16_t>(sinf(angle) * radius);
-        const int16_t x2 = cx + static_cast<int16_t>(cosf(next) * radius);
-        const int16_t y2 = cy + static_cast<int16_t>(sinf(next) * radius);
+        const int16_t x1 = cx + static_cast<int16_t>(cosf(angle) * rx);
+        const int16_t y1 = cy + static_cast<int16_t>(sinf(angle) * ry);
+        const int16_t x2 = cx + static_cast<int16_t>(cosf(next) * rx);
+        const int16_t y2 = cy + static_cast<int16_t>(sinf(next) * ry);
         tft.fillTriangle(cx, cy, x1, y1, x2, y2, color);
         angle = next;
     }

--- a/src/games/PercentCircleGame.cpp
+++ b/src/games/PercentCircleGame.cpp
@@ -353,7 +353,7 @@ void PercentCircleGame::render(AppContext& host) {
         host.drawTopBar(title());
     }
 
-    tft.fillRect(0, 48, SCREEN_WIDTH, 34, Ui::bg());
+    tft.fillRect(0, 48, GAME_CANVAS_WIDTH, 34, Ui::bg());
     tft.setTextColor(Ui::muted(), Ui::bg());
     tft.setTextDatum(MC_DATUM);
     tft.drawString(promptBuffer_, 200, 60, 4);
@@ -369,7 +369,7 @@ void PercentCircleGame::render(AppContext& host) {
 
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(TL_DATUM);
-    tft.fillRect(0, 222, SCREEN_WIDTH, 18, Ui::bg());
+    tft.fillRect(0, 222, GAME_CANVAS_WIDTH, 18, Ui::bg());
     char scoreStr[48];
     snprintf(scoreStr, sizeof(scoreStr), "Score: %u  Streak: %u  Lvl: %u", score_, streak_, level());
     tft.drawString(scoreStr, 8, 226, 1);

--- a/src/games/ScoresGame.cpp
+++ b/src/games/ScoresGame.cpp
@@ -11,8 +11,29 @@ void ScoresGame::begin(GameHost& host) {
     markFullDirty();
 }
 
-Rect ScoresGame::rowRect(uint8_t row) const {
-    return Rect{8, static_cast<int16_t>(56 + row * 30), 304, 28};
+namespace {
+/* The footer sits a fixed distance off the bottom; rows fill what is left
+ * between the tab baseline and it. */
+constexpr int16_t SCORES_ROWS_TOP = 56;
+constexpr int16_t SCORES_FOOTER_H = 32;
+constexpr int16_t SCORES_MARGIN = 8;
+}  // namespace
+
+/* Rows share the height between the tabs and the footer, but never get
+ * tighter than the 30px pitch this screen was designed with -- so 320x240
+ * yields exactly the old 56 + row * 30, and a taller panel spends its extra
+ * height on taller rows, which are also easier to hit. */
+Rect ScoresGame::rowRect(uint8_t row, int16_t screenW, int16_t screenH) const {
+    const int16_t footerY = static_cast<int16_t>(screenH - SCORES_FOOTER_H);
+    const int16_t avail = static_cast<int16_t>(footerY - SCORES_ROWS_TOP - 4);
+    int16_t pitch = static_cast<int16_t>(avail / ROWS_PER_PAGE);
+    if (pitch < 30) {
+        pitch = 30;
+    }
+    return Rect{SCORES_MARGIN,
+                static_cast<int16_t>(SCORES_ROWS_TOP + row * pitch),
+                static_cast<int16_t>(screenW - SCORES_MARGIN * 2),
+                static_cast<int16_t>(pitch - 2)};
 }
 Rect ScoresGame::mineTabRect() const {
     return Rect{8, 34, 64, 18};
@@ -20,9 +41,24 @@ Rect ScoresGame::mineTabRect() const {
 Rect ScoresGame::deviceTabRect() const {
     return Rect{80, 34, 80, 18};
 }
-Rect ScoresGame::prevRect()   const { return Rect{8, 208, 88, 26}; }
-Rect ScoresGame::switchRect() const { return Rect{104, 208, 112, 26}; }
-Rect ScoresGame::nextRect()   const { return Rect{224, 208, 88, 26}; }
+
+/* Prev and Next hug the edges, Switch is centred between them. The fractions
+ * are the old widths over 320, so the original board keeps 88 / 112 / 88 at
+ * x = 8 / 104 / 224 exactly. */
+Rect ScoresGame::prevRect(int16_t screenW, int16_t screenH) const {
+    return Rect{SCORES_MARGIN, static_cast<int16_t>(screenH - SCORES_FOOTER_H),
+                static_cast<int16_t>(screenW * 0.275f), 26};
+}
+Rect ScoresGame::switchRect(int16_t screenW, int16_t screenH) const {
+    const int16_t w = static_cast<int16_t>(screenW * 0.35f);
+    return Rect{static_cast<int16_t>((screenW - w) / 2),
+                static_cast<int16_t>(screenH - SCORES_FOOTER_H), w, 26};
+}
+Rect ScoresGame::nextRect(int16_t screenW, int16_t screenH) const {
+    const int16_t w = static_cast<int16_t>(screenW * 0.275f);
+    return Rect{static_cast<int16_t>(screenW - SCORES_MARGIN - w),
+                static_cast<int16_t>(screenH - SCORES_FOOTER_H), w, 26};
+}
 
 uint8_t ScoresGame::playedCount(GameHost& host) const {
     uint8_t n = 0;
@@ -104,6 +140,9 @@ void ScoresGame::update(GameHost& host, const TouchPoint& touch) {
         return;
     }
 
+    const int16_t sW = static_cast<int16_t>(host.display().width());
+    const int16_t sH = static_cast<int16_t>(host.display().height());
+
     // Tab switching
     if (mineTabRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
         if (activeTab_ != Tab::Mine) {
@@ -130,25 +169,25 @@ void ScoresGame::update(GameHost& host, const TouchPoint& touch) {
         const uint8_t total = playedCount(host);
         const uint8_t pages = max<uint8_t>(1, (total + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE);
 
-        if (prevRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ > 0) {
+        if (prevRect(sW, sH).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ > 0) {
             --page_; markFullDirty(); return;
         }
-        if (nextRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ + 1 < pages) {
+        if (nextRect(sW, sH).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ + 1 < pages) {
             ++page_; markFullDirty(); return;
         }
     } else {
         const uint8_t total = deviceRowCount_;
         const uint8_t pages = max<uint8_t>(1, (total + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE);
 
-        if (prevRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ > 0) {
+        if (prevRect(sW, sH).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ > 0) {
             --page_; markFullDirty(); return;
         }
-        if (nextRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ + 1 < pages) {
+        if (nextRect(sW, sH).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && page_ + 1 < pages) {
             ++page_; markFullDirty(); return;
         }
     }
 
-    if (switchRect().contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+    if (switchRect(sW, sH).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
         host.openProfiles();
         return;
     }
@@ -157,6 +196,8 @@ void ScoresGame::update(GameHost& host, const TouchPoint& touch) {
 void ScoresGame::render(GameHost& host) {
     Board& board = host.board();
     Ui::Renderer& tft = host.display();
+    const int16_t sW = static_cast<int16_t>(tft.width());
+    const int16_t sH = static_cast<int16_t>(tft.height());
     Ui::clear(tft);
     Ui::drawTopBar(host.board(), title());
 
@@ -186,7 +227,7 @@ void ScoresGame::render(GameHost& host) {
 
         const uint8_t total = playedCount(host);
         if (total == 0) {
-            Ui::drawLabel(tft, Rect{20, 110, 280, 20},
+            Ui::drawLabel(tft, Rect{static_cast<int16_t>(sW * 0.0625f), static_cast<int16_t>(sH * 0.458f), static_cast<int16_t>(sW * 0.875f), 20},
                           "No games played yet", Ui::muted(), 2, Align::Center);
         }
 
@@ -200,7 +241,7 @@ void ScoresGame::render(GameHost& host) {
             if (score == nullptr || !board.hasScore(score->bestKey)) continue;
             if (seen++ < first) continue;
 
-            const Rect r = rowRect(drawn++);
+            const Rect r = rowRect(drawn++, sW, sH);
             tft.fillRoundRect(r.x, r.y, r.w, r.h, 4, Ui::surface());
             tft.drawRoundRect(r.x, r.y, r.w, r.h, 4, Ui::outline());
 
@@ -230,10 +271,10 @@ void ScoresGame::render(GameHost& host) {
         const uint8_t pages = max<uint8_t>(1, (total + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE);
         const bool canPrev = page_ > 0;
         const bool canNext = page_ + 1 < pages;
-        Ui::drawPagerButton(tft, prevRect(), "Prev", canPrev);
-        Ui::drawButton(tft, switchRect(), "Switch player", Ui::rgb(36, 132, 204),
+        Ui::drawPagerButton(tft, prevRect(sW, sH), "Prev", canPrev);
+        Ui::drawButton(tft, switchRect(sW, sH), "Switch player", Ui::rgb(36, 132, 204),
                        Ui::outline(), TFT_WHITE, false, 2);
-        Ui::drawPagerButton(tft, nextRect(), "Next", canNext);
+        Ui::drawPagerButton(tft, nextRect(sW, sH), "Next", canNext);
     } else {
         // Device tab: device-wide best
         const uint8_t playerCount = board.playerCount();
@@ -249,7 +290,7 @@ void ScoresGame::render(GameHost& host) {
 
         const uint8_t total = deviceRowCount_;
         if (total == 0) {
-            Ui::drawLabel(tft, Rect{20, 110, 280, 20},
+            Ui::drawLabel(tft, Rect{static_cast<int16_t>(sW * 0.0625f), static_cast<int16_t>(sH * 0.458f), static_cast<int16_t>(sW * 0.875f), 20},
                           "No games played yet", Ui::muted(), 2, Align::Center);
         } else {
             uint8_t drawn = 0;
@@ -261,7 +302,7 @@ void ScoresGame::render(GameHost& host) {
                     continue;
                 }
 
-                const Rect r = rowRect(drawn++);
+                const Rect r = rowRect(drawn++, sW, sH);
                 tft.fillRoundRect(r.x, r.y, r.w, r.h, 4, Ui::surface());
                 tft.drawRoundRect(r.x, r.y, r.w, r.h, 4, Ui::outline());
 
@@ -292,10 +333,10 @@ void ScoresGame::render(GameHost& host) {
         const uint8_t pages = max<uint8_t>(1, (total + ROWS_PER_PAGE - 1) / ROWS_PER_PAGE);
         const bool canPrev = page_ > 0;
         const bool canNext = page_ + 1 < pages;
-        Ui::drawPagerButton(tft, prevRect(), "Prev", canPrev);
-        Ui::drawButton(tft, switchRect(), "Switch player", Ui::rgb(36, 132, 204),
+        Ui::drawPagerButton(tft, prevRect(sW, sH), "Prev", canPrev);
+        Ui::drawButton(tft, switchRect(sW, sH), "Switch player", Ui::rgb(36, 132, 204),
                        Ui::outline(), TFT_WHITE, false, 2);
-        Ui::drawPagerButton(tft, nextRect(), "Next", canNext);
+        Ui::drawPagerButton(tft, nextRect(sW, sH), "Next", canNext);
     }
 
     tft.setTextDatum(TL_DATUM);

--- a/src/games/ScoresGame.h
+++ b/src/games/ScoresGame.h
@@ -34,12 +34,18 @@ private:
         uint8_t holder;  // profile index, 0xFF = nobody
     };
 
-    Rect rowRect(uint8_t row) const;
+    /* Every rect is measured against the live panel. This screen had not one
+     * reference to the panel's size -- 302 lines of literals describing a
+     * 320x240 board -- so on anything larger it drew itself into the top-left
+     * corner and left the rest empty. The formulas below reproduce the old
+     * numbers exactly at 320x240, so the board this was written for is
+     * unchanged. */
+    Rect rowRect(uint8_t row, int16_t screenW, int16_t screenH) const;
     Rect mineTabRect() const;
     Rect deviceTabRect() const;
-    Rect prevRect() const;
-    Rect nextRect() const;
-    Rect switchRect() const;
+    Rect prevRect(int16_t screenW, int16_t screenH) const;
+    Rect nextRect(int16_t screenW, int16_t screenH) const;
+    Rect switchRect(int16_t screenW, int16_t screenH) const;
     uint8_t playedCount(GameHost& host) const;
     void buildDeviceTable(GameHost& host);
     uint8_t deviceRowCount() const;

--- a/src/games/SequenceGame.cpp
+++ b/src/games/SequenceGame.cpp
@@ -160,7 +160,7 @@ void SequenceGame::render(AppContext& host) {
     tft.setTextDatum(TR_DATUM);
     char scoreBuf[16];
     snprintf(scoreBuf, sizeof(scoreBuf), "%u/%u", score_, rounds_);
-    tft.drawString(scoreBuf, SCREEN_WIDTH - 8, 34, 2);
+    tft.drawString(scoreBuf, GAME_CANVAS_WIDTH - 8, 34, 2);
 
     // Question text
     tft.setTextDatum(MC_DATUM);
@@ -168,7 +168,7 @@ void SequenceGame::render(AppContext& host) {
     const char* qtypeStr = qtype_ == QType::After ? "AFTER" : "BEFORE";
     char prompt[32];
     snprintf(prompt, sizeof(prompt), "What comes %s:", qtypeStr);
-    tft.drawString(prompt, SCREEN_WIDTH / 2, 70, 2);
+    tft.drawString(prompt, GAME_CANVAS_WIDTH / 2, 70, 2);
 
     // Subject highlight box
     tft.fillRoundRect(60, 84, 200, 52, 8, Ui::surface());
@@ -178,11 +178,11 @@ void SequenceGame::render(AppContext& host) {
     // Fit long names
     uint8_t subjectFont = 4;
     if (tft.textWidth(subj, 4) > 180) subjectFont = 2;
-    tft.drawString(subj, SCREEN_WIDTH / 2, 110, subjectFont);
+    tft.drawString(subj, GAME_CANVAS_WIDTH / 2, 110, subjectFont);
 
     // "?" label
     tft.setTextColor(Ui::text(), Ui::bg());
-    tft.drawString("?", SCREEN_WIDTH / 2, 140, 2);
+    tft.drawString("?", GAME_CANVAS_WIDTH / 2, 140, 2);
 
     // Answer tiles
     for (uint8_t i = 0; i < 4; ++i) {

--- a/src/games/SettingsGame.cpp
+++ b/src/games/SettingsGame.cpp
@@ -39,10 +39,10 @@ void SettingsGame::begin(GameHost& host) {
  * -- 320 / 4 is exact, 320 / 3 was not, and the fudge belongs in one place
  * rather than in each tab's own accessor. */
 Rect SettingsGame::tabRect(uint8_t index) const {
-    const int16_t w = static_cast<int16_t>(SCREEN_WIDTH / TAB_COUNT);
+    const int16_t w = static_cast<int16_t>(panelW_ / TAB_COUNT);
     const int16_t x = static_cast<int16_t>(index * w);
     const int16_t last = index + 1 >= TAB_COUNT;
-    return Rect{x, 30, last ? static_cast<int16_t>(SCREEN_WIDTH - x) : w, 22};
+    return Rect{x, 30, last ? static_cast<int16_t>(panelW_ - x) : w, 22};
 }
 
 Rect SettingsGame::tabRectFor(Tab tab) const {
@@ -53,7 +53,17 @@ bool SettingsGame::isAdmin(Board& board) const {
     return board.isAdminProfile(board.activeProfile());
 }
 
+/* Read the panel once per entry point. Every rect helper on this screen is
+ * shared between hit testing and drawing, so they have to agree; caching it
+ * here is what lets them, and picks up a rotation without any of them
+ * knowing about it. */
+void SettingsGame::syncPanel(GameHost& host) {
+    panelW_ = static_cast<int16_t>(host.display().width());
+    panelH_ = static_cast<int16_t>(host.display().height());
+}
+
 void SettingsGame::update(GameHost& host, const TouchPoint& touch) {
+    syncPanel(host);
     if (!touch.justPressed) return;
 
     Board& board = host.board();
@@ -244,6 +254,7 @@ void SettingsGame::update(GameHost& host, const TouchPoint& touch) {
 }
 
 void SettingsGame::render(GameHost& host) {
+    syncPanel(host);
     Ui::Renderer& tft = host.display();
     Ui::clear(tft);
     Ui::drawTopBar(host.board(), title());
@@ -267,7 +278,7 @@ void SettingsGame::render(GameHost& host) {
     for (uint8_t i = 0; i < TAB_COUNT; ++i) {
         Ui::drawTab(tft, tabRect(i), TAB_LABELS[i], static_cast<Tab>(i) == tab_);
     }
-    Ui::drawTabBaseline(tft, 52, 0, SCREEN_WIDTH, tabRectFor(tab_));
+    Ui::drawTabBaseline(tft, 52, 0, panelW_, tabRectFor(tab_));
 
     switch (tab_) {
         case Tab::Device: renderDeviceTab(host); break;

--- a/src/games/SettingsGame.h
+++ b/src/games/SettingsGame.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "BoardConfig.h"
 #include "engine/Game.h"
 #include "ui/Ui.h"
 
@@ -38,6 +39,26 @@ private:
      * a change to TAB_COUNT and nothing else -- the previous version wrote
      * SCREEN_WIDTH / 3 out three times with the last one fudged to absorb the
      * rounding, which is a thing to get wrong once per tab. */
+    /* The live panel, refreshed at the top of update() and render().
+     *
+     * The rect helpers below are shared by hit testing and drawing -- which is
+     * what keeps a control's target under its glyph -- so they must all agree
+     * about the panel. Passing two arguments through forty call sites would
+     * have said the same thing forty times and given forty chances to say it
+     * differently; caching it once per frame says it in one place. Seeded with
+     * the board's landscape size so the helpers are sane before the first
+     * paint, and refreshed on entry so a rotation is picked up. */
+    int16_t panelW_ = SCREEN_WIDTH;
+    int16_t panelH_ = SCREEN_HEIGHT;
+    void syncPanel(GameHost& host);
+
+    /* Shared grid, measured against the cached panel. Two columns for the
+     * paired controls, one full-width row for the rest. */
+    int16_t gridRowPitch() const;
+    int16_t gridRowHeight() const;
+    Rect gridCell(uint8_t row, uint8_t col) const;   // col 0/1
+    Rect gridWide(uint8_t row) const;                // spans both columns
+
     Rect tabRect(uint8_t index) const;
     Rect tabRectFor(Tab tab) const;
     Rect changePinRect() const;

--- a/src/games/SettingsPanels.cpp
+++ b/src/games/SettingsPanels.cpp
@@ -24,15 +24,72 @@
  * Nearby is deliberately next to Beacon's row rather than beside it: it does
  * nothing unless Beacon is on, and reading downwards is the order you have to
  * turn them on in. */
-Rect SettingsGame::themeRect()  const { return Rect{8,    58, 144, 30}; }
-Rect SettingsGame::layoutRect() const { return Rect{164,  58, 144, 30}; }
-Rect SettingsGame::lightRect()  const { return Rect{8,    92, 144, 30}; }
-Rect SettingsGame::bleRect()    const { return Rect{164,  92, 144, 30}; }
-Rect SettingsGame::wifiRect()   const { return Rect{8,   126, 144, 30}; }
-Rect SettingsGame::ntpSyncRect() const { return Rect{164, 126, 144, 30}; }
-Rect SettingsGame::nearbyRect() const { return Rect{8,   160, 144, 30}; }
-Rect SettingsGame::resetRect()  const { return Rect{164, 160, 144, 30}; }
-Rect SettingsGame::brightRect() const { return Rect{8,   204, 304, 32}; }
+/* ---- the shared grid -------------------------------------------------
+ *
+ * Every control on every tab sits on one grid, so a taller or wider panel
+ * moves them all together rather than one tab at a time. The arithmetic is
+ * chosen to reproduce the original 320x240 numbers exactly: at that size the
+ * pitch works out to 34 and the columns to 144 wide at x = 8 and x = 164,
+ * which is where they have always been.
+ *
+ * On a bigger panel the rows spread and the buttons grow with them, capped so
+ * a very tall screen does not turn four controls into four slabs. Larger
+ * targets are the point on this board -- it is here for players who want a
+ * plainer screen and an easier thing to hit. */
+namespace {
+constexpr int16_t SETTINGS_MARGIN = 8;
+constexpr int16_t SETTINGS_GAP = 12;
+constexpr int16_t SETTINGS_TOP = 58;
+constexpr int16_t SETTINGS_BOTTOM_RESERVE = 36;   // the brightness bar
+constexpr int16_t SETTINGS_MIN_PITCH = 34;
+constexpr int16_t SETTINGS_MAX_ROW_H = 44;
+}  // namespace
+
+int16_t SettingsGame::gridRowPitch() const {
+    const int16_t avail = static_cast<int16_t>(
+        panelH_ - SETTINGS_BOTTOM_RESERVE - SETTINGS_MARGIN - SETTINGS_TOP);
+    const int16_t pitch = static_cast<int16_t>(avail / 4);
+    return pitch < SETTINGS_MIN_PITCH ? SETTINGS_MIN_PITCH : pitch;
+}
+
+int16_t SettingsGame::gridRowHeight() const {
+    const int16_t h = static_cast<int16_t>(gridRowPitch() - 4);
+    return h > SETTINGS_MAX_ROW_H ? SETTINGS_MAX_ROW_H : h;
+}
+
+Rect SettingsGame::gridCell(uint8_t row, uint8_t col) const {
+    const int16_t colW = static_cast<int16_t>(
+        (panelW_ - SETTINGS_MARGIN - SETTINGS_GAP - SETTINGS_GAP) / 2);
+    const int16_t x = col == 0
+        ? SETTINGS_MARGIN
+        : static_cast<int16_t>(SETTINGS_MARGIN + colW + SETTINGS_GAP);
+    return Rect{x, static_cast<int16_t>(SETTINGS_TOP + row * gridRowPitch()),
+                colW, gridRowHeight()};
+}
+
+Rect SettingsGame::gridWide(uint8_t row) const {
+    return Rect{SETTINGS_MARGIN,
+                static_cast<int16_t>(SETTINGS_TOP + row * gridRowPitch()),
+                static_cast<int16_t>(panelW_ - SETTINGS_MARGIN * 2),
+                gridRowHeight()};
+}
+
+Rect SettingsGame::themeRect()   const { return gridCell(0, 0); }
+Rect SettingsGame::layoutRect()  const { return gridCell(0, 1); }
+Rect SettingsGame::lightRect()   const { return gridCell(1, 0); }
+Rect SettingsGame::bleRect()     const { return gridCell(1, 1); }
+Rect SettingsGame::wifiRect()    const { return gridCell(2, 0); }
+Rect SettingsGame::ntpSyncRect() const { return gridCell(2, 1); }
+Rect SettingsGame::nearbyRect()  const { return gridCell(3, 0); }
+Rect SettingsGame::resetRect()   const { return gridCell(3, 1); }
+
+/* The brightness bar is pinned to the bottom rather than following the grid:
+ * it is the only continuous control here and it reads as a footer. */
+Rect SettingsGame::brightRect() const {
+    return Rect{SETTINGS_MARGIN,
+                static_cast<int16_t>(panelH_ - SETTINGS_BOTTOM_RESERVE),
+                static_cast<int16_t>(panelW_ - SETTINGS_MARGIN * 2), 32};
+}
 
 /* Sound tab.
  *
@@ -45,20 +102,23 @@ Rect SettingsGame::brightRect() const { return Rect{8,   204, 304, 32}; }
  * buttons 148-178, and two lines of explanation at 190 and 206 -- which leaves
  * 34px of margin at the bottom. There is room for one more row here and not
  * two. */
-Rect SettingsGame::muteRect()      const { return Rect{8,   58, 304, 30}; }
-Rect SettingsGame::volumeRect()    const { return Rect{8,  104, 304, 32}; }
-Rect SettingsGame::testCueRect()   const { return Rect{8,  148, 144, 30}; }
-Rect SettingsGame::testVoiceRect() const { return Rect{164, 148, 144, 30}; }
+Rect SettingsGame::muteRect()      const { return gridWide(0); }
+Rect SettingsGame::volumeRect()    const {
+    const Rect r = gridWide(1);
+    return Rect{r.x, r.y, r.w, static_cast<int16_t>(r.h + 2)};
+}
+Rect SettingsGame::testCueRect()   const { return gridCell(2, 0); }
+Rect SettingsGame::testVoiceRect() const { return gridCell(2, 1); }
 
 /* Power tab: four full-width rows, so the labels have room to say what the
  * setting actually does rather than abbreviating to fit half a screen.
  *
  * Wake lock sits with them because it is the last thing in the idle sequence:
  * saver, sleep, then what it takes to get back. */
-Rect SettingsGame::idleActionRect() const { return Rect{8,  58, 304, 30}; }
-Rect SettingsGame::idleAfterRect()  const { return Rect{8,  92, 304, 30}; }
-Rect SettingsGame::sleepAfterRect() const { return Rect{8, 126, 304, 30}; }
-Rect SettingsGame::wakeLockRect()   const { return Rect{8, 160, 304, 30}; }
+Rect SettingsGame::idleActionRect() const { return gridWide(0); }
+Rect SettingsGame::idleAfterRect()  const { return gridWide(1); }
+Rect SettingsGame::sleepAfterRect() const { return gridWide(2); }
+Rect SettingsGame::wakeLockRect()   const { return gridWide(3); }
 
 bool SettingsGame::sleepRowActive(Board& board) const {
     return board.idleAction() == Board::IdleAction::SaverThenSleep;
@@ -143,7 +203,7 @@ void SettingsGame::renderDeviceTab(GameHost& host) {
                                  : "Brightness", 8, 194, 1);
         tft.setTextDatum(TR_DATUM);
         snprintf(label, sizeof(label), "%u%%", board.brightness());
-        tft.drawString(label, SCREEN_WIDTH - 8, 194, 1);
+        tft.drawString(label, panelW_ - 8, static_cast<int16_t>(brightRect().y - 10), 1);
         tft.setTextDatum(TL_DATUM);
         Ui::drawSlider(tft, brightRect(), board.brightness(), Board::BRIGHTNESS_MIN);
     }
@@ -276,7 +336,7 @@ void SettingsGame::renderSoundTab(GameHost& host) {
     } else {
         snprintf(label, sizeof(label), "%u%%", board.volume());
     }
-    tft.drawString(label, SCREEN_WIDTH - 8, 92, 1);
+    tft.drawString(label, panelW_ - 8, static_cast<int16_t>(volumeRect().y - 12), 1);
     tft.setTextDatum(TL_DATUM);
 
     Ui::drawSlider(tft, volumeRect(), present ? board.volume() : 0, 0,

--- a/src/games/SettingsPanels.cpp
+++ b/src/games/SettingsPanels.cpp
@@ -197,10 +197,12 @@ void SettingsGame::renderDeviceTab(GameHost& host) {
     tft.setTextColor(Ui::muted(), Ui::bg());
     tft.setTextDatum(TL_DATUM);
     if (!admin) {
-        tft.drawString("Settings locked. Only Admin can change.", 8, 194, 1);
+        tft.drawString("Settings locked. Only Admin can change.", 8,
+                       static_cast<int16_t>(brightRect().y - 10), 1);
     } else {
         tft.drawString(confirmReset_ ? "Erases scores, names, Wi-Fi and settings"
-                                 : "Brightness", 8, 194, 1);
+                                 : "Brightness", 8,
+                       static_cast<int16_t>(brightRect().y - 10), 1);
         tft.setTextDatum(TR_DATUM);
         snprintf(label, sizeof(label), "%u%%", board.brightness());
         tft.drawString(label, panelW_ - 8, static_cast<int16_t>(brightRect().y - 10), 1);
@@ -280,14 +282,16 @@ void SettingsGame::renderPowerTab(GameHost& host) {
     }
     tft.setTextColor(Ui::muted(), Ui::bg());
     tft.setTextDatum(TL_DATUM);
-    tft.drawString(explain, 8, 196, 1);
+    const int16_t powerFootY =
+        static_cast<int16_t>(wakeLockRect().y + wakeLockRect().h + 6);
+    tft.drawString(explain, 8, powerFootY, 1);
     if (admin) {
         /* Say what a touch actually does, because the row above changes it.
          * A stray press in a bag is the case this exists for. */
         tft.drawString(board.wakeLockEnabled()
                            ? "A touch lights the screen; hold to go back."
                            : "Any touch goes straight back to what you were doing.",
-                       8, 212, 1);
+                       8, static_cast<int16_t>(powerFootY + 16), 1);
     }
 }
 
@@ -322,9 +326,15 @@ void SettingsGame::renderSoundTab(GameHost& host) {
                    (admin && present) ? Ui::panel() : Ui::surface(), Ui::outline(),
                    (admin && present) ? Ui::text() : Ui::muted(), false, 2);
 
+    /* The footnotes sit under the test buttons, so they move with them. They
+     * were at a fixed 190/206, which was under the buttons at 240 tall and
+     * straight through them on a taller panel. */
+    const int16_t soundFootY =
+        static_cast<int16_t>(testCueRect().y + testCueRect().h + 12);
+
     tft.setTextColor(Ui::muted(), Ui::bg());
     tft.setTextDatum(TL_DATUM);
-    tft.drawString("Volume", 8, 92, 1);
+    tft.drawString("Volume", 8, static_cast<int16_t>(volumeRect().y - 12), 1);
     tft.setTextDatum(TR_DATUM);
     if (!present) {
         snprintf(label, sizeof(label), "--");
@@ -354,16 +364,19 @@ void SettingsGame::renderSoundTab(GameHost& host) {
      * characters: TFT_eSPI drops characters off the right edge silently. */
     tft.setTextColor(Ui::muted(), Ui::bg());
     if (!admin) {
-        tft.drawString("Settings locked. Only Admin can change.", 8, 190, 1);
+        tft.drawString("Settings locked. Only Admin can change.", 8, soundFootY, 1);
     } else if (!present) {
-        tft.drawString("This board has no speaker or audio codec.", 8, 190, 1);
-        tft.drawString("The case LED still flashes for right and wrong.", 8, 206, 1);
+        tft.drawString("This board has no speaker or audio codec.", 8, soundFootY, 1);
+        tft.drawString("The case LED still flashes for right and wrong.", 8,
+                       static_cast<int16_t>(soundFootY + 16), 1);
     } else if (!on) {
-        tft.drawString("Muted: no beeps, no cues, no startup voice.", 8, 190, 1);
-        tft.drawString("The case LED still flashes for right and wrong.", 8, 206, 1);
+        tft.drawString("Muted: no beeps, no cues, no startup voice.", 8, soundFootY, 1);
+        tft.drawString("The case LED still flashes for right and wrong.", 8,
+                       static_cast<int16_t>(soundFootY + 16), 1);
     } else {
-        tft.drawString("Volume is capped for young ears.", 8, 190, 1);
-        tft.drawString("Every sound is made by the device, not a file.", 8, 206, 1);
+        tft.drawString("Volume is capped for young ears.", 8, soundFootY, 1);
+        tft.drawString("Every sound is made by the device, not a file.", 8,
+                       static_cast<int16_t>(soundFootY + 16), 1);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/SettingsPanels.cpp
+++ b/src/games/SettingsPanels.cpp
@@ -103,9 +103,17 @@ Rect SettingsGame::brightRect() const {
  * 34px of margin at the bottom. There is room for one more row here and not
  * two. */
 Rect SettingsGame::muteRect()      const { return gridWide(0); }
+/* Takes the grid's position but keeps its designed height.
+ *
+ * A button gets easier to hit as it grows; a slider does not -- what matters
+ * is the length of its travel, which is already the full width. Letting it
+ * take the grid's row height made the rect 46px tall, and drawSlider centres
+ * the track inside the rect, so the track sank while the "Volume" caption
+ * stayed pinned above the rect's top edge and was left floating in the gap.
+ * The brightness bar has always been a fixed 32 for the same reason. */
 Rect SettingsGame::volumeRect()    const {
     const Rect r = gridWide(1);
-    return Rect{r.x, r.y, r.w, static_cast<int16_t>(r.h + 2)};
+    return Rect{r.x, r.y, r.w, 32};
 }
 Rect SettingsGame::testCueRect()   const { return gridCell(2, 0); }
 Rect SettingsGame::testVoiceRect() const { return gridCell(2, 1); }

--- a/src/games/ShapeColorGame.cpp
+++ b/src/games/ShapeColorGame.cpp
@@ -184,7 +184,7 @@ void ShapeColorGame::render(AppContext& host) {
     } else {
         snprintf(stats, sizeof(stats), "Taps %u", taps_);
     }
-    tft.drawString(stats, SCREEN_WIDTH - 8, 50, 1);
+    tft.drawString(stats, GAME_CANVAS_WIDTH - 8, 50, 1);
 
     for (uint8_t i = 0; i < 4; ++i) {
         const Rect choice = choiceRect(i);
@@ -212,8 +212,8 @@ void ShapeColorGame::render(AppContext& host) {
         tft.drawRoundRect(54, 94, 212, 52, 8, Ui::success());
         tft.setTextColor(Ui::success(), Ui::panel());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Great matching!", SCREEN_WIDTH / 2, 112, 4);
-        tft.drawString("Tap to play again", SCREEN_WIDTH / 2, 137, 2);
+        tft.drawString("Great matching!", GAME_CANVAS_WIDTH / 2, 112, 4);
+        tft.drawString("Tap to play again", GAME_CANVAS_WIDTH / 2, 137, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/SlidingPuzzleGame.cpp
+++ b/src/games/SlidingPuzzleGame.cpp
@@ -105,7 +105,7 @@ void SlidingPuzzleGame::shuffle() {
 Rect SlidingPuzzleGame::tileRect(uint8_t index) const {
     const int16_t cell = size_ == 2 ? 58 : 48;
     const int16_t grid = cell * size_;
-    const int16_t startX = (SCREEN_WIDTH - grid) / 2;
+    const int16_t startX = (GAME_CANVAS_WIDTH - grid) / 2;
     const int16_t startY = size_ == 2 ? 80 : 68;
     return Rect{static_cast<int16_t>(startX + (index % size_) * cell), static_cast<int16_t>(startY + (index / size_) * cell), cell, cell};
 }
@@ -186,7 +186,7 @@ void SlidingPuzzleGame::render(AppContext& host) {
     } else {
         snprintf(bestBuf, sizeof(bestBuf), "Best --");
     }
-    tft.drawString(bestBuf, SCREEN_WIDTH - 8, 36, 2);
+    tft.drawString(bestBuf, GAME_CANVAS_WIDTH - 8, 36, 2);
     Ui::drawLabel(tft, Rect{8, 54, 304, 16}, "Slide tiles into order", Ui::muted(), 1, Align::Center);
 
     const uint8_t total = size_ * size_;

--- a/src/games/SortGame.cpp
+++ b/src/games/SortGame.cpp
@@ -154,7 +154,7 @@ void SortGame::render(AppContext& host) {
     tft.setTextDatum(TR_DATUM);
     char bestBuf[24];
     snprintf(bestBuf, sizeof(bestBuf), "Best streak %u", bestStreak_);
-    tft.drawString(bestBuf, SCREEN_WIDTH - 8, 35, 2);
+    tft.drawString(bestBuf, GAME_CANVAS_WIDTH - 8, 35, 2);
     Ui::drawLabel(tft, Rect{10, 55, 300, 18}, ascending_ ? "Tap smallest to largest" : "Tap largest to smallest", Ui::text(), 2, Align::Center);
 
     for (uint8_t i = 0; i < count_; ++i) {

--- a/src/games/StateFlagGame.cpp
+++ b/src/games/StateFlagGame.cpp
@@ -224,7 +224,7 @@ void StateFlagGame::render(AppContext& host) {
     tft.setTextColor(Ui::rgb(255, 200, 0), Ui::bg());
     char bonusBuf[8];
     snprintf(bonusBuf, sizeof(bonusBuf), "+%u", capBonus_);
-    tft.drawString(bonusBuf, SCREEN_WIDTH - 8, 33, 2);
+    tft.drawString(bonusBuf, GAME_CANVAS_WIDTH - 8, 33, 2);
 
     static const char* const TIER_NAMES[4] = {"", "Easy", "Medium", "Hard"};
     Ui::drawButton(tft, tierRect(), TIER_NAMES[tier_], Ui::panel(), Ui::outline(), Ui::text(), false, 1);
@@ -246,7 +246,7 @@ void StateFlagGame::render(AppContext& host) {
     tft.drawString(capitalRound
                        ? String("Bonus! Capital of ") + current_->name + "?"
                        : String("Which state?"),
-                   SCREEN_WIDTH / 2, 176, 2);
+                   GAME_CANVAS_WIDTH / 2, 176, 2);
 
     const bool showingFeedback =
         (phase_ == Phase::FeedbackState || phase_ == Phase::FeedbackCapital);

--- a/src/games/StateMapGame.cpp
+++ b/src/games/StateMapGame.cpp
@@ -195,7 +195,7 @@ void StateMapGame::render(AppContext& host) {
     tft.setTextColor(Ui::rgb(255, 200, 0), Ui::bg());
     char bonusBuf[8];
     snprintf(bonusBuf, sizeof(bonusBuf), "+%u", capBonus_);
-    tft.drawString(bonusBuf, SCREEN_WIDTH - 8, 33, 2);
+    tft.drawString(bonusBuf, GAME_CANVAS_WIDTH - 8, 33, 2);
 
     static const char* const TIER_NAMES[4] = {"", "Easy", "Medium", "Hard"};
     Ui::drawButton(tft, tierRect(), TIER_NAMES[tier_], Ui::panel(), Ui::outline(), Ui::text(), false, 1);
@@ -219,9 +219,9 @@ void StateMapGame::render(AppContext& host) {
     if (capitalRound) {
         char prompt[48];
         snprintf(prompt, sizeof(prompt), "Bonus! Capital of %s?", current_->name);
-        tft.drawString(prompt, SCREEN_WIDTH / 2, 150, 2);
+        tft.drawString(prompt, GAME_CANVAS_WIDTH / 2, 150, 2);
     } else {
-        tft.drawString("Which state?", SCREEN_WIDTH / 2, 176, 2);
+        tft.drawString("Which state?", GAME_CANVAS_WIDTH / 2, 176, 2);
     }
 
     const bool showingFeedback =

--- a/src/games/StatesGame.cpp
+++ b/src/games/StatesGame.cpp
@@ -210,7 +210,7 @@ void StatesGame::render(AppContext& host) {
     tft.setTextDatum(MC_DATUM);
     tft.setTextColor(Ui::rgb(90, 170, 255), Ui::bg());
     tft.drawString(mode_ == Mode::CapitalOf ? current_->name : current_->capital,
-                   SCREEN_WIDTH / 2, 72, 4);
+                   GAME_CANVAS_WIDTH / 2, 72, 4);
 
     const bool done = (phase_ == Phase::Feedback);
     tft.setTextColor(done ? (lastCorrect_ ? Ui::success() : Ui::error()) : Ui::text(), Ui::bg());
@@ -223,7 +223,7 @@ void StatesGame::render(AppContext& host) {
         prompt = (mode_ == Mode::CapitalOf) ? String("What is its capital?")
                                             : String("is the capital of which state?");
     }
-    tft.drawString(fitLabel(tft, prompt, SCREEN_WIDTH - 16, 2), SCREEN_WIDTH / 2, 112, 2);
+    tft.drawString(fitLabel(tft, prompt, GAME_CANVAS_WIDTH - 16, 2), GAME_CANVAS_WIDTH / 2, 112, 2);
 
     for (uint8_t i = 0; i < OPTION_COUNT; ++i) {
         const StateFact* opt = options_[i];

--- a/src/games/TicTacToeGame.cpp
+++ b/src/games/TicTacToeGame.cpp
@@ -168,7 +168,7 @@ void TicTacToeGame::render(AppContext& host) {
     tft.setTextDatum(TR_DATUM);
     char scoreBuf[32];
     snprintf(scoreBuf, sizeof(scoreBuf), "X %u  O %u  D %u", xWins_, oWins_, draws_);
-    tft.drawString(scoreBuf, SCREEN_WIDTH - 8, 40, 1);
+    tft.drawString(scoreBuf, GAME_CANVAS_WIDTH - 8, 40, 1);
     tft.setTextDatum(TL_DATUM);
 
     tft.fillRoundRect(BOARD_RECT.x - 4, BOARD_RECT.y - 4, BOARD_RECT.w + 8, BOARD_RECT.h + 8, 8, Ui::panel());

--- a/src/games/TimeGame.cpp
+++ b/src/games/TimeGame.cpp
@@ -177,7 +177,7 @@ void TimeGame::update(AppContext& host, const TouchPoint& touch) {
 }
 
 void TimeGame::drawClock(Ui::Renderer& tft) const {
-    constexpr int16_t cx = SCREEN_WIDTH / 2;
+    constexpr int16_t cx = GAME_CANVAS_WIDTH / 2;
     constexpr int16_t cy = 91;
     constexpr int16_t radius = 49;
 
@@ -231,9 +231,9 @@ void TimeGame::render(AppContext& host) {
     tft.setTextDatum(TR_DATUM);
     char rightBuf[20];
     snprintf(rightBuf, sizeof(rightBuf), "Streak %u", streak_);
-    tft.drawString(rightBuf, SCREEN_WIDTH - 10, 35, 2);
+    tft.drawString(rightBuf, GAME_CANVAS_WIDTH - 10, 35, 2);
     snprintf(rightBuf, sizeof(rightBuf), "Best %u", bestStreak_);
-    tft.drawString(rightBuf, SCREEN_WIDTH - 10, 52, 2);
+    tft.drawString(rightBuf, GAME_CANVAS_WIDTH - 10, 52, 2);
 
     drawClock(tft);
     Ui::drawLabel(tft, Rect{8, 133, 304, 16}, "Which time is shown?", Ui::text(), 2, Align::Center);
@@ -256,7 +256,7 @@ void TimeGame::render(AppContext& host) {
     if (answered_) {
         tft.setTextColor(selected_ == correctButton_ ? GREEN : RED, Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Try the green time next", SCREEN_WIDTH / 2, 226, 2);
+        tft.drawString(selected_ == correctButton_ ? "Correct - tap for next" : "Try the green time next", GAME_CANVAS_WIDTH / 2, 226, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/TraceGame.cpp
+++ b/src/games/TraceGame.cpp
@@ -355,7 +355,7 @@ void TraceGame::drawProgress(Ui::Renderer& tft) {
 
     uint8_t pct = totalPoints > 0 ? (uint8_t)((uint32_t)claimedPoints * 100 / totalPoints) : 0;
     int16_t barW = 120;
-    int16_t barX = (SCREEN_WIDTH - barW) / 2;
+    int16_t barX = (GAME_CANVAS_WIDTH - barW) / 2;
     int16_t barY = 222;
 
     tft.fillRoundRect(barX, barY, barW, 10, 4, Ui::panel());

--- a/src/games/WhackAMoleGame.cpp
+++ b/src/games/WhackAMoleGame.cpp
@@ -4,7 +4,7 @@
 namespace {
 constexpr uint8_t GRID = 9;
 constexpr int16_t CELL = 20;
-constexpr int16_t GRID_X = (SCREEN_WIDTH - GRID * CELL) / 2;
+constexpr int16_t GRID_X = (GAME_CANVAS_WIDTH - GRID * CELL) / 2;
 constexpr int16_t GRID_Y = TOP_BAR_HEIGHT + 28;
 constexpr uint16_t CELL_FILL = 0x1085;
 constexpr uint16_t SMILE = 0xFFE6;
@@ -208,9 +208,9 @@ void WhackAMoleGame::render(AppContext& host) {
     tft.setTextDatum(TR_DATUM);
     char rightBuf[24];
     snprintf(rightBuf, sizeof(rightBuf), "Best %u", bestScore_);
-    tft.drawString(rightBuf, SCREEN_WIDTH - 8, 35, 2);
+    tft.drawString(rightBuf, GAME_CANVAS_WIDTH - 8, 35, 2);
     snprintf(rightBuf, sizeof(rightBuf), "Speed %ums", visibleMs());
-    tft.drawString(rightBuf, SCREEN_WIDTH - 8, 51, 1);
+    tft.drawString(rightBuf, GAME_CANVAS_WIDTH - 8, 51, 1);
 
     for (uint8_t i = 0; i < GRID * GRID; ++i) {
         const Rect r = cellRect(i);
@@ -230,9 +230,9 @@ void WhackAMoleGame::render(AppContext& host) {
         tft.drawRoundRect(46, 88, 228, 72, 8, Ui::error());
         tft.setTextColor(Ui::error(), Ui::panel());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Game over", SCREEN_WIDTH / 2, 110, 4);
+        tft.drawString("Game over", GAME_CANVAS_WIDTH / 2, 110, 4);
         tft.setTextColor(Ui::text(), Ui::panel());
-        tft.drawString("Tap to restart", SCREEN_WIDTH / 2, 140, 2);
+        tft.drawString("Tap to restart", GAME_CANVAS_WIDTH / 2, 140, 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/WifiGame.cpp
+++ b/src/games/WifiGame.cpp
@@ -399,12 +399,13 @@ void WifiGame::render(GameHost& host) {
         // ---------- Wi-Fi ----------
         tft.setTextDatum(TL_DATUM);
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("WI-FI", 14, 36, 1);
-        tft.drawFastHLine(52, 41, 254, Ui::outline());
+        tft.drawString("WI-FI", baseX(14), baseY(36), 1);
+        tft.drawFastHLine(baseX(52), baseY(41), static_cast<int16_t>(baseX(52 + 254) - baseX(52)),
+                          Ui::outline());
 
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString(hasCreds ? ssid : String("No saved network"), 14, 48, 2);
-        Ui::drawWifiBadge(tft, 296, 54, Ui::bg());
+        tft.drawString(hasCreds ? ssid : String("No saved network"), baseX(14), baseY(48), 2);
+        Ui::drawWifiBadge(tft, baseX(296), baseY(54), Ui::bg());
 
         Ui::drawButton(tft, baseRect(14, 64, 140, 30), "Scan Wi-Fi", Ui::rgb(36, 132, 204), Ui::outline(), TFT_WHITE, false, 2);
         Ui::drawButton(tft, baseRect(166, 64, 140, 30), hasCreds ? "Forget" : "---",
@@ -413,8 +414,9 @@ void WifiGame::render(GameHost& host) {
 
         // ---------- Time ----------
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("TIME", 14, 104, 1);
-        tft.drawFastHLine(48, 109, 258, Ui::outline());
+        tft.drawString("TIME", baseX(14), baseY(104), 1);
+        tft.drawFastHLine(baseX(48), baseY(109), static_cast<int16_t>(baseX(48 + 258) - baseX(48)),
+                          Ui::outline());
 
         const bool synced = Clock::synced();
         // Date alongside the time: NTP delivers both, and seeing the date is
@@ -422,13 +424,18 @@ void WifiGame::render(GameHost& host) {
         const String stamp = synced ? (Clock::dateText() + "  " + Clock::timeText())
                                     : Clock::timeText();
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString(stamp, 14, 116, 2);
+        tft.drawString(stamp, baseX(14), baseY(116), 2);
 
-        const int16_t badgeX = static_cast<int16_t>(14 + tft.textWidth(stamp, 2) + 12);
-        Ui::drawSyncBadge(tft, badgeX, 122, synced, Ui::bg());
+        /* Measured, so it lives in panel pixels -- the 14 it starts from is a
+         * design-space origin and has to be mapped before the two are added,
+         * or the badge lands short of the text it belongs to and the caption
+         * lands on top of it. */
+        const int16_t badgeX =
+            static_cast<int16_t>(baseX(14) + tft.textWidth(stamp, 2) + 12);
+        Ui::drawSyncBadge(tft, badgeX, baseY(122), synced, Ui::bg());
         tft.setTextColor(synced ? Ui::success() : Ui::warning(), Ui::bg());
         tft.drawString(synced ? "" : (up ? "not synced" : "needs Wi-Fi"),
-                       static_cast<int16_t>(badgeX + 12), 116, 2);
+                       static_cast<int16_t>(badgeX + 12), baseY(116), 2);
 
         Ui::drawButton(tft, baseRect(14, 132, 140, 30),
                        String("Auto time: ") + (board.ntpEnabled() ? "On" : "Off"),
@@ -456,7 +463,7 @@ void WifiGame::render(GameHost& host) {
     } else if (phase_ == Phase::TimeZone) {
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(TL_DATUM);
-        tft.drawString("Choose your time zone", 8, 34, 2);
+        tft.drawString("Choose your time zone", baseX(8), baseY(34), 2);
 
         const uint8_t n = Board::tzZoneCount();
         const uint8_t current = board.tzZoneChosen() ? board.tzZoneIndex() : 0xFF;
@@ -495,7 +502,7 @@ void WifiGame::render(GameHost& host) {
         // Header above list
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(TL_DATUM);
-        tft.drawString(netCount_ == 0 ? "No networks found" : String(netCount_) + " found - tap to connect", 8, 34, 2);
+        tft.drawString(netCount_ == 0 ? "No networks found" : String(netCount_) + " found - tap to connect", baseX(8), baseY(34), 2);
         if (netCount_ == 0) {
             // -1 = still running, -2 = scan failed, 0 = radio saw nothing.
             tft.setTextColor(Ui::muted(), Ui::bg());
@@ -542,14 +549,14 @@ void WifiGame::render(GameHost& host) {
         const String ssid = selectedSsid_.length() ? selectedSsid_ : board.wifiSsid();
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(TL_DATUM);
-        tft.drawString(String("< back   ") + ssid, 8, 36, 2);
+        tft.drawString(String("< back   ") + ssid, baseX(8), baseY(36), 2);
         tft.fillRoundRect(8, 54, 304, 34, 4, Ui::surface());
         tft.drawRoundRect(8, 54, 304, 34, 4, Ui::outline());
         tft.setTextColor(password_.length() > 0 ? Ui::text() : Ui::muted(), Ui::surface());
         tft.setTextDatum(ML_DATUM);
         String shown = password_.length() > 0 ? password_ : "Password";
         while (shown.length() > 2 && tft.textWidth(shown, 2) > 280) shown.remove(shown.length() - 1);
-        tft.drawString(shown, 16, 71, 2);
+        tft.drawString(shown, baseX(16), baseY(71), 2);
         for (uint8_t row = 0; row < 4; ++row) {
             for (uint8_t col = 0; col < 10; ++col) {
                 char buf[2] = {keys[row][col], 0};

--- a/src/games/WifiGame.cpp
+++ b/src/games/WifiGame.cpp
@@ -550,13 +550,24 @@ void WifiGame::render(GameHost& host) {
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(TL_DATUM);
         tft.drawString(String("< back   ") + ssid, baseX(8), baseY(36), 2);
-        tft.fillRoundRect(8, 54, 304, 34, 4, Ui::surface());
-        tft.drawRoundRect(8, 54, 304, 34, 4, Ui::outline());
+        /* The one shape on this screen that is not built from a Rect, and so
+         * the one the mapping pass missed: it was still drawn at the design
+         * size while the text inside it had moved, which put the caption
+         * below the box it belongs in. */
+        const Rect field = baseRect(8, 54, 304, 34);
+        tft.fillRoundRect(field.x, field.y, field.w, field.h, 4, Ui::surface());
+        tft.drawRoundRect(field.x, field.y, field.w, field.h, 4, Ui::outline());
         tft.setTextColor(password_.length() > 0 ? Ui::text() : Ui::muted(), Ui::surface());
         tft.setTextDatum(ML_DATUM);
         String shown = password_.length() > 0 ? password_ : "Password";
-        while (shown.length() > 2 && tft.textWidth(shown, 2) > 280) shown.remove(shown.length() - 1);
-        tft.drawString(shown, baseX(16), baseY(71), 2);
+        const int16_t fieldTextMax = static_cast<int16_t>(field.w - 16);
+        while (shown.length() > 2 && tft.textWidth(shown, 2) > fieldTextMax) {
+            shown.remove(shown.length() - 1);
+        }
+        /* Centred in the field rather than at a mapped y of its own, so the
+         * two cannot drift apart again. */
+        tft.drawString(shown, static_cast<int16_t>(field.x + 8),
+                       static_cast<int16_t>(field.y + field.h / 2), 2);
         for (uint8_t row = 0; row < 4; ++row) {
             for (uint8_t col = 0; col < 10; ++col) {
                 char buf[2] = {keys[row][col], 0};

--- a/src/games/WifiGame.cpp
+++ b/src/games/WifiGame.cpp
@@ -40,21 +40,45 @@ void WifiGame::begin(GameHost& host) {
     markDirty();
 }
 
+namespace {
+/* The size this screen's geometry was authored against. */
+constexpr int16_t WIFI_BASE_W = 320;
+constexpr int16_t WIFI_BASE_H = 240;
+}  // namespace
+
+void WifiGame::syncPanel(GameHost& host) {
+    panelW_ = static_cast<int16_t>(host.display().width());
+    panelH_ = static_cast<int16_t>(host.display().height());
+}
+
+/* Map a rect from the design size onto the panel. Exact identity at 320x240. */
+Rect WifiGame::baseRect(int16_t x, int16_t y, int16_t w, int16_t h) const {
+    return Rect{static_cast<int16_t>(static_cast<int32_t>(x) * panelW_ / WIFI_BASE_W),
+                static_cast<int16_t>(static_cast<int32_t>(y) * panelH_ / WIFI_BASE_H),
+                static_cast<int16_t>(static_cast<int32_t>(w) * panelW_ / WIFI_BASE_W),
+                static_cast<int16_t>(static_cast<int32_t>(h) * panelH_ / WIFI_BASE_H)};
+}
+
+int16_t WifiGame::baseX(int16_t x) const {
+    return static_cast<int16_t>(static_cast<int32_t>(x) * panelW_ / WIFI_BASE_W);
+}
+
+int16_t WifiGame::baseY(int16_t y) const {
+    return static_cast<int16_t>(static_cast<int32_t>(y) * panelH_ / WIFI_BASE_H);
+}
+
 Rect WifiGame::netRect(uint8_t slot) const {
     // 31px pitch keeps all five rows clear of the Prev/Back/Next row at y=206.
-    return Rect{8, static_cast<int16_t>(48 + slot * 31), 304, 29};
+    return baseRect(8, static_cast<int16_t>(48 + slot * 31), 304, 29);
 }
 
 Rect WifiGame::zoneRect(uint8_t slot) const {
-    return Rect{8, static_cast<int16_t>(46 + slot * 28), 304, 26};
+    return baseRect(8, static_cast<int16_t>(46 + slot * 28), 304, 26);
 }
 
 Rect WifiGame::keyRect(uint8_t row, uint8_t col) const {
-    return Rect{
-        static_cast<int16_t>(2 + col * 32),
-        static_cast<int16_t>(96 + row * 28),
-        28, 24
-    };
+    return baseRect(static_cast<int16_t>(2 + col * 32),
+                    static_cast<int16_t>(96 + row * 28), 28, 24);
 }
 
 void WifiGame::startScan(GameHost& host) {
@@ -228,6 +252,7 @@ void WifiGame::checkConnect(GameHost& host) {
 }
 
 void WifiGame::update(GameHost& host, const TouchPoint& touch) {
+    syncPanel(host);
     if (phase_ == Phase::Idle) {
         // Repaint when the link or sync state changes, so the badges and the
         // status line do not sit stale while the user watches them.
@@ -259,33 +284,33 @@ void WifiGame::update(GameHost& host, const TouchPoint& touch) {
 
     if (phase_ == Phase::Idle) {
         // --- Wi-Fi section ---
-        if (Rect{14, 64, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { startScan(host); return; }
-        if (Rect{166, 64, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP) && board.hasWifiCredentials()) {
+        if (baseRect(14, 64, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { startScan(host); return; }
+        if (baseRect(166, 64, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && board.hasWifiCredentials()) {
             board.clearWifiCredentials(); markDirty(); return;
         }
         // --- Time section ---
-        if (Rect{14, 132, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(14, 132, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             board.setNtpEnabled(!board.ntpEnabled()); markDirty(); return;
         }
-        if (Rect{166, 132, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(166, 132, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             zonePage_ = static_cast<uint8_t>(board.tzZoneIndex() / 5);
             phase_ = Phase::TimeZone; markDirty(); return;
         }
-        if (Rect{14, 172, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(14, 172, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             if (Ui::wifiUp()) { board.syncTimeNow(); markDirty(); }
             return;
         }
-        if (Rect{166, 172, 140, 30}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { host.openSettings(); return; }
+        if (baseRect(166, 172, 140, 30).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { host.openSettings(); return; }
 
     } else if (phase_ == Phase::List) {
         const uint8_t pages = max<uint8_t>(1, (netCount_ + 4) / 5);
-        if (Rect{8, 206, 84, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP) && listPage_ > 0) {
+        if (baseRect(8, 206, 84, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && listPage_ > 0) {
             --listPage_; markDirty(); return;
         }
-        if (Rect{228, 206, 84, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP) && listPage_ + 1 < pages) {
+        if (baseRect(228, 206, 84, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && listPage_ + 1 < pages) {
             ++listPage_; markDirty(); return;
         }
-        if (Rect{104, 206, 112, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(104, 206, 112, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             phase_ = Phase::Idle; markDirty(); return;
         }
         for (uint8_t slot = 0; slot < 5; ++slot) {
@@ -314,33 +339,33 @@ void WifiGame::update(GameHost& host, const TouchPoint& touch) {
                 }
             }
         }
-        if (Rect{2, 208, 52, 24}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(2, 208, 52, 24).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             capsLock_ = !capsLock_; symbols_ = false; markDirty(); return;
         }
-        if (Rect{58, 208, 52, 24}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(58, 208, 52, 24).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             symbols_ = !symbols_; markDirty(); return;
         }
-        if (Rect{114, 208, 74, 24}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(114, 208, 74, 24).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             if (password_.length() < 63) password_ += ' ';
             markDirty(); return;
         }
-        if (Rect{192, 208, 50, 24}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(192, 208, 50, 24).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             if (password_.length() > 0) password_.remove(password_.length() - 1);
             markDirty(); return;
         }
-        if (Rect{246, 208, 72, 24}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { startConnect(host); return; }
-        if (Rect{8, 34, 60, 20}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { phase_ = Phase::List; markDirty(); }
+        if (baseRect(246, 208, 72, 24).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { startConnect(host); return; }
+        if (baseRect(8, 34, 60, 20).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) { phase_ = Phase::List; markDirty(); }
 
     } else if (phase_ == Phase::TimeZone) {
         const uint8_t n = Board::tzZoneCount();
         const uint8_t pages = static_cast<uint8_t>((n + 4) / 5);
-        if (Rect{8, 208, 90, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP) && zonePage_ > 0) {
+        if (baseRect(8, 208, 90, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && zonePage_ > 0) {
             --zonePage_; markDirty(); return;
         }
-        if (Rect{222, 208, 90, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP) && zonePage_ + 1 < pages) {
+        if (baseRect(222, 208, 90, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP) && zonePage_ + 1 < pages) {
             ++zonePage_; markDirty(); return;
         }
-        if (Rect{106, 208, 108, 26}.contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
+        if (baseRect(106, 208, 108, 26).contains(touch.x, touch.y, TOUCH_HIT_SLOP)) {
             phase_ = Phase::Idle; markDirty(); return;
         }
         for (uint8_t slot = 0; slot < 5; ++slot) {
@@ -360,6 +385,7 @@ void WifiGame::update(GameHost& host, const TouchPoint& touch) {
 }
 
 void WifiGame::render(GameHost& host) {
+    syncPanel(host);
     Board& board = host.board();
     Ui::Renderer& tft = host.display();
     Ui::clear(tft);
@@ -380,8 +406,8 @@ void WifiGame::render(GameHost& host) {
         tft.drawString(hasCreds ? ssid : String("No saved network"), 14, 48, 2);
         Ui::drawWifiBadge(tft, 296, 54, Ui::bg());
 
-        Ui::drawButton(tft, Rect{14, 64, 140, 30}, "Scan Wi-Fi", Ui::rgb(36, 132, 204), Ui::outline(), TFT_WHITE, false, 2);
-        Ui::drawButton(tft, Rect{166, 64, 140, 30}, hasCreds ? "Forget" : "---",
+        Ui::drawButton(tft, baseRect(14, 64, 140, 30), "Scan Wi-Fi", Ui::rgb(36, 132, 204), Ui::outline(), TFT_WHITE, false, 2);
+        Ui::drawButton(tft, baseRect(166, 64, 140, 30), hasCreds ? "Forget" : "---",
                        hasCreds ? Ui::panel() : Ui::surface(), Ui::outline(),
                        hasCreds ? Ui::text() : Ui::muted(), false, 2);
 
@@ -404,27 +430,27 @@ void WifiGame::render(GameHost& host) {
         tft.drawString(synced ? "" : (up ? "not synced" : "needs Wi-Fi"),
                        static_cast<int16_t>(badgeX + 12), 116, 2);
 
-        Ui::drawButton(tft, Rect{14, 132, 140, 30},
+        Ui::drawButton(tft, baseRect(14, 132, 140, 30),
                        String("Auto time: ") + (board.ntpEnabled() ? "On" : "Off"),
                        board.ntpEnabled() ? Ui::rgb(45, 154, 96) : Ui::panel(),
                        Ui::outline(), board.ntpEnabled() ? TFT_WHITE : Ui::text(), false, 2);
         // Say "Auto" until a zone is picked by hand, rather than showing the
         // index-0 default ("UTC") as though it were a deliberate choice.
-        Ui::drawButton(tft, Rect{166, 132, 140, 30},
+        Ui::drawButton(tft, baseRect(166, 132, 140, 30),
                        board.tzZoneChosen() ? Board::tzZoneName(board.tzZoneIndex())
                                             : String("Zone: Auto"),
                        Ui::panel(), Ui::outline(), Ui::text(), false, 2);
 
-        Ui::drawButton(tft, Rect{14, 172, 140, 30}, "Sync now",
+        Ui::drawButton(tft, baseRect(14, 172, 140, 30), "Sync now",
                        up ? Ui::rgb(45, 154, 96) : Ui::surface(), Ui::outline(),
                        up ? TFT_WHITE : Ui::muted(), false, 2);
-        Ui::drawButton(tft, Rect{166, 172, 140, 30}, "Back", Ui::panel(), Ui::outline(), Ui::text(), false, 2);
+        Ui::drawButton(tft, baseRect(166, 172, 140, 30), "Back", Ui::panel(), Ui::outline(), Ui::text(), false, 2);
 
         tft.setTextColor(Ui::muted(), Ui::bg());
         tft.setTextDatum(TC_DATUM);
         tft.drawString(board.tzAutoDetected() ? "Zone detected automatically"
                                               : "Tap the zone to change it",
-                       SCREEN_WIDTH / 2, 210, 1);
+                       baseX(WIFI_BASE_W / 2), baseY(210), 1);
         tft.setTextDatum(TL_DATUM);
 
     } else if (phase_ == Phase::TimeZone) {
@@ -447,9 +473,9 @@ void WifiGame::render(GameHost& host) {
         }
 
         const uint8_t pages = static_cast<uint8_t>((n + 4) / 5);
-        Ui::drawPagerButton(tft, Rect{8, 208, 90, 26}, "Prev", zonePage_ > 0);
-        Ui::drawButton(tft, Rect{106, 208, 108, 26}, "Cancel", Ui::panel(), Ui::outline(), Ui::text(), false, 2);
-        Ui::drawPagerButton(tft, Rect{222, 208, 90, 26}, "Next", zonePage_ + 1 < pages);
+        Ui::drawPagerButton(tft, baseRect(8, 208, 90, 26), "Prev", zonePage_ > 0);
+        Ui::drawButton(tft, baseRect(106, 208, 108, 26), "Cancel", Ui::panel(), Ui::outline(), Ui::text(), false, 2);
+        Ui::drawPagerButton(tft, baseRect(222, 208, 90, 26), "Next", zonePage_ + 1 < pages);
 
     } else if (phase_ == Phase::Scanning) {
 
@@ -458,11 +484,11 @@ void WifiGame::render(GameHost& host) {
         const uint32_t dots = (millis() / 450) % 4;
         String s = "Scanning";
         for (uint32_t i = 0; i < dots; ++i) s += '.';
-        tft.drawString(s, SCREEN_WIDTH / 2, 90, 4);
+        tft.drawString(s, baseX(WIFI_BASE_W / 2), baseY(90), 4);
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("Looking for networks", SCREEN_WIDTH / 2, 130, 2);
+        tft.drawString("Looking for networks", baseX(WIFI_BASE_W / 2), baseY(130), 2);
         tft.setTextColor(Ui::text(), Ui::bg());
-        tft.drawString("Please wait...", SCREEN_WIDTH / 2, 160, 2);
+        tft.drawString("Please wait...", baseX(WIFI_BASE_W / 2), baseY(160), 2);
         markDirty(); // keep refreshing for animation
 
     } else if (phase_ == Phase::List) {
@@ -474,10 +500,10 @@ void WifiGame::render(GameHost& host) {
             // -1 = still running, -2 = scan failed, 0 = radio saw nothing.
             tft.setTextColor(Ui::muted(), Ui::bg());
             tft.setTextDatum(TR_DATUM);
-            tft.drawString(String("code ") + lastScanCode_, SCREEN_WIDTH - 8, 34, 1);
+            tft.drawString(String("code ") + lastScanCode_, baseX(WIFI_BASE_W - 8), baseY(34), 1);
             tft.setTextDatum(TL_DATUM);
             tft.setTextColor(Ui::text(), Ui::bg());
-            Ui::drawLabel(tft, Rect{20, 96, 280, 20},
+            Ui::drawLabel(tft, baseRect(20, 96, 280, 20),
                           "2.4GHz only - a 5GHz-only network will not appear",
                           Ui::muted(), 2, Align::Center);
         }
@@ -506,9 +532,9 @@ void WifiGame::render(GameHost& host) {
             }
         }
         const uint8_t pages = max<uint8_t>(1, (netCount_ + 4) / 5);
-        Ui::drawPagerButton(tft, Rect{8, 206, 84, 26}, "Prev", listPage_ > 0);
-        Ui::drawButton(tft, Rect{104, 206, 112, 26}, "Back", Ui::panel(), Ui::outline(), Ui::text());
-        Ui::drawPagerButton(tft, Rect{228, 206, 84, 26}, "Next", listPage_ + 1 < pages);
+        Ui::drawPagerButton(tft, baseRect(8, 206, 84, 26), "Prev", listPage_ > 0);
+        Ui::drawButton(tft, baseRect(104, 206, 112, 26), "Back", Ui::panel(), Ui::outline(), Ui::text());
+        Ui::drawPagerButton(tft, baseRect(228, 206, 84, 26), "Next", listPage_ + 1 < pages);
 
     } else if (phase_ == Phase::Keyboard) {
         const char (*keys)[11] = symbols_ ? KEYS_SYMBOL
@@ -530,42 +556,42 @@ void WifiGame::render(GameHost& host) {
                 Ui::drawButton(tft, keyRect(row, col), String(buf), Ui::surface(), Ui::outline(), Ui::text(), false, 2);
             }
         }
-        Ui::drawButton(tft, Rect{2, 208, 52, 24}, "CAPS",
+        Ui::drawButton(tft, baseRect(2, 208, 52, 24), "CAPS",
                        capsLock_ ? Ui::rgb(36, 132, 204) : Ui::surface(), Ui::outline(),
                        capsLock_ ? TFT_WHITE : Ui::text(), false, 1);
-        Ui::drawButton(tft, Rect{58, 208, 52, 24}, symbols_ ? "abc" : "!#$",
+        Ui::drawButton(tft, baseRect(58, 208, 52, 24), symbols_ ? "abc" : "!#$",
                        symbols_ ? Ui::rgb(36, 132, 204) : Ui::surface(), Ui::outline(),
                        symbols_ ? TFT_WHITE : Ui::text(), false, 1);
-        Ui::drawButton(tft, Rect{114, 208, 74, 24}, "SPACE", Ui::surface(), Ui::outline(), Ui::text(), false, 1);
-        Ui::drawButton(tft, Rect{192, 208, 50, 24}, "DEL", Ui::panel(), Ui::outline(), Ui::text(), false, 1);
-        Ui::drawButton(tft, Rect{246, 208, 72, 24}, "JOIN", Ui::rgb(36, 132, 204), Ui::outline(), TFT_WHITE, false, 2);
+        Ui::drawButton(tft, baseRect(114, 208, 74, 24), "SPACE", Ui::surface(), Ui::outline(), Ui::text(), false, 1);
+        Ui::drawButton(tft, baseRect(192, 208, 50, 24), "DEL", Ui::panel(), Ui::outline(), Ui::text(), false, 1);
+        Ui::drawButton(tft, baseRect(246, 208, 72, 24), "JOIN", Ui::rgb(36, 132, 204), Ui::outline(), TFT_WHITE, false, 2);
 
     } else if (phase_ == Phase::Connecting) {
         const String ssid = selectedSsid_.length() ? selectedSsid_ : board.wifiSsid();
         tft.setTextColor(Ui::text(), Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString("Connecting to", SCREEN_WIDTH / 2, 88, 2);
-        tft.drawString(ssid, SCREEN_WIDTH / 2, 112, 4);
+        tft.drawString("Connecting to", baseX(WIFI_BASE_W / 2), baseY(88), 2);
+        tft.drawString(ssid, baseX(WIFI_BASE_W / 2), baseY(112), 4);
         const uint32_t dots = (millis() - connectStart_) / 500 % 4;
         String prog;
         for (uint32_t i = 0; i < dots + 1; ++i) prog += "...";
-        tft.drawString(prog, SCREEN_WIDTH / 2, 152, 2);
+        tft.drawString(prog, baseX(WIFI_BASE_W / 2), baseY(152), 2);
         markDirty();
 
     } else if (phase_ == Phase::Done) {
         tft.setTextColor(connectOk_ ? Ui::success() : Ui::error(), Ui::bg());
         tft.setTextDatum(MC_DATUM);
-        tft.drawString(connectOk_ ? "Connected!" : "Connection failed", SCREEN_WIDTH / 2, 96, 4);
+        tft.drawString(connectOk_ ? "Connected!" : "Connection failed", baseX(WIFI_BASE_W / 2), baseY(96), 4);
         tft.setTextColor(saveReadback_.length() ? Ui::success() : Ui::error(), Ui::bg());
         tft.drawString(saveReadback_.length() ? String("Saved: ") + saveReadback_
                                               : String("NOT saved - empty SSID"),
-                       SCREEN_WIDTH / 2, 122, 2);
+                       baseX(WIFI_BASE_W / 2), baseY(122), 2);
         if (connectOk_ && board.ntpEnabled()) {
             tft.setTextColor(Ui::text(), Ui::bg());
-            tft.drawString("Clock sync started", SCREEN_WIDTH / 2, 136, 2);
+            tft.drawString("Clock sync started", baseX(WIFI_BASE_W / 2), baseY(136), 2);
         }
         tft.setTextColor(Ui::muted(), Ui::bg());
-        tft.drawString("Tap to return", SCREEN_WIDTH / 2, 200, 2);
+        tft.drawString("Tap to return", baseX(WIFI_BASE_W / 2), baseY(200), 2);
     }
     tft.setTextDatum(TL_DATUM);
 }

--- a/src/games/WifiGame.h
+++ b/src/games/WifiGame.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "BoardConfig.h"
 #include "engine/Game.h"
 #include "ui/Ui.h"
 
@@ -47,6 +48,23 @@ private:
     void runScan();
     void startConnect(GameHost& host);
     void checkConnect(GameHost& host);
+
+    /* This screen was drawn against 320x240 and says so in every rect. Rather
+     * than restate ~17 literals -- which are duplicated between the hit tests
+     * and the drawing, so each would have had to be found twice and could be
+     * fixed in one place and not the other -- everything goes through one
+     * mapping from that design size onto the live panel.
+     *
+     * At 320x240 it is the identity, so the board this was drawn for keeps the
+     * exact numbers it had. On a larger panel the layout fills it and the
+     * targets grow, while the text stays its own size: this is a system app,
+     * so it gets more room rather than bigger type. */
+    int16_t panelW_ = SCREEN_WIDTH;
+    int16_t panelH_ = SCREEN_HEIGHT;
+    void syncPanel(GameHost& host);
+    Rect baseRect(int16_t x, int16_t y, int16_t w, int16_t h) const;
+    int16_t baseX(int16_t x) const;
+    int16_t baseY(int16_t y) const;
 
     Rect netRect(uint8_t slot) const;
     Rect zoneRect(uint8_t slot) const;

--- a/src/hal/BoardTouch.cpp
+++ b/src/hal/BoardTouch.cpp
@@ -159,6 +159,28 @@ Board::RawTouch Board::readCapacitiveTouch() {
 #if !GUME_TOUCH_CAPACITIVE
 Board::RawTouch Board::readResistiveTouch() {
     RawTouch touch;
+
+#if defined(TOUCH_CS)
+    /* This board's XPT2046 shares the display's hardware SPI bus, arbitrated
+     * by its own CS, rather than having a bit-banged bus of its own. Use
+     * TFT_eSPI's built-in touch extension -- activated by TOUCH_CS in
+     * platformio.ini, and the same path the panel vendor's reference firmware
+     * takes -- rather than hand-rolling shared-bus transactions, because it
+     * already arbitrates correctly with the display driver. Bit-banging these
+     * lines as plain GPIO would fight that driver for pins it owns. */
+    const uint16_t pressure = tft_.getTouchRawZ();
+    if (pressure < BOARD.touch.pressureThreshold) {
+        return touch;
+    }
+    uint16_t sharedX = 0;
+    uint16_t sharedY = 0;
+    tft_.getTouchRaw(&sharedX, &sharedY);
+    touch.down = true;
+    touch.x = static_cast<int16_t>(sharedX);
+    touch.y = static_cast<int16_t>(sharedY);
+    touch.pressure = pressure;
+    return touch;
+#else
     const uint16_t z1 = readTouchAdc(CMD_READ_Z1);
     const uint16_t z2 = readTouchAdc(CMD_READ_Z2);
     uint16_t pressure = 0;
@@ -166,7 +188,13 @@ Board::RawTouch Board::readResistiveTouch() {
         pressure = static_cast<uint16_t>(z1 + 4095 - z2);
     }
 
-    const bool irqDown = digitalRead(BOARD.touch.irq) == LOW;
+    /* An IRQ this board cannot believe is worse than none. Where no pull-up is
+     * fitted the line floats LOW, and since this gate accepts a press when the
+     * IRQ is low OR pressure is high, trusting it would report a touch on
+     * every poll forever -- not degraded input, no input. Boards that say so
+     * gate on pressure alone, which is clean here: idle noise 10-20, a real
+     * press 2000+. */
+    const bool irqDown = BOARD.touch.irqUsable && digitalRead(BOARD.touch.irq) == LOW;
     if (!irqDown && pressure < BOARD.touch.pressureThreshold) {
         return touch;
     }
@@ -185,6 +213,7 @@ Board::RawTouch Board::readResistiveTouch() {
     touch.y = static_cast<int16_t>(y / samples);
     touch.pressure = pressure;
     return touch;
+#endif
 }
 
 #endif  /* !GUME_TOUCH_CAPACITIVE -- end of the XPT2046 half */

--- a/src/ui/LauncherLayout.cpp
+++ b/src/ui/LauncherLayout.cpp
@@ -73,18 +73,34 @@ Rect profileRect(Board::LayoutMode mode, int16_t screenW) {
     return Rect{x, 30, w, 18};
 }
 
-Rect tileRect(uint8_t slot, Board::LayoutMode mode) {
-    if (mode == Board::LayoutMode::Vertical) {
-        const uint8_t col = slot % 2;
-        const uint8_t row = slot / 2;
-        return Rect{static_cast<int16_t>(8 + col * 116),
-                    static_cast<int16_t>(LAUNCHER_HEADER_H_TALL + 8 + row * 104),
-                    108, 96};
-    }
+Rect tileRect(uint8_t slot, Board::LayoutMode mode, int16_t screenW, int16_t screenH) {
+    /* Divide what is actually there rather than stepping by a fixed pitch. The
+     * old form -- 10 + col * 155, 145 wide -- was a correct description of a
+     * 320px panel and a wrong one of anything else: on 480px it drew the same
+     * 300px of tiles and left 170px empty on the right, next to a header that
+     * had already adapted. The launcher is the first thing anyone sees, so it
+     * was also the most obvious way for a bigger board to look broken.
+     *
+     * Bigger tiles are the point on a larger panel, not a side effect: this
+     * board exists to give players who need one a plainer, easier screen, and
+     * a target that grows with the glass is easier to hit as well as to read. */
+    constexpr int16_t GAP = 8;
+    constexpr int16_t FOOTER_H = 32;  // the pager row
+
+    const bool tall = mode == Board::LayoutMode::Vertical;
+    const int16_t headerH = tall ? LAUNCHER_HEADER_H_TALL : LAUNCHER_HEADER_H_WIDE;
+    const uint8_t rows = tall ? 2 : 3;
+
+    // Two columns either way: three gaps across, one more than the row count down.
+    const int16_t tileW = static_cast<int16_t>((screenW - GAP * 3) / 2);
+    const int16_t tileH = static_cast<int16_t>(
+        (screenH - headerH - FOOTER_H - GAP * (rows + 1)) / rows);
 
     const uint8_t col = slot % 2;
     const uint8_t row = slot / 2;
-    return Rect{static_cast<int16_t>(10 + col * 155), static_cast<int16_t>(52 + row * 53), 145, 46};
+    return Rect{static_cast<int16_t>(GAP + col * (tileW + GAP)),
+                static_cast<int16_t>(headerH + GAP + row * (tileH + GAP)),
+                tileW, tileH};
 }
 
 uint8_t pageSize(Board::LayoutMode mode) {

--- a/src/ui/LauncherLayout.cpp
+++ b/src/ui/LauncherLayout.cpp
@@ -1,5 +1,7 @@
 #include "ui/LauncherLayout.h"
 
+#include "BoardConfig.h"
+
 namespace {
 
 constexpr int16_t LAUNCHER_HEADER_H_TALL = 78;
@@ -17,14 +19,34 @@ Rect topBarHomeRect() {
     return Rect{0, 0, 32, TOP_BAR_HEIGHT};
 }
 
-Rect topBarLockRect() {
-    /* Starts at 40 so that home's 8px of touch slop -- which reaches exactly
-     * 40 -- stops where the padlock starts drawing. The two targets overlap in
-     * slop only, never in pixels either of them paints. Sized like a status
-     * badge rather than like the gear: it belongs to the same family as the
-     * battery and Wi-Fi glyphs, and a gear-sized padlock read as a control
-     * twice as important as anything else on the bar. */
-    return Rect{40, 6, 18, 18};
+Rect topBarLockRect(int16_t screenW) {
+    /* Sized like a status badge rather than like the gear: it belongs to the
+     * same family as the battery and Wi-Fi glyphs, and a gear-sized padlock
+     * read as a control twice as important as anything else on the bar.
+     *
+     * At 320px it starts at 40, where home's 8px of touch slop ends, so the
+     * two overlap in slop only and never in painted pixels. That was as far
+     * apart as they could be on a bar with no spare room -- and it is too
+     * close: Home and Lock do opposite things, and reaching for Home is the
+     * commonest thing anyone does up here. Landing on the padlock instead
+     * blanks the screen and demands a hold to get back, which is a harsh
+     * price for a few pixels of aim.
+     *
+     * A wider panel has room the 320px bar never did, so spend some of it on
+     * separating them. The offset is a quarter of the extra width, capped, so
+     * 320px is unchanged and 480px opens a clear gap between Home's slop and
+     * the padlock's. */
+    const int16_t extra = static_cast<int16_t>((screenW - GAME_CANVAS_WIDTH) / 4);
+    const int16_t offset = extra < 0 ? 0 : (extra > 30 ? 30 : extra);
+    return Rect{static_cast<int16_t>(40 + offset), 6, 18, 18};
+}
+
+/* Derived from the padlock rather than stated, so the title cannot creep back
+ * over it when the lock moves. At 320px this is 40 + 18 + 4 = 62, which is
+ * exactly where the title has always started. */
+int16_t topBarTitleLeft(int16_t screenW) {
+    const Rect lock = topBarLockRect(screenW);
+    return static_cast<int16_t>(lock.x + lock.w + 4);
 }
 
 /* Both layouts put the padlock in the status cluster, at badge size, centred

--- a/src/ui/LauncherLayout.h
+++ b/src/ui/LauncherLayout.h
@@ -22,7 +22,15 @@ Rect lockRect(Board::LayoutMode mode, int16_t screenW);
 int16_t headerHeight(Board::LayoutMode mode);
 Rect gearRect(Board::LayoutMode mode, int16_t screenW);
 Rect profileRect(Board::LayoutMode mode, int16_t screenW);
-Rect tileRect(uint8_t slot, Board::LayoutMode mode);
+/* The launcher's tile grid, measured against the live panel.
+ *
+ * screenW/screenH are required rather than defaulted. Everything else on this
+ * screen -- gear, profile, lock, the top bar -- already takes a width and
+ * adapts; the tiles alone were fixed at the 320x240 geometry, so on a 480x320
+ * panel they stopped two-thirds of the way across and left a dead band while
+ * the header and pager correctly reached the edges. A default of 320/240 here
+ * would be that same literal, just hidden where nobody would look for it. */
+Rect tileRect(uint8_t slot, Board::LayoutMode mode, int16_t screenW, int16_t screenH);
 uint8_t pageSize(Board::LayoutMode mode);
 
 }  // namespace LauncherLayout

--- a/src/ui/LauncherLayout.h
+++ b/src/ui/LauncherLayout.h
@@ -13,7 +13,9 @@ Rect topBarSettingsRect(int16_t screenW);
  * the lock takes comes out of the title. Drawing and hit testing both read
  * these, so the glyph and its target cannot drift apart. */
 Rect topBarHomeRect();
-Rect topBarLockRect();
+Rect topBarLockRect(int16_t screenW);
+/** Where the top bar's title may start: clear of Home and the padlock. */
+int16_t topBarTitleLeft(int16_t screenW);
 
 /* Where the launcher draws its own Lock button. The launcher has no top bar,
  * so it needs its own slot: the air between the title and the profile name in

--- a/src/ui/Renderer.h
+++ b/src/ui/Renderer.h
@@ -58,6 +58,11 @@ public:
     virtual void setTextDatum(uint8_t datum) = 0;
     virtual void setTextColor(uint16_t fg) = 0;
     virtual void setTextColor(uint16_t fg, uint16_t bg, bool bgFill = false) = 0;
+    /* Whole-number glyph scale for subsequent drawString()/textWidth() calls.
+     * Implementations must apply this before every text op rather than
+     * relying on it staying set, since the same driver instance is shared
+     * across screens that want different scales. */
+    virtual void setTextSize(uint8_t size) = 0;
     virtual int16_t drawString(const char* text, int32_t x, int32_t y, uint8_t font = 2) = 0;
     template <typename Text>
     auto drawString(const Text& text, int32_t x, int32_t y, uint8_t font = 2)
@@ -81,6 +86,25 @@ public:
     virtual bool getSwapBytes() = 0;
     virtual void setSwapBytes(bool swap) = 0;
     virtual void pushPixels(uint16_t* data, uint32_t len) = 0;
+
+    /* Average scale factor relative to the fixed game canvas. Returns 1.0
+     * when the panel is exactly the canvas size, so nothing changes there.
+     * ScaledRenderer overrides this so image-blitting helpers can choose an
+     * appropriate integer scale rather than drawing at native size on a
+     * physically larger panel. */
+    virtual float imageScale() const { return 1.0f; }
+
+    /* Per-axis scale factors. Used by trig-based pie/wedge drawing to
+     * pre-correct radii so wedge points land on the same circle that
+     * fillCircle draws (which uses the averaged radius). */
+    virtual float imageScaleX() const { return 1.0f; }
+    virtual float imageScaleY() const { return 1.0f; }
+
+    /* The underlying physical renderer, bypassing any coordinate transform.
+     * Image-blitting code that computes its own scaled origin and pushes raw
+     * pixel data needs this -- ScaledRenderer's setAddrWindow would otherwise
+     * scale coordinates that have already been scaled. Defaults to `this`. */
+    virtual Renderer* physicalRenderer() { return this; }
 };
 
 }  // namespace Ui

--- a/src/ui/ScaledRenderer.h
+++ b/src/ui/ScaledRenderer.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <math.h>
+
+#include "BoardConfig.h"
+#include "ui/Renderer.h"
+
+namespace Ui {
+
+/* Wraps another Renderer and stretches shape/layout coordinates from the fixed
+ * game canvas (GAME_CANVAS_WIDTH x GAME_CANVAS_HEIGHT) onto a physically
+ * bigger panel. It is computed from the panel's actual size rather than from
+ * any one board, so a future board with yet another resolution gets the same
+ * treatment without touching this file.
+ *
+ * This exists because the playable games are authored against a fixed canvas
+ * and position everything by arithmetic on it -- see BoardConfig.h, where that
+ * canvas is stated rather than derived. Scaling here is what lets a bigger
+ * panel fill its screen without every game learning a second layout.
+ *
+ * Two things deliberately do NOT scale:
+ *
+ * - Images (setAddrWindow's w/h, pushPixels' pixel data) stay native size.
+ *   Only the address window's origin moves, so a flag keeps its real pixel
+ *   dimensions but lands in the same relative spot on the bigger screen.
+ * - Text renders at a fixed whole-number size (TFT_eSPI's font renderer has no
+ *   arbitrary-scale option), not proportionally stretched; only its position
+ *   moves with everything else.
+ *
+ * On a panel that is exactly the canvas size, scaleX_ and scaleY_ are both 1.0
+ * and textScale_ is 1, so every method here is a value-preserving passthrough
+ * and this class changes nothing. */
+class ScaledRenderer final : public Renderer {
+public:
+    using Renderer::drawString;
+    using Renderer::textWidth;
+
+    /* Constructed at scale 1.0 -- a no-op -- so it is safe to build before
+     * Board::begin() has run; call configure() once the panel size is known. */
+    explicit ScaledRenderer(Renderer& inner, uint8_t textScale = 1)
+        : inner_(inner), textScale_(textScale) {}
+
+    void configure(int16_t physicalWidth, int16_t physicalHeight) {
+        scaleX_ = static_cast<float>(physicalWidth) / GAME_CANVAS_WIDTH;
+        scaleY_ = static_cast<float>(physicalHeight) / GAME_CANVAS_HEIGHT;
+    }
+
+    // Games only ever know about the fixed logical canvas.
+    int16_t width() override { return GAME_CANVAS_WIDTH; }
+    int16_t height() override { return GAME_CANVAS_HEIGHT; }
+
+    void fillScreen(uint16_t color) override { inner_.fillScreen(color); }
+    void fillRect(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t color) override {
+        inner_.fillRect(sx(x), sy(y), sw(w), sh(h), color);
+    }
+    void drawRect(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t color) override {
+        inner_.drawRect(sx(x), sy(y), sw(w), sh(h), color);
+    }
+    void fillRoundRect(int32_t x, int32_t y, int32_t w, int32_t h,
+                       int32_t radius, uint16_t color) override {
+        inner_.fillRoundRect(sx(x), sy(y), sw(w), sh(h), sr(radius), color);
+    }
+    void drawRoundRect(int32_t x, int32_t y, int32_t w, int32_t h,
+                       int32_t radius, uint16_t color) override {
+        inner_.drawRoundRect(sx(x), sy(y), sw(w), sh(h), sr(radius), color);
+    }
+    void drawFastHLine(int32_t x, int32_t y, int32_t w, uint16_t color) override {
+        inner_.drawFastHLine(sx(x), sy(y), sw(w), color);
+    }
+    void drawFastVLine(int32_t x, int32_t y, int32_t h, uint16_t color) override {
+        inner_.drawFastVLine(sx(x), sy(y), sh(h), color);
+    }
+    void drawLine(int32_t x0, int32_t y0, int32_t x1, int32_t y1,
+                  uint16_t color) override {
+        inner_.drawLine(sx(x0), sy(y0), sx(x1), sy(y1), color);
+    }
+    void drawPixel(int32_t x, int32_t y, uint16_t color) override {
+        inner_.drawPixel(sx(x), sy(y), color);
+    }
+    void drawCircle(int32_t x, int32_t y, int32_t radius, uint16_t color) override {
+        inner_.drawCircle(sx(x), sy(y), sr(radius), color);
+    }
+    /* Radii go through sr(), the averaged scale, so a circle stays a circle
+     * rather than becoming an ellipse. fillTriangle scales x and y
+     * independently, so the games' pie-slice fills -- which pass the same
+     * logical radius to both -- only line up with their enclosing circle
+     * because this uses sr() too. Changing one without the other detaches
+     * every wedge from its circle. */
+    void fillCircle(int32_t x, int32_t y, int32_t radius, uint16_t color) override {
+        inner_.fillCircle(sx(x), sy(y), sr(radius), color);
+    }
+    void drawTriangle(int32_t x0, int32_t y0, int32_t x1, int32_t y1,
+                      int32_t x2, int32_t y2, uint16_t color) override {
+        inner_.drawTriangle(sx(x0), sy(y0), sx(x1), sy(y1), sx(x2), sy(y2), color);
+    }
+    void fillTriangle(int32_t x0, int32_t y0, int32_t x1, int32_t y1,
+                      int32_t x2, int32_t y2, uint16_t color) override {
+        inner_.fillTriangle(sx(x0), sy(y0), sx(x1), sy(y1), sx(x2), sy(y2), color);
+    }
+
+    void setTextDatum(uint8_t datum) override { inner_.setTextDatum(datum); }
+    void setTextColor(uint16_t fg) override { inner_.setTextColor(fg); }
+    void setTextColor(uint16_t fg, uint16_t bg, bool bgFill = false) override {
+        inner_.setTextColor(fg, bg, bgFill);
+    }
+    void setTextSize(uint8_t size) override { inner_.setTextSize(size); }
+    int16_t drawString(const char* text, int32_t x, int32_t y, uint8_t font = 2) override {
+        inner_.setTextSize(textScale_);
+        return inner_.drawString(text, sx(x), sy(y), font);
+    }
+    int16_t textWidth(const char* text, uint8_t font = 2) override {
+        inner_.setTextSize(textScale_);
+        return inner_.textWidth(text, font);
+    }
+
+    void setViewport(int32_t x, int32_t y, int32_t w, int32_t h,
+                     bool vpDatum = true) override {
+        inner_.setViewport(sx(x), sy(y), sw(w), sh(h), vpDatum);
+    }
+    void resetViewport() override { inner_.resetViewport(); }
+
+    void startWrite() override { inner_.startWrite(); }
+    void endWrite() override { inner_.endWrite(); }
+    // Only the origin moves -- w/h stay native pixel dimensions (see class comment).
+    void setAddrWindow(int32_t x, int32_t y, int32_t w, int32_t h) override {
+        inner_.setAddrWindow(sx(x), sy(y), w, h);
+    }
+    bool getSwapBytes() override { return inner_.getSwapBytes(); }
+    void setSwapBytes(bool swap) override { inner_.setSwapBytes(swap); }
+    void pushPixels(uint16_t* data, uint32_t len) override { inner_.pushPixels(data, len); }
+
+    float imageScale() const override { return (scaleX_ + scaleY_) * 0.5f; }
+    float imageScaleX() const override { return scaleX_; }
+    float imageScaleY() const override { return scaleY_; }
+    Renderer* physicalRenderer() override { return &inner_; }
+
+private:
+    static int32_t roundf32(float v) { return static_cast<int32_t>(lroundf(v)); }
+    int32_t sx(int32_t v) const { return roundf32(v * scaleX_); }
+    int32_t sy(int32_t v) const { return roundf32(v * scaleY_); }
+    int32_t sw(int32_t v) const { return roundf32(v * scaleX_); }
+    int32_t sh(int32_t v) const { return roundf32(v * scaleY_); }
+    // Radii have one dimension to scale two axes into -- split the difference
+    // so circles stay circles.
+    int32_t sr(int32_t v) const { return roundf32(v * (scaleX_ + scaleY_) * 0.5f); }
+
+    Renderer& inner_;
+    float scaleX_ = 1.0f;
+    float scaleY_ = 1.0f;
+    uint8_t textScale_;
+};
+
+}  // namespace Ui

--- a/src/ui/ScaledRenderer.h
+++ b/src/ui/ScaledRenderer.h
@@ -133,23 +133,17 @@ public:
 
     void startWrite() override { inner_.startWrite(); }
     void endWrite() override { inner_.endWrite(); }
-    /* Images keep their native pixel size and are CENTRED in the space the
-     * layout gave them.
+    /* Only the origin moves; w/h stay native pixel dimensions.
      *
-     * Scaling the origin alone was wrong, and visibly so on flags and maps: the
-     * artwork stayed its true size while the box around it grew, so its centre
-     * drifted up and to the left by half the growth and it sat in the corner of
-     * its own frame rather than in the middle of it. Resampling the pixels
-     * instead would be worse -- these are small bitmaps and stretching them by
-     * 1.5 with no filtering turns a flag's stripes into ragged steps.
-     *
-     * So: place the unscaled image at the centre of the scaled rect. On a panel
-     * that is already canvas-sized both terms are zero and this is the old
-     * behaviour exactly. */
+     * Nothing in the firmware should reach this while scaling is active, and
+     * that is deliberate. A blit is one scanline per call, so a fractional row
+     * pitch makes consecutive rows overlap and gap and the image tears into
+     * bands. Ui.cpp's image helpers therefore compute a physical destination
+     * once and write through physicalRenderer(), which keeps rows 1:1 and
+     * centres the artwork properly -- see physicalImageOrigin() there. This
+     * override remains only so the interface is honoured. */
     void setAddrWindow(int32_t x, int32_t y, int32_t w, int32_t h) override {
-        const int32_t offsetX = (sw(w) - w) / 2;
-        const int32_t offsetY = (sh(h) - h) / 2;
-        inner_.setAddrWindow(sx(x) + offsetX, sy(y) + offsetY, w, h);
+        inner_.setAddrWindow(sx(x), sy(y), w, h);
     }
     bool getSwapBytes() override { return inner_.getSwapBytes(); }
     void setSwapBytes(bool swap) override { inner_.setSwapBytes(swap); }

--- a/src/ui/ScaledRenderer.h
+++ b/src/ui/ScaledRenderer.h
@@ -45,6 +45,18 @@ public:
         scaleY_ = static_cast<float>(physicalHeight) / GAME_CANVAS_HEIGHT;
     }
 
+    /* Scale directly, for callers that are not stretching the game canvas.
+     *
+     * The launcher icons use this. They are vector art with their geometry
+     * written inline across thirty-odd cases, so there is no size argument to
+     * pass and adding one would mean editing every icon. Drawing them through
+     * a renderer scaled by s, with the centre point divided by s, scales the
+     * art about that centre and leaves the icon code untouched. */
+    void setScale(float x, float y) {
+        scaleX_ = x;
+        scaleY_ = y;
+    }
+
     // Games only ever know about the fixed logical canvas.
     int16_t width() override { return GAME_CANVAS_WIDTH; }
     int16_t height() override { return GAME_CANVAS_HEIGHT; }
@@ -121,9 +133,23 @@ public:
 
     void startWrite() override { inner_.startWrite(); }
     void endWrite() override { inner_.endWrite(); }
-    // Only the origin moves -- w/h stay native pixel dimensions (see class comment).
+    /* Images keep their native pixel size and are CENTRED in the space the
+     * layout gave them.
+     *
+     * Scaling the origin alone was wrong, and visibly so on flags and maps: the
+     * artwork stayed its true size while the box around it grew, so its centre
+     * drifted up and to the left by half the growth and it sat in the corner of
+     * its own frame rather than in the middle of it. Resampling the pixels
+     * instead would be worse -- these are small bitmaps and stretching them by
+     * 1.5 with no filtering turns a flag's stripes into ragged steps.
+     *
+     * So: place the unscaled image at the centre of the scaled rect. On a panel
+     * that is already canvas-sized both terms are zero and this is the old
+     * behaviour exactly. */
     void setAddrWindow(int32_t x, int32_t y, int32_t w, int32_t h) override {
-        inner_.setAddrWindow(sx(x), sy(y), w, h);
+        const int32_t offsetX = (sw(w) - w) / 2;
+        const int32_t offsetY = (sh(h) - h) / 2;
+        inner_.setAddrWindow(sx(x) + offsetX, sy(y) + offsetY, w, h);
     }
     bool getSwapBytes() override { return inner_.getSwapBytes(); }
     void setSwapBytes(bool swap) override { inner_.setSwapBytes(swap); }

--- a/src/ui/TftRenderer.h
+++ b/src/ui/TftRenderer.h
@@ -63,10 +63,17 @@ public:
     void setTextColor(uint16_t fg, uint16_t bg, bool bgFill = false) override {
         tft_.setTextColor(fg, bg, bgFill);
     }
+    void setTextSize(uint8_t size) override { tft_.setTextSize(size); }
+    /* Unconditionally 1x here, not "leave whatever was set before" -- this
+     * driver instance is shared with ScaledRenderer, which sets a bigger size
+     * for playable games. Without resetting it here, system-app text would
+     * inherit whatever a game left behind. */
     int16_t drawString(const char* text, int32_t x, int32_t y, uint8_t font = 2) override {
+        tft_.setTextSize(1);
         return static_cast<int16_t>(tft_.drawString(text, x, y, font));
     }
     int16_t textWidth(const char* text, uint8_t font = 2) override {
+        tft_.setTextSize(1);
         return static_cast<int16_t>(tft_.textWidth(text, font));
     }
 

--- a/src/ui/TftRenderer.h
+++ b/src/ui/TftRenderer.h
@@ -63,17 +63,24 @@ public:
     void setTextColor(uint16_t fg, uint16_t bg, bool bgFill = false) override {
         tft_.setTextColor(fg, bg, bgFill);
     }
-    void setTextSize(uint8_t size) override { tft_.setTextSize(size); }
-    /* Unconditionally 1x here, not "leave whatever was set before" -- this
-     * driver instance is shared with ScaledRenderer, which sets a bigger size
-     * for playable games. Without resetting it here, system-app text would
-     * inherit whatever a game left behind. */
+    /* Remembered rather than pushed straight at the driver, and re-applied
+     * before every text op.
+     *
+     * The driver instance is shared with ScaledRenderer, which sets a bigger
+     * size for playable games, so a screen that never asks for a size must not
+     * inherit whatever a game left behind. The first version of this forced 1x
+     * inside drawString to guarantee that -- which also made setTextSize()
+     * impossible to use, silently: callers set a size, the next drawString
+     * threw it away, and text came out 1x with no error anywhere. Tracking it
+     * here gives both properties: an explicit size is honoured, and the
+     * default is always 1x rather than a leftover. */
+    void setTextSize(uint8_t size) override { textSize_ = size < 1 ? 1 : size; }
     int16_t drawString(const char* text, int32_t x, int32_t y, uint8_t font = 2) override {
-        tft_.setTextSize(1);
+        tft_.setTextSize(textSize_);
         return static_cast<int16_t>(tft_.drawString(text, x, y, font));
     }
     int16_t textWidth(const char* text, uint8_t font = 2) override {
-        tft_.setTextSize(1);
+        tft_.setTextSize(textSize_);
         return static_cast<int16_t>(tft_.textWidth(text, font));
     }
 
@@ -94,6 +101,7 @@ public:
 
 private:
     TFT_eSPI& tft_;
+    uint8_t textSize_ = 1;
 };
 
 }  // namespace Ui

--- a/src/ui/Ui.cpp
+++ b/src/ui/Ui.cpp
@@ -226,7 +226,7 @@ void drawTopBar(Board& board, const String& title) {
     /* Lock beside Home: one tap blanks the panel and the next wake asks for a
      * hold. The 18px it occupies come out of the title, which is why the
      * title's start and its budget below both moved. */
-    drawLockIcon(tft, LauncherLayout::topBarLockRect(), COLOR_BAR_TEXT, COLOR_BAR);
+    drawLockIcon(tft, LauncherLayout::topBarLockRect(w), COLOR_BAR_TEXT, COLOR_BAR);
     // The top bar stays dark in both themes, so this gear is always white.
     drawGearIcon(tft, Rect{static_cast<int16_t>(w - 34), 3, 26, 24}, COLOR_BAR_TEXT);
     tft.setTextColor(COLOR_BAR_TEXT, COLOR_BAR);
@@ -247,11 +247,13 @@ void drawTopBar(Board& board, const String& title) {
     String fitted = title;
     const int16_t statusLeft =
         static_cast<int16_t>(clockRight - tft.textWidth(Clock::timeText(), 2));
-    const int16_t titleMax = static_cast<int16_t>(max<int16_t>(32, statusLeft - 66));
+    const int16_t titleLeft = LauncherLayout::topBarTitleLeft(w);
+    const int16_t titleMax =
+        static_cast<int16_t>(max<int16_t>(32, statusLeft - titleLeft - 4));
     while (fitted.length() > 2 && tft.textWidth(fitted, 2) > titleMax) {
         fitted.remove(fitted.length() - 1);
     }
-    tft.drawString(fitted, 62, TOP_BAR_HEIGHT / 2, 2);
+    tft.drawString(fitted, titleLeft, TOP_BAR_HEIGHT / 2, 2);
     tft.setTextDatum(MR_DATUM);
     /* Right side: clock and its sync badge kept together (the badge describes
      * the clock), then the wifi badge, then the gear. */

--- a/src/ui/Ui.cpp
+++ b/src/ui/Ui.cpp
@@ -812,21 +812,58 @@ constexpr int16_t MNF_MAX_ROW = (MNF_FLAG_WIDTH > MNF_MAP_BOX) ? MNF_FLAG_WIDTH 
  * Save/restore rather than setting it globally, so we do not disturb any other
  * drawing code that relies on the current setting.
  */
+/* Where a native-size image goes on the real panel.
+ *
+ * Artwork is never resampled: these are small bitmaps and stretching them by a
+ * non-integer factor with no filtering turns a flag's stripes into ragged
+ * steps. So the pixels keep their size and only the destination moves -- but
+ * that destination has to be computed here, against the physical panel, for
+ * two separate reasons.
+ *
+ * The blit is row by row, one scanline per setAddrWindow. Sent through a
+ * scaling renderer each 1px row becomes 1.33px, so consecutive rows
+ * alternately overlap and leave gaps and the image tears into bands. That is
+ * the distortion; it is not a scaling artefact of the artwork but of the
+ * addressing. Writing straight to the physical renderer keeps rows 1:1.
+ *
+ * And the image is CENTRED in the scaled rect rather than placed at a scaled
+ * origin. Scaling the origin alone leaves it short of centre by a quarter of
+ * its own width -- correct-looking on a board that does not scale, visibly
+ * off on one that does.
+ *
+ * On a board whose panel is the canvas both scales are 1 and this returns
+ * exactly the coordinates it was given. */
+static void physicalImageOrigin(Ui::Renderer& tft, const Rect& r,
+                                int16_t imgW, int16_t imgH,
+                                Ui::Renderer** phys, int32_t* px, int32_t* py) {
+    *phys = tft.physicalRenderer();
+    const float sxAxis = tft.imageScaleX();
+    const float syAxis = tft.imageScaleY();
+    *px = static_cast<int32_t>(lroundf(r.x * sxAxis + (r.w * sxAxis - imgW) / 2.0f));
+    *py = static_cast<int32_t>(lroundf(r.y * syAxis + (r.h * syAxis - imgH) / 2.0f));
+}
+
 void drawCountryImage(Ui::Renderer& tft, const void* img, int16_t x, int16_t y, uint16_t bgColor) {
     const mnf_img_t* im = static_cast<const mnf_img_t*>(img);
     if (im == nullptr) return;
 
+    Ui::Renderer* phys = nullptr;
+    int32_t px = 0;
+    int32_t py = 0;
+    physicalImageOrigin(tft, Rect{x, y, static_cast<int16_t>(im->w), static_cast<int16_t>(im->h)},
+                        static_cast<int16_t>(im->w), static_cast<int16_t>(im->h), &phys, &px, &py);
+
     uint16_t row[MNF_MAX_ROW];
-    const bool prevSwap = tft.getSwapBytes();
-    tft.setSwapBytes(true);
-    tft.startWrite();
+    const bool prevSwap = phys->getSwapBytes();
+    phys->setSwapBytes(true);
+    phys->startWrite();
     for (uint16_t yy = 0; yy < im->h; ++yy) {
         mnf_row_rgb565(im, yy, row, bgColor);
-        tft.setAddrWindow(x, static_cast<int16_t>(y + yy), im->w, 1);
-        tft.pushPixels(row, im->w);
+        phys->setAddrWindow(px, py + yy, im->w, 1);
+        phys->pushPixels(row, im->w);
     }
-    tft.endWrite();
-    tft.setSwapBytes(prevSwap);
+    phys->endWrite();
+    phys->setSwapBytes(prevSwap);
 }
 
 bool drawCountryImageCentred(Ui::Renderer& tft, const void* img, const Rect& r, uint16_t bgColor) {
@@ -843,20 +880,23 @@ bool drawCountryImageTinted(Ui::Renderer& tft, const void* img, const Rect& r,
     const mnf_img_t* im = static_cast<const mnf_img_t*>(img);
     if (im == nullptr) return false;
 
-    const int16_t x = static_cast<int16_t>(r.x + (r.w - im->w) / 2);
-    const int16_t y = static_cast<int16_t>(r.y + (r.h - im->h) / 2);
+    Ui::Renderer* phys = nullptr;
+    int32_t px = 0;
+    int32_t py = 0;
+    physicalImageOrigin(tft, r, static_cast<int16_t>(im->w), static_cast<int16_t>(im->h),
+                        &phys, &px, &py);
 
     uint16_t row[MNF_MAX_ROW];
-    const bool prevSwap = tft.getSwapBytes();
-    tft.setSwapBytes(true);
-    tft.startWrite();
+    const bool prevSwap = phys->getSwapBytes();
+    phys->setSwapBytes(true);
+    phys->startWrite();
     for (uint16_t yy = 0; yy < im->h; ++yy) {
         mnf_row_rgb565_tint(im, yy, row, bgColor, inkColor);
-        tft.setAddrWindow(x, static_cast<int16_t>(y + yy), im->w, 1);
-        tft.pushPixels(row, im->w);
+        phys->setAddrWindow(px, py + yy, im->w, 1);
+        phys->pushPixels(row, im->w);
     }
-    tft.endWrite();
-    tft.setSwapBytes(prevSwap);
+    phys->endWrite();
+    phys->setSwapBytes(prevSwap);
     return true;
 }
 
@@ -866,13 +906,18 @@ bool drawCountryImageScaled(Ui::Renderer& tft, const void* img, const Rect& r,
     if (im == nullptr) return false;
     if (scale < 1) scale = 1;
 
-    // Cap the scale so the result still fits the target rect.
-    while (scale > 1 && (im->w * scale > r.w || im->h * scale > r.h)) --scale;
+    /* Cap the scale against the rect as it exists ON THE PANEL, not in canvas
+     * units. The artwork is enlarged by whole-pixel replication, so a board
+     * with a physically bigger rect can carry a bigger multiple -- which is
+     * the one way this artwork gets larger at all, since it is never resampled.
+     * On a board where the canvas is the panel both are the same number. */
+    const int16_t availW = static_cast<int16_t>(r.w * tft.imageScaleX());
+    const int16_t availH = static_cast<int16_t>(r.h * tft.imageScaleY());
+    while (scale > 1 && (im->w * scale > availW || im->h * scale > availH)) --scale;
     if (scale == 1) return drawCountryImageCentred(tft, im, r, bgColor);
 
     const int16_t outW = static_cast<int16_t>(im->w * scale);
-    const int16_t x = static_cast<int16_t>(r.x + (r.w - outW) / 2);
-    const int16_t y = static_cast<int16_t>(r.y + (r.h - im->h * scale) / 2);
+    const int16_t outH = static_cast<int16_t>(im->h * scale);
 
     uint16_t src[MNF_MAX_ROW];
     uint16_t dst[MNF_MAX_ROW * 3];   // scale is clamped to 3 by the rect check below
@@ -880,21 +925,29 @@ bool drawCountryImageScaled(Ui::Renderer& tft, const void* img, const Rect& r,
         return drawCountryImageCentred(tft, im, r, bgColor);
     }
 
-    const bool prevSwap = tft.getSwapBytes();
-    tft.setSwapBytes(true);
-    tft.startWrite();
+    Ui::Renderer* phys = nullptr;
+    int32_t px = 0;
+    int32_t py = 0;
+    physicalImageOrigin(tft, r, outW, outH, &phys, &px, &py);
+
+    const bool prevSwap = phys->getSwapBytes();
+    phys->setSwapBytes(true);
+    phys->startWrite();
     for (uint16_t yy = 0; yy < im->h; ++yy) {
         mnf_row_rgb565(im, yy, src, bgColor);
         for (uint16_t xx = 0; xx < im->w; ++xx) {
             for (uint8_t s = 0; s < scale; ++s) dst[xx * scale + s] = src[xx];
         }
+        /* Integer row replication, straight to the panel: every output row is
+         * a whole pixel tall, so the nearest-neighbour enlargement stays clean
+         * instead of tearing the way a fractional row pitch does. */
         for (uint8_t s = 0; s < scale; ++s) {
-            tft.setAddrWindow(x, static_cast<int16_t>(y + yy * scale + s), outW, 1);
-            tft.pushPixels(dst, outW);
+            phys->setAddrWindow(px, py + yy * scale + s, outW, 1);
+            phys->pushPixels(dst, outW);
         }
     }
-    tft.endWrite();
-    tft.setSwapBytes(prevSwap);
+    phys->endWrite();
+    phys->setSwapBytes(prevSwap);
     return true;
 }
 

--- a/tools/check_boards.py
+++ b/tools/check_boards.py
@@ -57,7 +57,7 @@ REQUIRED_BOARD_MACROS = ("BOARD_NAME", "GUME_BOARD_HEADER",
 # build. Making it before the capacitive touch path exists would advertise a
 # firmware that boots into a screen nobody can press, which is precisely the
 # outcome BoardProfile.h refuses to allow. The section arrives with the port.
-BOARDLESS_ENVS = ("wifidiag", "s3diag")
+BOARDLESS_ENVS = ("wifidiag", "s3diag", "diag4")
 
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -80,6 +80,15 @@ VARIANTS = (
                 "Wi-Fi clock and the BLE beacon.",
     },
     {
+        "env": "app_e32r40t",
+        "label": "Braino! (the games) -- E32R40T (4 inch ST7796)",
+        "name": "Braino!",
+        "note": "The full console on a 4 inch screen: {count} games, profiles, scores, settings, "
+                "Wi-Fi clock and the BLE beacon. The bigger panel is the point -- games are "
+                "scaled up with larger text, for players who want a plainer, easier screen to "
+                "read. This board has no SD, status LED, sound or battery gauge yet.",
+    },
+    {
         "env": "app_fnk0104b",
         "label": "Braino! (the games) -- Freenove FNK0104B (ESP32-S3, capacitive touch)",
         "name": "Braino!",
@@ -116,6 +125,11 @@ BOARD_DETAILS = {
         "label": "ESP32-2432S028Rv3 -- 2.4 inch newer CYD variant (ST7789 + XPT2046 resistive touch, USB-C/dual-USB)",
         "chip": "ESP32",
         "buy": "https://www.aliexpress.com/w/wholesale-esp32-2432s028.html",
+    },
+    "e32r40t": {
+        "label": "E32R40T / ESP32-32E -- 4 inch ST7796 + XPT2046 (resistive)",
+        "chip": "ESP32",
+        "buy": "https://www.lcdwiki.com/4.0inch_ESP32-32E_Display",
     },
     "fnk0104b": {
         "label": "Freenove FNK0104B -- 2.8 inch ESP32-S3 (ILI9341 + FT6336U capacitive touch, USB-C)",

--- a/tools/pack_release.py
+++ b/tools/pack_release.py
@@ -81,6 +81,7 @@ ENV_BLURBS = {
                 "interfere with the result.",
     "batdiag": "Eight-page battery bring-up and calibration tool, with CSV "
                "over serial for capturing a full discharge.",
+    "app_e32r40t": "Braino! for the 4-inch E32R40T (ST7796): the full console on a bigger screen, with games scaled up for easier reading.",
     "diag4": "Bring-up probe for an unsupported 4-inch ST7796 board: identifies the panel controller over SPI, sweeps candidate backlight pins and tests both touch wirings.",
     "s3diag": "Bring-up probe for an unsupported ESP32-S3 board: panel, "
               "rotation, I2C touch scan and battery divider. Not the console.",

--- a/tools/pack_release.py
+++ b/tools/pack_release.py
@@ -81,6 +81,7 @@ ENV_BLURBS = {
                 "interfere with the result.",
     "batdiag": "Eight-page battery bring-up and calibration tool, with CSV "
                "over serial for capturing a full discharge.",
+    "diag4": "Bring-up probe for an unsupported 4-inch ST7796 board: identifies the panel controller over SPI, sweeps candidate backlight pins and tests both touch wirings.",
     "s3diag": "Bring-up probe for an unsupported ESP32-S3 board: panel, "
               "rotation, I2C touch scan and battery divider. Not the console.",
 }


### PR DESCRIPTION
Adds the 4-inch LCDWIKI E32R40T as a supported board, and fixes the layout
faults that only a panel bigger than the game canvas could expose.

The board exists in Braino for a particular audience: a physically bigger,
plainer screen for players who need one.

## What was measured, not assumed

Brought up with a new standalone probe (`env:diag4`) rather than by porting the
abandoned `feat/st7796-4inch-board` branch, whose values were self-described
guesses:

| Fact | Result |
|---|---|
| Controller / geometry | ST7796, 320x480 native, rotation 3 -> 480x320 landscape |
| Display bus | **Identical** to the 2.8-inch board: MISO 12, MOSI 13, SCLK 14, CS 15, DC 2, HSPI 40MHz |
| Backlight | **GPIO27**. GPIO21 -- the obvious assumption -- measured dark twice, once from a clean reset |
| Touch | XPT2046 sharing the display bus, CS 33 |
| Touch IRQ | Wired to 36 but **unusable**: no pull-up fitted, floats low, reports a permanent false pen-down |

The backlight is the pin that fails silently -- wrong value gives a black panel
while Wi-Fi, BLE, NVS and the screen saver all run perfectly, so the log looks
healthy. `BoardConfig.h` static_asserts the profile against `TFT_BL`, so the two
cannot drift.

## One new profile field

`TouchProfile::irqUsable`. The resistive gate accepts a press when the IRQ is
low **or** pressure is high, so an IRQ that floats low does not degrade touch,
it defeats it -- every poll reports a touch, forever. Whether the pull-up is
fitted is a property of the board, so it is stated rather than inferred, and
filled in for all five boards.

## The layout faults

- **Games laid out against the panel instead of their canvas.** `SCREEN_WIDTH`
  is correctly 480 here, but a playable game draws into the fixed 320-wide
  canvas that `ScaledRenderer` stretches, so `SCREEN_WIDTH / 2` asked for 240 in
  canvas space and became 360 physical. Every centred element sat 120px right.
  Fixed across 29 files, 107 references.
- **Launcher tiles** were fixed at `10 + col * 155`, which describes a 320px
  panel and no other -- so they stopped two thirds across on the first screen
  anyone sees. They now divide the space they are given, and their contents
  scale with them.
- **Images tore into bands.** The blit is one scanline per `setAddrWindow`, so
  through a scaling renderer each 1px row became 1.33px and rows alternately
  overlapped and gapped. All three image helpers now write 1:1 to the physical
  renderer, and centre the artwork rather than placing it at a scaled origin.
- **Pie slices detached from their circles.** `fillCircle` uses the averaged
  axis scale so it stays a circle; the wedge points were scaled per axis and
  landed on an ellipse.
- **Enlargement is by whole numbers or not at all.** Icons are built from small
  integers -- 1px strokes, a 17px radius -- and a fractional multiplier rounds
  each independently. Coarse art survived it; detailed art did not.
- **Scores** had zero references to the panel's size: 300 lines of literals
  where `304` is `320 - 16`. Its geometry is now measured, and reproduces the
  old numbers exactly at 320x240.

## Effect on existing boards

None intended, and mostly provable: all four other boards are 240x320 native ->
320x240 landscape, which **is** the game canvas, so every scaling path is a
value-preserving passthrough at scale 1.0. The games sweep left the 2.8-inch
firmware byte-identical when it landed.

## Verification

- `pio run -e app_e32r40t` and `-e app` both build on this tree
- `check_docs`, `check_boards` (5 boards, 44 fields), `check_catalog`,
  `check_frame_rules`, `check_privacy` all clean; `gen_site.py` generates
- Registered as a supported board: web-installer label and offered firmware,
  CI build, release-packer description
- Flashed and run on the hardware: boots, advertises, joins Wi-Fi, touch works

## Known gaps

- **Settings and Wi-Fi still use fixed geometry.** Wi-Fi reads `SCREEN_WIDTH`
  twelve times and the live panel never; Settings is partway. Both also want
  portrait, which they have never had. `SettingsGame` is 613 lines and wants its
  refactor commit first, per the 600-line rule.
- **Worst frame 165ms** against a 20ms budget, on the 4-inch board only: a full
  repaint doubled to ~307KB over SPI.
- **SD slot left `PIN_NONE`** -- not characterised, and declared absent rather
  than guessed. LED, speaker and battery are inherited from the E32R28T-1, each
  annotated with what would disprove it.
- The last few commits are verified by build and by reading, but the board was
  disconnected before they could be flashed.

## Separately: a crash found while bringing this up

`env:diag4`'s radio page reproduced a hard panic tearing NimBLE down with Wi-Fi
active -- `PC = 0x00000000`, a null function pointer, at
`NimBLEDevice::deinit(true)`. Steady state is clean (five rounds of scanning
beside a live advertisement, heap flat, no fragmentation); the crash is in
teardown. `BleBeacon::stopRadio()` has the same sequence. Not fixed here, and
not caused by this branch. `dev` already carries
`fix: keep Wi-Fi modem sleep on while the BLE controller is up`, which may be
related.