### PR TITLE
Release 5.5.1 — fix: the built-in DAC was claiming the touch clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 5.5.1 — 2026-09-05
+
+**Fixes a 5.5.0 defect that made the two 2.8-inch boards untouchable.** If you
+flashed 5.5.0 to an E32R28T-1 or an ESP32-2432S028R, the screen drew correctly
+and nothing responded to a finger. Flash this.
+
+GPIO25 is ESP32 DAC channel 1, and it is also the bit-banged SPI clock for the
+XPT2046 resistive touch controller on both of those boards. 5.5.0 enabled the
+built-in DAC audio backend on them; bringing I2S up in I2S_MODE_DAC_BUILT_IN
+routes the DAC subsystem onto both of its pads and takes them off the GPIO
+matrix. Narrowing the channel with `i2s_set_dac_mode()` picks which pad carries
+samples, not which pads are claimed. `Board::begin()` configures touch and then
+calls `beginAudio()` forty lines later, so audio took the touch clock.
+
+Nothing is lost by turning it off there: the speaker on those boards never
+worked anyway, because IO4 is declared as the RGB green channel while the
+vendor pin table calls it the amplifier enable, so the amplifier sat in
+shutdown. Sound on them needs both facts resolved on hardware.
+
+**The combination is now a compile error.** `BoardConfig.h` refuses any board
+that enables `GUME_HAS_AUDIO_DAC` while a touch, SD, backlight, RGB, battery or
+BOOT pin sits on GPIO25 or GPIO26, and requires the speaker to be on one of
+them. The 4-inch E32R40T keeps its audio -- its touch clock is GPIO14.
+
+The 4-inch was the only board the audio work was tested on, and it is the one
+board this could not happen to. That is the whole lesson.
+
 ## 5.5.0 — 2026-09-05
 
 Sound on a second family of boards, and a console that stops redrawing the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,9 +392,9 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,389,885 / 3,145,728 bytes,
