### PR TITLE
Installer: offer only the firmware that fits the board (5.4.0 page fix)

### DIFF
--- a/site/index.template.html
+++ b/site/index.template.html
@@ -403,6 +403,38 @@ footer {
   var links     = document.getElementById('download-links');
   var installer = document.getElementById('installer');
 
+  /* The firmware list belongs to the board, and only ever offers builds that
+   * exist for it.
+   *
+   * It used to list every firmware regardless of board and leave the reader to
+   * pair them. Choosing a board whose name did not match the firmware still
+   * selected simply found no build -- and the old code returned at that point,
+   * leaving the install button pointing at whichever manifest had been set
+   * last. So picking the 4-inch board while the default 2.8-inch firmware was
+   * selected flashed the 2.8-inch image onto it: a silent mismatch, and the
+   * worst possible symptom, because the wrong backlight pin gives a black
+   * panel on a device that is otherwise running perfectly. */
+  function buildsForBoard(board) {
+    return BUILDS.filter(function (b) { return b.board === board; });
+  }
+
+  function populateVariants() {
+    var available = buildsForBoard(boardSel.value);
+    var wanted = variantSel.value;
+    variantSel.innerHTML = '';
+    available.forEach(function (b) {
+      var opt = document.createElement('option');
+      opt.value = b.env;
+      opt.textContent = b.label;
+      variantSel.appendChild(opt);
+    });
+    /* Keep the reader's choice when the new board also offers it -- switching
+     * between two boards should not silently move them from the diagnostic
+     * build back to the games. */
+    var keep = available.some(function (b) { return b.env === wanted; });
+    variantSel.value = keep ? wanted : (available.length ? available[0].env : '');
+  }
+
   function apply() {
     var build = null;
     for (var i = 0; i < BUILDS.length; i++) {
@@ -411,7 +443,17 @@ footer {
         break;
       }
     }
-    if (!build) return;
+    /* Should be unreachable now that the list is filtered, so say so loudly
+     * rather than leaving a stale manifest armed behind a live button. */
+    if (!build) {
+      note.textContent = 'No firmware is published for this combination. '
+                       + 'Please report this — do not flash.';
+      installer.removeAttribute('manifest');
+      installer.setAttribute('disabled', 'disabled');
+      links.innerHTML = '';
+      return;
+    }
+    installer.removeAttribute('disabled');
     note.textContent = build.note;
     installer.setAttribute('manifest', build.manifest);
     links.innerHTML = 'Files for this build: ' + build.parts.map(function (part) {
@@ -419,8 +461,9 @@ footer {
     }).join(' &middot; ');
   }
 
-  boardSel.addEventListener('change', apply);
+  boardSel.addEventListener('change', function () { populateVariants(); apply(); });
   variantSel.addEventListener('change', apply);
+  populateVariants();
   apply();
 </script>
 </body>

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -566,6 +566,9 @@ def main():
             builds.append({
                 "board": target["id"],
                 "env": env,
+                # The page rebuilds the firmware dropdown from this list when a
+                # board is chosen, so each build has to carry its own label.
+                "label": variant["label"],
                 "dir": directory,
                 "manifest": directory + "/manifest.json",
                 "note": variant["note"].format(count=len(catalog)),
@@ -575,9 +578,11 @@ def main():
     board_options = "\n".join(
         '          <option value="%s">%s</option>' % (t["id"], escape(t["label"]))
         for t in supported)
-    variant_options = "\n".join(
-        '          <option value="%s">%s</option>' % (v["env"], escape(v["label"]))
-        for v in VARIANTS)
+    # Deliberately empty: the page fills it from BUILDS for whichever board is
+    # selected. Offering every firmware regardless of board and trusting the
+    # reader to pair them is how somebody flashes the 2.8-inch build onto a
+    # 4-inch board and gets a black screen that looks like a dead device.
+    variant_options = ""
     game_cards = render_game_cards(catalog)
     system_cards = render_system_cards()
     still_wall = render_still_wall()


### PR DESCRIPTION
The same fix as #90, onto `main`, so the **published** installer stops offering
the wrong firmware for a board.

**No firmware changes and no version bump.** `BRAINO_VERSION` stays `5.4.0` and
the v5.4.0 release assets are untouched and correct — the binaries were never
the problem. What was wrong is the page that pairs a board with a build, and
Pages regenerates that from `main`, so this repairs the live installer for the
same release rather than needing a 5.4.1.

## The bug

The firmware dropdown listed every build regardless of board. Pick the 4-inch
board while the default 2.8-inch "Braino! (the games)" is still selected, and
the lookup finds no build for that pair — at which point the old code did:

```js
if (!build) return;
```

leaving the install button armed with whichever manifest was set last, which is
the 2.8-inch one from page load. It then flashed that.

## Why it looked like a dead board

The 2.8-inch build drives the backlight on **GPIO21**, which is dark on the
4-inch panel. The console boots, joins Wi-Fi, keeps time and answers touch
behind a screen that never lights:

```
[boot] board=E32R28T-1 rot=3 layout=Horizontal
[boot] build=main @ 503c9f4 built=Sep  4 2026 15:46 version=5.4.0
```

`BoardConfig.h` static_asserts the backlight pin against `TFT_BL` to make this
impossible at compile time. It arrived through the one path where the firmware
and the board are chosen separately.

## The fix

The firmware list is rebuilt from the builds that exist for the selected board,
so the mismatch cannot be expressed. A reader's choice survives a board change
where the new board offers it too, and the unreachable case disables the button
and says so instead of leaving a stale manifest behind a live control.

Verified in a browser against the generated page — each of the five boards
offers exactly its own build and arms the matching manifest. This predates
5.4.0: it has been reachable since the second board was offered.