### PR TITLE
Installer: offer only the firmware that fits the selected board

### DIFF
--- a/site/index.template.html
+++ b/site/index.template.html
@@ -403,6 +403,38 @@ footer {
   var links     = document.getElementById('download-links');
   var installer = document.getElementById('installer');
 
+  /* The firmware list belongs to the board, and only ever offers builds that
+   * exist for it.
+   *
+   * It used to list every firmware regardless of board and leave the reader to
+   * pair them. Choosing a board whose name did not match the firmware still
+   * selected simply found no build -- and the old code returned at that point,
+   * leaving the install button pointing at whichever manifest had been set
+   * last. So picking the 4-inch board while the default 2.8-inch firmware was
+   * selected flashed the 2.8-inch image onto it: a silent mismatch, and the
+   * worst possible symptom, because the wrong backlight pin gives a black
+   * panel on a device that is otherwise running perfectly. */
+  function buildsForBoard(board) {
+    return BUILDS.filter(function (b) { return b.board === board; });
+  }
+
+  function populateVariants() {
+    var available = buildsForBoard(boardSel.value);
+    var wanted = variantSel.value;
+    variantSel.innerHTML = '';
+    available.forEach(function (b) {
+      var opt = document.createElement('option');
+      opt.value = b.env;
+      opt.textContent = b.label;
+      variantSel.appendChild(opt);
+    });
+    /* Keep the reader's choice when the new board also offers it -- switching
+     * between two boards should not silently move them from the diagnostic
+     * build back to the games. */
+    var keep = available.some(function (b) { return b.env === wanted; });
+    variantSel.value = keep ? wanted : (available.length ? available[0].env : '');
+  }
+
   function apply() {
     var build = null;
     for (var i = 0; i < BUILDS.length; i++) {
@@ -411,7 +443,17 @@ footer {
         break;
       }
     }
-    if (!build) return;
+    /* Should be unreachable now that the list is filtered, so say so loudly
+     * rather than leaving a stale manifest armed behind a live button. */
+    if (!build) {
+      note.textContent = 'No firmware is published for this combination. '
+                       + 'Please report this — do not flash.';
+      installer.removeAttribute('manifest');
+      installer.setAttribute('disabled', 'disabled');
+      links.innerHTML = '';
+      return;
+    }
+    installer.removeAttribute('disabled');
     note.textContent = build.note;
     installer.setAttribute('manifest', build.manifest);
     links.innerHTML = 'Files for this build: ' + build.parts.map(function (part) {
@@ -419,8 +461,9 @@ footer {
     }).join(' &middot; ');
   }
 
-  boardSel.addEventListener('change', apply);
+  boardSel.addEventListener('change', function () { populateVariants(); apply(); });
   variantSel.addEventListener('change', apply);
+  populateVariants();
   apply();
 </script>
 </body>

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -566,6 +566,9 @@ def main():
             builds.append({
                 "board": target["id"],
                 "env": env,
+                # The page rebuilds the firmware dropdown from this list when a
+                # board is chosen, so each build has to carry its own label.
+                "label": variant["label"],
                 "dir": directory,
                 "manifest": directory + "/manifest.json",
                 "note": variant["note"].format(count=len(catalog)),
@@ -575,9 +578,11 @@ def main():
     board_options = "\n".join(
         '          <option value="%s">%s</option>' % (t["id"], escape(t["label"]))
         for t in supported)
-    variant_options = "\n".join(
-        '          <option value="%s">%s</option>' % (v["env"], escape(v["label"]))
-        for v in VARIANTS)
+    # Deliberately empty: the page fills it from BUILDS for whichever board is
+    # selected. Offering every firmware regardless of board and trusting the
+    # reader to pair them is how somebody flashes the 2.8-inch build onto a
+    # 4-inch board and gets a black screen that looks like a dead device.
+    variant_options = ""
     game_cards = render_game_cards(catalog)
     system_cards = render_system_cards()
     still_wall = render_still_wall()


### PR DESCRIPTION
Found by flashing 5.4.0 from the published page onto a 4-inch board and getting
a black screen.

## What happens

The firmware dropdown lists every build regardless of board. Choose the 4-inch
board while the default "Braino! (the games)" — the **2.8-inch** build — is
still selected, and nothing objects. The lookup finds no build for that pair,
and the old code returned at exactly that point:

```js
if (!build) return;
```

…leaving the install button armed with whichever manifest was set last, which
is the 2.8-inch one from page load. It then flashes it.

## Why it is the worst possible symptom

The 2.8-inch build drives the backlight on **GPIO21**, which is dark on the
4-inch panel. So the console boots, joins Wi-Fi, keeps time and answers touch
behind a screen that never lights:

```
[boot] board=E32R28T-1 rot=3 layout=Horizontal
[boot] build=main @ 503c9f4 built=Sep  4 2026 15:46 version=5.4.0
```

It reads as a dead device. `BoardConfig.h` static_asserts the backlight pin
against `TFT_BL` precisely to stop this at compile time — and here it arrives
through the one path where the firmware and the board are chosen *separately*.

The SD spam in that log is the same cause: the 2.8-inch profile declares an SD
slot, so it spends ~1.3s per boot timing out on hardware that is not there.

## The fix

The firmware list is rebuilt from the builds that exist for the selected board,
so the mismatch cannot be expressed. Each board offers exactly one build today,
so the dropdown becomes a confirmation rather than a decision.

Three details:

- **A reader's choice survives a board change** where the new board offers the
  same variant, so switching boards does not quietly move somebody off a
  diagnostic build back to the games.
- **The unreachable case disables the button and says so**, rather than leaving
  a stale manifest behind a live control. An installer that cannot find the
  firmware must not offer to flash something else.
- **`BUILDS` entries carry their label**, since the page now renders the list.

## Verified

Generated the site and drove the real page in a browser — for each of the five
boards, the firmware list and the armed manifest:

| Board | Firmware offered | Manifest |
|---|---|---|
| `e32r28t1` | `app` | `firmware/e32r28t1/app/manifest.json` |
| `esp32_2432s028r` | `app_esp32_2432s028r` | `…/esp32_2432s028r/…` |
| `esp32_2432s028_st7789` | `app_esp32_2432s028_st7789` | `…/st7789/…` |
| `fnk0104b` | `app_fnk0104b` | `…/fnk0104b/…` |
| `e32r40t` | `app_e32r40t` | `…/e32r40t/app_e32r40t/…` |

`check_docs`, `check_boards`, `check_catalog`, `check_frame_rules` all clean.

## Note on urgency

This is live on the published page now, and it predates 5.4.0 — it has been
reachable since the second board was offered. Pages deploys from `main`, so the
public installer stays wrong until this reaches `main`. Worth considering a
5.4.1 patch rather than waiting for the next feature release.