-**76.0%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
-at 73,916 / 327,680 (22.5%) -- higher than it was, deliberately: RowList traded
+Flash is global and nearly the binding constraint (2,371,981 / 3,145,728 bytes,
+**75.4%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
+at 72,900 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
 profile-move buffers static. On this device that is a good
 trade every time. Two agents can each add artwork that fits locally and together overflow it. Read the size line from `pio run` and report it when you add data tables or images.
@@ -792,7 +792,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,389,885 on `5.5.0` against 2,365,349 on `5.4.0` -- and that is
+   2,371,981 on `5.5.1` against 2,365,349 on `5.4.0` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![CI](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml)
 [![Pages](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml)
 [![Flash in browser](https://img.shields.io/badge/flash%20in%20browser-Web%20Serial-6f42c1)](https://iamankushpandit.github.io/Gume/)
-[![Version](https://img.shields.io/badge/version-5.5.0-brightgreen)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.5.1-brightgreen)](CHANGELOG.md)
 [![Games](https://img.shields.io/badge/games-31-2d7d9a)](#the-games)
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
 [![C++17](https://img.shields.io/badge/C%2B%2B-17-00599c)](platformio.ini)
-[![Flash](https://img.shields.io/badge/flash-76.0%25%20of%203%20MB-yellow)](#build-and-flash)
+[![Flash](https://img.shields.io/badge/flash-75.4%25%20of%203%20MB-yellow)](#build-and-flash)
 [![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen)](#privacy)
 [![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue)](LICENSE)
 
@@ -30,8 +30,8 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,389,885 / 3,145,728 bytes (**76.0%**) |
-| RAM | 73,916 / 327,680 bytes (**22.5%**) |
+| Flash | 2,371,981 / 3,145,728 bytes (**75.4%**) |
+| RAM | 72,900 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
 Contribution workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md), alongside
@@ -900,7 +900,7 @@ owner should be able to see what it is transmitting, from the device itself.**
 
 ## Version
 
-Current release: **5.5.0** — the previous release was **5.4.0**. See
+Current release: **5.5.1** — the previous release was **5.4.0**. See
 [CHANGELOG.md](CHANGELOG.md) for what has changed since.
 
 ---

--- a/include/AppVersion.h
+++ b/include/AppVersion.h
@@ -31,7 +31,7 @@
  * not go away -- it is waiting for the next name that does not fit. If you
  * change either, re-measure: the portrait launcher has about 38px of air
  * between the product name and this string, and that is the whole allowance. */
-#define BRAINO_VERSION          "5.5.0"
+#define BRAINO_VERSION          "5.5.1"
 #define BRAINO_PRODUCT_NAME     "Braino!"
 /** The brand that publishes the console, and the owner of the marks. */
 #define BRAINO_COMPANY          "GoodTime Micro Company"

--- a/include/BoardConfig.h
+++ b/include/BoardConfig.h
@@ -30,6 +30,56 @@
 #define GUME_HAS_AUDIO_DAC 0
 #endif
 
+/* ---- The built-in DAC claims BOTH of its pads, not just the one you asked for
+ *
+ * GPIO25 is DAC channel 1 and GPIO26 is DAC channel 2. Bringing I2S up in
+ * I2S_MODE_DAC_BUILT_IN routes the DAC subsystem onto those pads and takes
+ * them off the GPIO matrix -- narrowing the channel with i2s_set_dac_mode()
+ * chooses which one carries the samples, NOT which one is claimed.
+ *
+ * 5.5.0 shipped with DAC audio enabled on the E32R28T-1 and ESP32-2432S028R,
+ * whose resistive touch clock is GPIO25. Board::begin() configures touch and
+ * then calls beginAudio() forty lines later, so audio quietly took the touch
+ * clock: a console that drew perfectly and could not be touched. It reached a
+ * public release because the only board the audio work was tested on was the
+ * 4-inch, whose touch is on GPIO14 -- the board that would have shown the
+ * fault was the one nobody flashed.
+ *
+ * So it is a compile error now. A board may put its SPEAKER on a DAC pad --
+ * that is the whole point -- and nothing else may go near either of them. */
+#if GUME_HAS_AUDIO_DAC
+constexpr bool gumeOnDacPad(int8_t pin) { return pin == 25 || pin == 26; }
+
+static_assert(!gumeOnDacPad(BOARD.touch.sclk),
+    "GUME_HAS_AUDIO_DAC: touch.sclk is on a DAC pad (GPIO25/26). Enabling the "
+    "built-in DAC claims both pads and the touch clock stops working. This is "
+    "the 5.5.0 defect. Either the board cannot have DAC audio, or the pin is "
+    "wrong.");
+static_assert(!gumeOnDacPad(BOARD.touch.mosi),
+    "GUME_HAS_AUDIO_DAC: touch.mosi is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.touch.miso),
+    "GUME_HAS_AUDIO_DAC: touch.miso is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.touch.cs),
+    "GUME_HAS_AUDIO_DAC: touch.cs is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.touch.irq),
+    "GUME_HAS_AUDIO_DAC: touch.irq is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.panel.backlightPin),
+    "GUME_HAS_AUDIO_DAC: the backlight is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.sd.cs) && !gumeOnDacPad(BOARD.sd.mosi) &&
+              !gumeOnDacPad(BOARD.sd.miso) && !gumeOnDacPad(BOARD.sd.sclk),
+    "GUME_HAS_AUDIO_DAC: an SD pin is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.rgb.r) && !gumeOnDacPad(BOARD.rgb.g) &&
+              !gumeOnDacPad(BOARD.rgb.b),
+    "GUME_HAS_AUDIO_DAC: an RGB LED pin is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.battery.adcPin),
+    "GUME_HAS_AUDIO_DAC: battery sense is on a DAC pad (GPIO25/26).");
+static_assert(!gumeOnDacPad(BOARD.button.bootPin),
+    "GUME_HAS_AUDIO_DAC: the BOOT key is on a DAC pad (GPIO25/26).");
+static_assert(BOARD.audio.speakerPin == 25 || BOARD.audio.speakerPin == 26,
+    "GUME_HAS_AUDIO_DAC needs a speakerPin on GPIO25 or GPIO26 -- those are the "
+    "only two pins the ESP32 built-in DAC reaches.");
+#endif
+
 /* The canvas the playable games are drawn on. This is a property of the
  * *games*, not of any board -- they were authored against it and position
  * things by arithmetic on it. It is the floor a panel has to clear to be

--- a/include/boards/e32r28t1.h
+++ b/include/boards/e32r28t1.h
@@ -16,7 +16,26 @@
  * same reasoning as the codec macro above: the DAC path would link the driver
  * into every board if it were not guarded. GUME_HAS_AUDIO_CODEC stays 0. */
 #define GUME_HAS_AUDIO_CODEC 0
-#define GUME_HAS_AUDIO_DAC   1
+/* NO DAC AUDIO ON THIS BOARD: ITS TOUCH CLOCK IS A DAC PAD.
+ *
+ * The XPT2046's bit-banged SPI clock is GPIO25, and GPIO25 is ESP32 DAC
+ * channel 1. Bringing up I2S in I2S_MODE_DAC_BUILT_IN takes the DAC pads over
+ * from the GPIO matrix, so Board::begin() -- which configures touch first and
+ * calls beginAudio() forty lines later -- ended up handing the touch clock to
+ * the audio peripheral. The panel drew perfectly and nothing responded to a
+ * finger.
+ *
+ * That shipped in 5.5.0 and is why 5.5.1 exists. Do not re-enable this without
+ * moving the touch clock, which is a hardware fact and cannot be moved.
+ *
+ * Nothing is lost by it: the speaker on this board never worked anyway, because
+ * IO4 is declared here as the RGB green channel while the vendor pin table
+ * calls it the amplifier enable -- so the amp sat in shutdown. Sound on this
+ * board needs that resolved AND a touch clock that is not a DAC pad.
+ *
+ * BoardConfig.h now refuses this combination at compile time rather than
+ * leaving it to whoever flashes it. */
+#define GUME_HAS_AUDIO_DAC   0
 
 /* HOSYOND / LCDWIKI E32R28T-1 (ESP32-32E) -- the 2.8-inch board Braino! ships
  * on. ILI9341 320x240 TFT, XPT2046 resistive touch on its own bit-banged bus,

--- a/include/boards/esp32-2432s028r.h
+++ b/include/boards/esp32-2432s028r.h
@@ -15,7 +15,26 @@
  * macro above: the DAC path pulls in driver/i2s.h and `if constexpr` would
  * link it into boards without one. GUME_HAS_AUDIO_CODEC stays 0. */
 #define GUME_HAS_AUDIO_CODEC 0
-#define GUME_HAS_AUDIO_DAC   1
+/* NO DAC AUDIO ON THIS BOARD: ITS TOUCH CLOCK IS A DAC PAD.
+ *
+ * The XPT2046's bit-banged SPI clock is GPIO25, and GPIO25 is ESP32 DAC
+ * channel 1. Bringing up I2S in I2S_MODE_DAC_BUILT_IN takes the DAC pads over
+ * from the GPIO matrix, so Board::begin() -- which configures touch first and
+ * calls beginAudio() forty lines later -- ended up handing the touch clock to
+ * the audio peripheral. The panel drew perfectly and nothing responded to a
+ * finger.
+ *
+ * That shipped in 5.5.0 and is why 5.5.1 exists. Do not re-enable this without
+ * moving the touch clock, which is a hardware fact and cannot be moved.
+ *
+ * Nothing is lost by it: the speaker on this board never worked anyway, because
+ * IO4 is declared here as the RGB green channel while the vendor pin table
+ * calls it the amplifier enable -- so the amp sat in shutdown. Sound on this
+ * board needs that resolved AND a touch clock that is not a DAC pad.
+ *
+ * BoardConfig.h now refuses this combination at compile time rather than
+ * leaving it to whoever flashes it. */
+#define GUME_HAS_AUDIO_DAC   0
 
 /* Makerfabs / Sunton ESP32-2432S028R -- the original/classic 2.4-inch CYD.
  * Micro-USB connector, ILI9341 240x320 TFT, XPT2046 resistive touch, RGB LED, LDR.


### PR DESCRIPTION
**5.5.0 made the two 2.8-inch boards untouchable.** The panel drew correctly and nothing responded to a finger. This fixes it and makes the mistake impossible to express again.

## The bug

GPIO25 is ESP32 DAC channel 1, and it is also the bit-banged SPI clock for the XPT2046 on the E32R28T-1 and ESP32-2432S028R. 5.5.0 enabled the built-in DAC audio backend on both.

Bringing I2S up in `I2S_MODE_DAC_BUILT_IN` routes the DAC subsystem onto **both** of its pads and takes them off the GPIO matrix. `i2s_set_dac_mode()` chooses which pad carries samples, **not which pads are claimed** — that was the wrong assumption. `Board::begin()` configures touch and calls `beginAudio()` forty lines later, so audio took the touch clock on every boot.

## The fix

DAC audio is off on both boards. Nothing is lost — their speakers never worked anyway, because IO4 is declared as the RGB green channel while the vendor pin table calls it the amplifier enable, so the amp sat in shutdown.

The 4-inch E32R40T keeps its audio; its touch clock is GPIO14.

## The guard

`BoardConfig.h` now refuses, at compile time, any board that enables `GUME_HAS_AUDIO_DAC` while a touch, SD, backlight, RGB, battery or BOOT pin sits on GPIO25/26 — and requires the speaker to be on one of them.

Verified by re-enabling the flag on the E32R28T-1 and watching the build fail with the message naming the defect. A guard nobody has seen fire is not a guard.

## Why it reached a release

The audio work was validated on the 4-inch, whose touch clock is GPIO14 — the one board this could not happen to. Every other board was built but never flashed. The static assert is the part that would have caught it without hardware, which is what makes it the real fix rather than the board change.

## Verification

All five environments build. All four checkers clean. Flash 2,371,981 (75.4%) / RAM 72,900 (22.2%) on `env:app`, 17.9 KB below 5.5.0 — the DAC backend compiling out of the two boards that cannot have it.