### PR TITLE
Installer: generate the terminal instructions for the selected board (5.4.0 page fix)

### DIFF
--- a/site/index.template.html
+++ b/site/index.template.html
@@ -240,11 +240,7 @@ footer {
     Every build here is also a plain set of <code>.bin</code> files. With
     <a href="https://github.com/espressif/esptool">esptool</a> installed:
   </p>
-  <pre><code>esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 460800 write_flash \
-  0x1000  bootloader.bin \
-  0x8000  partitions.bin \
-  0xe000  boot_app0.bin \
-  0x10000 firmware.bin</code></pre>
+  <pre><code id="esptool-cmd"></code></pre>
   <p class="note" id="download-links"></p>
 </section>
 
@@ -401,6 +397,7 @@ footer {
   var variantSel = document.getElementById('variant');
   var note      = document.getElementById('variant-note');
   var links     = document.getElementById('download-links');
+  var cmd       = document.getElementById('esptool-cmd');
   var installer = document.getElementById('installer');
 
   /* The firmware list belongs to the board, and only ever offers builds that
@@ -459,6 +456,28 @@ footer {
     links.innerHTML = 'Files for this build: ' + build.parts.map(function (part) {
       return '<a href="' + build.dir + '/' + part + '" download>' + part + '</a>';
     }).join(' &middot; ');
+
+    /* The terminal instructions are generated for the selected build too.
+     *
+     * They used to be one fixed block: --chip esp32 and four bare filenames.
+     * That chip is wrong for the Freenove board, which is an esp32s3 and will
+     * refuse the command outright, and the bare names do not match what the
+     * links above download -- those live under firmware/<board>/<env>/. So the
+     * reader who cannot use Web Serial, which is the only reader this section
+     * exists for, was handed a command that either failed or flashed nothing
+     * they had. */
+    if (cmd) {
+      var offsets = { 'bootloader.bin': '0x1000', 'partitions.bin': '0x8000',
+                      'boot_app0.bin': '0xe000', 'firmware.bin': '0x10000' };
+      var lines = build.parts.filter(function (part) {
+        return offsets[part];
+      }).map(function (part) {
+        return '  ' + offsets[part] + ' ' + build.dir + '/' + part;
+      });
+      cmd.textContent = 'esptool.py --chip ' + build.chip
+        + ' --port /dev/ttyUSB0 --baud 460800 write_flash \\\n'
+        + lines.join(' \\\n');
+    }
   }
 
   boardSel.addEventListener('change', function () { populateVariants(); apply(); });

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -569,6 +569,13 @@ def main():
                 # The page rebuilds the firmware dropdown from this list when a
                 # board is chosen, so each build has to carry its own label.
                 "label": variant["label"],
+                # esptool needs the right chip, and the S3 board is not an
+                # esp32. The manual instructions are generated per build for
+                # that reason -- a single hard-coded command was wrong for it.
+                # esptool spells it esp32s3, with no hyphen; BOARD_DETAILS
+                # spells it ESP32-S3 for people to read. Getting this wrong
+                # fails the same way the hard-coded command did.
+                "chip": target["chip"].lower().replace("-", ""),
                 "dir": directory,
                 "manifest": directory + "/manifest.json",
                 "note": variant["note"].format(count=len(catalog)),


### PR DESCRIPTION
Same change as #92, onto `main`, so the published page carries it for 5.4.0.

**No firmware change, no version bump.** `BRAINO_VERSION` stays `5.4.0` and the
release assets are untouched — this is the page that tells people how to use
them.

The terminal fallback was one fixed command for every board:

- **`--chip esp32` always.** The Freenove FNK0104B is an esp32s3 and refuses it
  outright — and it is the board most likely to need a terminal, having no
  USB-UART bridge.
- **Four bare filenames** (`bootloader.bin`, …) that nothing downloads. The
  links beneath point into `firmware/<board>/<env>/`.

This section exists for readers whose browser cannot do Web Serial — exactly
the people who cannot check their work against the graphical installer.

It is now generated from the selected build, with that build's chip and real
paths. The chip is normalised because esptool wants `esp32s3` while the board
table reads `ESP32-S3`; shipping the hyphen would have reproduced the original
bug in new form.

Verified in a browser across all five boards.