### PR TITLE
Stop the PIN pads and six quiz screens repainting the whole screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ In development on `dev`. Nothing here has shipped; the version carries the
 release, and About's **This build** page names the branch and commit.
 `release.yml` refuses to publish a tag whose version carries this suffix.
 
+**Six quiz screens no longer clear the screen between questions.** Math,
+Multiplication, Counting, Time, Flags and Percent Circle classified their
+question panel as static, and only a full repaint replaces a static element --
+so moving to the next question cost a 320x240 wipe, a top bar redraw and a
+battery read, every time. The panel is now dynamic: repainted when the question
+changes, without clearing the screen.
+
+Percent Circle still clears when it needs to. Its three round types have
+genuinely different layouts, so it compares the type across a new round and
+asks for a full repaint only when it actually changed.
+
 **The PIN pads no longer flash on every digit.** Entering the admin PIN
 repainted the entire screen once per keypress -- in Profiles that was a literal
 `Ui::clear()`, a 320x240 wipe costing ~150 KB over SPI and ~30 ms of blanking,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ In development on `dev`. Nothing here has shipped; the version carries the
 release, and About's **This build** page names the branch and commit.
 `release.yml` refuses to publish a tag whose version carries this suffix.
 
+**The PIN pads no longer flash on every digit.** Entering the admin PIN
+repainted the entire screen once per keypress -- in Profiles that was a literal
+`Ui::clear()`, a 320x240 wipe costing ~150 KB over SPI and ~30 ms of blanking,
+on the one screen where you are deliberately tapping four times in a row.
+
+Both pads are now split by what a digit actually changes: four small circles.
+The heading, the Back button and all twelve keys are painted once when the pad
+opens. The dots erase themselves, each fill covering its predecessor exactly,
+so nothing is left behind when one empties on DEL or on a rejected PIN.
+
 **The web installer can now flash older releases.** It offered exactly one
 firmware -- whatever `main` last built -- so when 5.5.0 shipped a defect that
 made the two 2.8-inch boards untouchable, the only thing anyone could install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,371,997 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,372,121 / 3,145,728 bytes,
 **75.4%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 72,900 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -796,7 +796,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,371,997 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
+   2,372,121 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,9 +392,9 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,372,121 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,372,313 / 3,145,728 bytes,
 **75.4%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
-at 72,900 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
+at 72,908 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
 profile-move buffers static. On this device that is a good
 trade every time. Two agents can each add artwork that fits locally and together overflow it. Read the size line from `pio run` and report it when you add data tables or images.
@@ -796,7 +796,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,372,121 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
+   2,372,313 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,372,121 / 3,145,728 bytes (**75.4%**) |
-| RAM | 72,900 / 327,680 bytes (**22.2%**) |
+| Flash | 2,372,313 / 3,145,728 bytes (**75.4%**) |
+| RAM | 72,908 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
 Contribution workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md), alongside

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,371,997 / 3,145,728 bytes (**75.4%**) |
+| Flash | 2,372,121 / 3,145,728 bytes (**75.4%**) |
 | RAM | 72,900 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/docs/RENDER_AUDIT.md
+++ b/docs/RENDER_AUDIT.md
@@ -418,6 +418,30 @@ it already returns `false` from `renderChrome()`. Phase changes are layout
 changes; within the picker, only the selected row changes. Convert after the
 games.
 
+**The PIN pad is done.** It was the worst single case in the firmware and the
+audit under-rated it: `renderPinEntry()` opened with `Ui::clear()`, and every
+digit called `markFullDirty()`, so a full 320x240 wipe — ~150 KB over SPI, ~30
+ms of blanking — was paid once per keypress on the one screen where the player
+is deliberately tapping four times in a row. It is now split by the question
+this document asks of everything: *does a digit change it?* The heading, the
+Back button and all twelve keys do not, so they are chrome painted once by
+`renderStatic()`; the four dots do, and they are the whole of `renderDynamic()`
+in that phase.
+
+The dots need no erase and must not be given one — each is a filled circle at a
+fixed centre and radius, so the fill covers its predecessor exactly, including
+the backwards case of a dot emptying on DEL or on a rejected PIN. That is the
+disappearing-thing trap not applying, which is worth stating because it usually
+does.
+
+Settings' pad had the same defect and the same fix; it was slightly cheaper
+only because it filled the body rather than the whole screen. Its heading
+varies (Enter new / Re-enter new) and so is chrome that depends on the task —
+safe because every task transition already asks for a full repaint. **If a
+third PIN task is added, check that it does too.**
+
+Still only recorded, not done: a single visibility row in the Games list.
+
 ### WifiGame — leave until last
 
 229 lines of render, 30 `markDirty()` sites, five timers, and a ~4.3 second

--- a/docs/RENDER_AUDIT.md
+++ b/docs/RENDER_AUDIT.md
@@ -309,6 +309,64 @@ displayed time already jumps rather than ticks. Decide that deliberately rather
 than inheriting it: if it should tick, that is a per-second `markDirty()` and the
 counter block needs its own erase.
 
+### Update: a new question no longer clears the screen (6 done)
+
+The audit above framed the win as *answering* -- recolouring four buttons
+without repainting the question. That was right, and it missed the larger and
+more visible half: **going from one question to the next was a full repaint on
+every one of these screens**, because the question panel was classified as
+static and only `markFullDirty()` replaces a static element. Every question
+change therefore cost a 320x240 wipe, a top bar redraw and a battery read.
+
+The fix is not a new mechanism. The question panel is **dynamic, not static**:
+gated on a `drawn...` flag so it is not repainted every frame, but repainted
+without clearing the screen when the question changes. `newQuestion()`
+invalidates what it changes and asks for `markDirty()`.
+
+Done: `MathGame`, `MultiplicationGame`, `CountingGame`, `TimeGame`, `FlagGame`,
+`PercentCircleGame`.
+
+**The trap that nearly shipped, and will catch the next one.** These screens
+repaint an answer button only when its *state* changed. On a new question the
+two buttons that were never highlighted go from state 0 to state 0 -- so they
+are skipped, and keep the previous question's labels. The full repaint hid this
+by resetting the trackers in `renderStatic()`. **Every conversion here must
+invalidate the button trackers in `newQuestion()`**, and the same applies to
+any counter block whose condition only fires on a score change: `MathGame`'s
+header carries the elapsed clock, and a wrong answer with the streak already at
+0 moves neither score nor streak.
+
+**What made each one safe was an opaque fill, checked individually**, not a
+rule:
+
+| Screen | Why the question region self-erases |
+|---|---|
+| Math, Multiplication | fixed rect, `fillRoundRect` before the text |
+| Counting | fixed panel filled before any of the up-to-21 circles |
+| Time | `drawClock()` opens with a `fillCircle` over the whole face |
+| Flag | the card is filled, and the 2x image fills it exactly |
+
+`FlagGame` also moved its difficulty button from static to dynamic, gated on
+the tier value rather than a bool -- six correct in a row auto-promotes, and
+the old label used to survive until the next full repaint.
+
+**`PercentCircleGame` is the one that still needs the redraw, sometimes.** Its
+three round types have genuinely different layouts, so a round that changes
+type must clear and a round that does not must not. It compares the type
+across `newRound()` rather than following a rule, so a fourth type needs no
+edit here.
+
+**`ElementsGame` was deliberately left alone.** Its full repaints are tab
+switches and card open/close, which are real layout changes. It is also still
+on the old single `render()` with a `needsFullRender()` guard rather than the
+two-phase split, so it is a conversion rather than a tweak.
+
+**Still outstanding:** the nine screens carrying only the mechanical split
+(`ColorMix`, `FingerCount`, `Fraction`, `Microku`, `Money`, `NumberLine`,
+`ObjectAdd`, `Sequence`, `ShapeColor`). They never call `markFullDirty()`, so
+they do not wipe the screen -- but they refill the whole body on every repaint,
+which is nearly the same thing to look at. They are the next piece of work.
+
 ---
 
 ## Group B — the board games (2)

--- a/src/games/CountingGame.cpp
+++ b/src/games/CountingGame.cpp
@@ -53,6 +53,14 @@ void CountingGame::newQuestion() {
     selected_ = -1;
     answered_ = false;
     makeOptions();
+    /* Everything a new round changes. The buttons are not optional: the loop
+     * repaints one only when its state changed, so the two that were never
+     * highlighted would keep the previous round's numbers. */
+    drawnObjects_ = false;
+    drawnStats_ = false;
+    for (uint8_t i = 0; i < 4; ++i) {
+        drawnButton_[i] = 0xFF;
+    }
 }
 
 void CountingGame::makeOptions() {
@@ -89,9 +97,11 @@ void CountingGame::update(AppContext& host, const TouchPoint& touch) {
     }
     if (answered_) {
         newQuestion();
-        /* A new count means a different number of objects in the panel, which
-         * is static -- only a full repaint replaces it. */
-        markFullDirty();
+        /* A new count means a different number of objects, drawn into the same
+         * fixed panel over an opaque fill -- content, not layout. The panel is
+         * dynamic now, so this is markDirty(); it used to wipe and repaint the
+         * whole screen between every round. */
+        markDirty();
         return;
     }
     for (uint8_t i = 0; i < 4; ++i) {
@@ -126,21 +136,6 @@ void CountingGame::renderStatic(AppContext& host) {
     tft.setTextDatum(TC_DATUM);
     tft.drawString("How many objects?", GAME_CANVAS_WIDTH / 2, 32, 4);
 
-    /* The objects belong to the round. There are up to 21 of them, each a
-     * filled circle and an outline, and not one of them moves while the player
-     * is choosing -- so the whole panel is drawn once and a new round, which
-     * changes the count, is a full repaint. */
-    const Rect area{18, 76, 284, 98};
-    tft.fillRoundRect(area.x, area.y, area.w, area.h, 8, Ui::panel());
-    tft.drawRoundRect(area.x, area.y, area.w, area.h, 8, Ui::outline());
-    for (uint8_t i = 0; i < count_; ++i) {
-        const uint8_t col = i % 7;
-        const uint8_t row = i / 7;
-        const int16_t x = area.x + 24 + col * 39 + (row % 2) * 8;
-        const int16_t y = area.y + 24 + row * 30;
-        tft.fillCircle(x, y, 10, DOT_COLORS[i % 5]);
-        tft.drawCircle(x, y, 10, TFT_DARKGREY);
-    }
     tft.setTextDatum(TL_DATUM);
 
     for (uint8_t i = 0; i < 4; ++i) {
@@ -150,10 +145,36 @@ void CountingGame::renderStatic(AppContext& host) {
     drawnStreak_ = 0xFFFF;
     drawnAnswered_ = !answered_;
     drawnStats_ = false;
+    drawnObjects_ = false;
 }
 
 void CountingGame::renderDynamic(AppContext& host) {
     Ui::Renderer& tft = host.display();
+
+    /* The objects. Up to 21 filled circles, none of which moves while the
+     * player is choosing -- so it is gated -- but the count is what a new
+     * round changes, so it is dynamic rather than static. A new round must not
+     * cost a wipe of the whole screen.
+     *
+     * fillRoundRect covers the entire area before any circle is drawn, so
+     * going from 21 objects to 3 leaves nothing behind. That opaque fill is
+     * the reason this is safe; drawing the circles onto whatever was there
+     * would not be. */
+    if (!drawnObjects_) {
+        const Rect area{18, 76, 284, 98};
+        tft.fillRoundRect(area.x, area.y, area.w, area.h, 8, Ui::panel());
+        tft.drawRoundRect(area.x, area.y, area.w, area.h, 8, Ui::outline());
+        for (uint8_t i = 0; i < count_; ++i) {
+            const uint8_t col = i % 7;
+            const uint8_t row = i / 7;
+            const int16_t x = area.x + 24 + col * 39 + (row % 2) * 8;
+            const int16_t y = area.y + 24 + row * 30;
+            tft.fillCircle(x, y, 10, DOT_COLORS[i % 5]);
+            tft.drawCircle(x, y, 10, TFT_DARKGREY);
+        }
+        tft.setTextDatum(TL_DATUM);
+        drawnObjects_ = true;
+    }
 
     /* One centred line, so it grows both ways from the middle and a shorter
      * one leaves tails at BOTH ends. Cleared across its whole width first;

--- a/src/games/CountingGame.h
+++ b/src/games/CountingGame.h
@@ -34,6 +34,9 @@ private:
     uint16_t drawnStreak_ = 0xFFFF;
     bool drawnAnswered_ = false;
     bool drawnStats_ = false;
+    /* The object panel is dynamic, not static: a new round changes the count,
+     * and a new round must not cost a full repaint. See renderDynamic(). */
+    bool drawnObjects_ = false;
     uint8_t correctButton_ = 0;
     uint8_t score_ = 0;
     uint8_t rounds_ = 0;

--- a/src/games/FlagGame.cpp
+++ b/src/games/FlagGame.cpp
@@ -142,11 +142,24 @@ bool poolAllows(uint16_t i, void* ctx) {
 }
 
 void FlagGame::newQuestion() {
-    /* A different country means a different flag, and the flag is static --
-     * only a full repaint replaces it. Here rather than at the call sites, of
-     * which there are three: begin(), the difficulty button and the end of
-     * feedback. */
-    markFullDirty();
+    /* A different country means a different flag, four different options and
+     * possibly a different tier. All of it is content in fixed rectangles
+     * drawn over opaque fills, so this is markDirty() -- it used to wipe and
+     * repaint the whole screen, top bar and battery read included, between
+     * every question.
+     *
+     * Invalidating here rather than at the call sites, of which there are
+     * three: begin(), the difficulty button and the end of feedback.
+     *
+     * The buttons are not optional. The loop in renderDynamic() repaints one
+     * only when its state or the round type changed, and a new country leaves
+     * both the same while changing every label. */
+    markDirty();
+    drawnFlag_ = false;
+    drawnPrompt_ = false;
+    for (uint8_t i = 0; i < OPTION_COUNT; ++i) {
+        drawnBtn_[i] = 0xFF;
+    }
     const uint16_t pool = countryPoolSize(tier_, false);
     if (pool == 0) { current_ = nullptr; return; }
 
@@ -201,7 +214,11 @@ void FlagGame::update(AppContext& host, const TouchPoint& touch) {
         } else {
             newQuestion();
         }
-        markFullDirty();
+        /* Either the same flag with capital labels, or a whole new question --
+         * both are content. The capital switch is caught by the drawnCapital_
+         * comparison in the button loop, and newQuestion() invalidates what it
+         * changes, so neither needs the screen wiped. */
+        markDirty();
         return;
     }
 
@@ -263,23 +280,6 @@ void FlagGame::renderStatic(AppContext& host) {
     Ui::clear(tft);
     host.drawTopBar(title());
 
-    /* The flag card. drawCountryImageScaled at 2x paints 160x120 -- the single
-     * most expensive thing on this screen -- and it stays put for the whole
-     * question, INCLUDING the capital bonus, which asks about the same country.
-     * newQuestion() is what replaces it, and that asks for a full repaint. */
-    if (current_ != nullptr) {
-        const Rect fr = flagRect();
-        tft.fillRect(fr.x - 2, fr.y - 2, fr.w + 4, fr.h + 4, FLAG_BG);
-        tft.drawRect(fr.x - 2, fr.y - 2, fr.w + 4, fr.h + 4, Ui::outline());
-        // 80x60 source drawn at 2x fills the 160x120 card exactly.
-        Ui::drawCountryImageScaled(tft, mnf_flag(current_->iso2), fr, FLAG_BG, 2);
-    }
-
-    /* Cycling the difficulty deals a new question, so this is static too. */
-    static const char* const TIER_NAMES[4] = {"", "Easy", "Medium", "Hard"};
-    Ui::drawButton(tft, tierRect(), TIER_NAMES[tier_], Ui::panel(), Ui::outline(),
-                   Ui::text(), false, 1);
-
     for (uint8_t i = 0; i < OPTION_COUNT; ++i) {
         drawnBtn_[i] = 0xFF;
     }
@@ -288,6 +288,8 @@ void FlagGame::renderStatic(AppContext& host) {
     drawnScore_ = 0xFFFF;
     drawnRounds_ = 0xFFFF;
     drawnCapBonus_ = 0xFFFF;
+    drawnFlag_ = false;
+    drawnTier_ = 0xFF;
 }
 
 void FlagGame::renderDynamic(AppContext& host) {
@@ -309,6 +311,41 @@ void FlagGame::renderDynamic(AppContext& host) {
         drawnScore_ = score_;
         drawnRounds_ = rounds_;
         drawnCapBonus_ = capBonus_;
+    }
+
+    /* The difficulty button. Gated on the tier itself rather than on a bool,
+     * because the tier also changes on its own -- six correct in a row
+     * auto-promotes -- and that used to show the old label until the next full
+     * repaint. drawButton fills its fixed rect opaquely, so "Medium" over
+     * "Easy" leaves nothing behind. */
+    if (drawnTier_ != tier_) {
+        static const char* const TIER_NAMES[4] = {"", "Easy", "Medium", "Hard"};
+        Ui::drawButton(tft, tierRect(), TIER_NAMES[tier_], Ui::panel(), Ui::outline(),
+                       Ui::text(), false, 1);
+        drawnTier_ = tier_;
+    }
+
+    /* The flag card: drawCountryImageScaled at 2x paints 160x120 and is the
+     * single most expensive thing on this screen. It stays put for the whole
+     * question INCLUDING the capital bonus, which asks about the same country
+     * -- so it is gated. It is dynamic rather than static because a new
+     * country must not cost a wipe of the screen.
+     *
+     * The card is filled before the image goes into it, and the image fills it
+     * exactly, so no part of the previous flag survives. The nullptr branch
+     * fills the card back to background: without it a flag would be left
+     * stranded under the "No countries available" message. */
+    if (!drawnFlag_) {
+        const Rect fr = flagRect();
+        if (current_ != nullptr) {
+            tft.fillRect(fr.x - 2, fr.y - 2, fr.w + 4, fr.h + 4, FLAG_BG);
+            tft.drawRect(fr.x - 2, fr.y - 2, fr.w + 4, fr.h + 4, Ui::outline());
+            // 80x60 source drawn at 2x fills the 160x120 card exactly.
+            Ui::drawCountryImageScaled(tft, mnf_flag(current_->iso2), fr, FLAG_BG, 2);
+        } else {
+            tft.fillRect(fr.x - 2, fr.y - 2, fr.w + 4, fr.h + 4, Ui::bg());
+        }
+        drawnFlag_ = true;
     }
 
     if (current_ == nullptr) {

--- a/src/games/FlagGame.h
+++ b/src/games/FlagGame.h
@@ -53,6 +53,11 @@ private:
     uint16_t drawnScore_ = 0xFFFF;
     uint16_t drawnRounds_ = 0xFFFF;
     uint16_t drawnCapBonus_ = 0xFFFF;
+    /* The flag card and the difficulty button are dynamic, not static: a new
+     * question changes the first and the auto-promote changes the second, and
+     * neither should cost a full repaint. See renderDynamic(). */
+    bool drawnFlag_ = false;
+    uint8_t drawnTier_ = 0xFF;
 
     Rect answerRect(uint8_t i) const;
     Rect tierRect() const;

--- a/src/games/MathGame.cpp
+++ b/src/games/MathGame.cpp
@@ -122,6 +122,24 @@ void MathGame::newQuestion() {
     }
     answer_ = operation_ == Operation::Add ? left_ + right_ : left_ - right_;
     makeOptions();
+    /* Everything a new question changes, invalidated together.
+     *
+     * The buttons matter more than they look. The loop below repaints a button
+     * only when its *state* changed, and on a new question the two that were
+     * never highlighted go from state 0 to state 0 -- so without this they
+     * keep the previous question's numbers on them. The full repaint this
+     * replaces hid that by resetting the trackers in renderStatic().
+     *
+     * The header is invalidated because it carries the elapsed clock and the
+     * level. Its own condition only fires when the score or streak moves, and
+     * a wrong answer with the streak already at 0 moves neither -- so the
+     * clock would sit still for longer than it used to. Repainting two small
+     * rects per question keeps that behaviour as it was. */
+    drawnQuestion_ = false;
+    drawnHeader_ = false;
+    for (uint8_t i = 0; i < 4; ++i) {
+        drawnButton_[i] = 0xFF;
+    }
 }
 
 void MathGame::makeOptions() {
@@ -160,9 +178,13 @@ void MathGame::update(AppContext& host, const TouchPoint& touch) {
     if (answered_) {
         newQuestion();
         /* A new sum, four new options and the prompt back to "Tap the answer".
-         * That is a layout change -- the equation panel is static, so only a
-         * full repaint replaces it. */
-        markFullDirty();
+         * All of that is CONTENT: the equation panel, the four buttons and the
+         * prompt line are in the same places, the same sizes, drawn over
+         * themselves opaquely. Nothing about the layout changed, so this is
+         * markDirty() -- it used to be markFullDirty(), which wiped and
+         * repainted the whole 320x240 panel, top bar and battery read
+         * included, between every question. */
+        markDirty();
         return;
     }
 
@@ -190,21 +212,6 @@ void MathGame::renderStatic(AppContext& host) {
     Ui::clear(tft);
     host.drawTopBar(title());
 
-    /* The equation belongs to the question, and a new question is a full
-     * repaint -- so this panel is static even though it is not constant. It is
-     * also the largest single block on the screen, which is what made
-     * repainting it to recolour one button worth stopping. */
-    char equation[24];
-    const char symbol = operation_ == Operation::Add ? '+' : '-';
-    snprintf(equation, sizeof(equation), "%d %c %d = ?",
-             static_cast<int>(left_), symbol, static_cast<int>(right_));
-    tft.fillRoundRect(26, 76, 268, 54, 8, Ui::panel());
-    tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
-    tft.setTextColor(Ui::text(), Ui::panel());
-    tft.setTextDatum(MC_DATUM);
-    tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
-    tft.setTextDatum(TL_DATUM);
-
     for (uint8_t i = 0; i < 4; ++i) {
         drawnButton_[i] = 0xFF;   // nothing painted there yet
     }
@@ -212,10 +219,33 @@ void MathGame::renderStatic(AppContext& host) {
     drawnStreak_ = 0xFFFF;
     drawnAnswered_ = !answered_;   // force the feedback line on the first pass
     drawnHeader_ = false;
+    drawnQuestion_ = false;        // and the equation
 }
 
 void MathGame::renderDynamic(AppContext& host) {
     Ui::Renderer& tft = host.display();
+
+    /* The equation. It changes only with a new question, which is why it is
+     * gated rather than drawn every frame -- but it is dynamic rather than
+     * static, because a new question must not cost a full repaint.
+     *
+     * It needs no erase of its own: the rect is fixed, and fillRoundRect
+     * covers it opaquely before the text goes down, so "12 - 7 = ?" cannot
+     * leave a tail behind "9 + 3 = ?". If this panel is ever made to grow with
+     * its content, that stops being true. */
+    if (!drawnQuestion_) {
+        char equation[24];
+        const char symbol = operation_ == Operation::Add ? '+' : '-';
+        snprintf(equation, sizeof(equation), "%d %c %d = ?",
+                 static_cast<int>(left_), symbol, static_cast<int>(right_));
+        tft.fillRoundRect(26, 76, 268, 54, 8, Ui::panel());
+        tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
+        tft.setTextColor(Ui::text(), Ui::panel());
+        tft.setTextDatum(MC_DATUM);
+        tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
+        tft.setTextDatum(TL_DATUM);
+        drawnQuestion_ = true;
+    }
 
     /* Four counters, two of them TR_DATUM. Level and the clock only move with
      * a new question, but Correct and Streak change on an answer, and Streak

--- a/src/games/MathGame.h
+++ b/src/games/MathGame.h
@@ -47,6 +47,9 @@ private:
     uint16_t drawnStreak_ = 0xFFFF;
     bool drawnAnswered_ = false;
     bool drawnHeader_ = false;
+    /* The equation panel is dynamic, not static: a new question changes it,
+     * and a new question must not cost a full repaint. See renderDynamic(). */
+    bool drawnQuestion_ = false;
     uint8_t correctButton_ = 0;
     Operation operation_ = Operation::Add;
     uint16_t score_ = 0;

--- a/src/games/MultiplicationGame.cpp
+++ b/src/games/MultiplicationGame.cpp
@@ -103,6 +103,16 @@ void MultiplicationGame::newQuestion() {
     }
     answer_ = left_ * right_;
     makeOptions();
+    /* Everything a new question changes, together. The buttons are not
+     * optional: the loop below repaints one only when its state changed, and
+     * the two that were never highlighted go 0 -> 0, so without this they keep
+     * the previous question's numbers. The header carries the level and is
+     * cheap. */
+    drawnQuestion_ = false;
+    drawnHeader_ = false;
+    for (uint8_t i = 0; i < 4; ++i) {
+        drawnButton_[i] = 0xFF;
+    }
 }
 
 void MultiplicationGame::makeOptions() {
@@ -151,9 +161,11 @@ void MultiplicationGame::update(AppContext& host, const TouchPoint& touch) {
     if (answered_) {
         newQuestion();
         /* A new product, four new options and the prompt back to its first
-         * wording: a layout change, and only a full repaint replaces a static
-         * element. */
-        markFullDirty();
+         * wording. All of it is content in fixed places, drawn over itself
+         * opaquely -- nothing about the layout changes -- so this is
+         * markDirty(). It used to wipe and repaint the whole panel, top bar
+         * and battery read included, between every question. */
+        markDirty();
         return;
     }
 
@@ -181,18 +193,6 @@ void MultiplicationGame::renderStatic(AppContext& host) {
     Ui::clear(tft);
     host.drawTopBar(title());
 
-    /* The product belongs to the question, and a new question is a full
-     * repaint, so this panel is static even though it is not constant. */
-    char equation[24];
-    snprintf(equation, sizeof(equation), "%d x %d = ?",
-             static_cast<int>(left_), static_cast<int>(right_));
-    tft.fillRoundRect(26, 76, 268, 54, 8, Ui::panel());
-    tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
-    tft.setTextColor(Ui::text(), Ui::panel());
-    tft.setTextDatum(MC_DATUM);
-    tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
-    tft.setTextDatum(TL_DATUM);
-
     for (uint8_t i = 0; i < 4; ++i) {
         drawnButton_[i] = 0xFF;
     }
@@ -200,10 +200,28 @@ void MultiplicationGame::renderStatic(AppContext& host) {
     drawnStreak_ = 0xFFFF;
     drawnAnswered_ = !answered_;
     drawnHeader_ = false;
+    drawnQuestion_ = false;
 }
 
 void MultiplicationGame::renderDynamic(AppContext& host) {
     Ui::Renderer& tft = host.display();
+
+    /* The product. Gated because it changes only with a new question, but
+     * dynamic rather than static because a new question must not cost a full
+     * repaint. The rect is fixed and fillRoundRect covers it opaquely before
+     * the text goes down, so a shorter product cannot leave a tail. */
+    if (!drawnQuestion_) {
+        char equation[24];
+        snprintf(equation, sizeof(equation), "%d x %d = ?",
+                 static_cast<int>(left_), static_cast<int>(right_));
+        tft.fillRoundRect(26, 76, 268, 54, 8, Ui::panel());
+        tft.drawRoundRect(26, 76, 268, 54, 8, Ui::outline());
+        tft.setTextColor(Ui::text(), Ui::panel());
+        tft.setTextDatum(MC_DATUM);
+        tft.drawString(equation, GAME_CANVAS_WIDTH / 2, 103, 4);
+        tft.setTextDatum(TL_DATUM);
+        drawnQuestion_ = true;
+    }
 
     /* Score and Streak move on an answer, and Streak resets to zero. The
      * right-hand pair is TR_DATUM, so a shrinking string leaves its stale

--- a/src/games/MultiplicationGame.h
+++ b/src/games/MultiplicationGame.h
@@ -38,6 +38,9 @@ private:
     uint16_t drawnStreak_ = 0xFFFF;
     bool drawnAnswered_ = false;
     bool drawnHeader_ = false;
+    /* The product panel is dynamic, not static: a new question changes it, and
+     * a new question must not cost a full repaint. See renderDynamic(). */
+    bool drawnQuestion_ = false;
     uint8_t correctButton_ = 0;
     uint16_t score_ = 0;
     uint16_t streak_ = 0;

--- a/src/games/PercentCircleGame.cpp
+++ b/src/games/PercentCircleGame.cpp
@@ -316,8 +316,30 @@ void PercentCircleGame::update(AppContext& host, const TouchPoint& touch) {
     }
 
     if (roundComplete_) {
+        /* THIS IS A CASE WHERE THE FULL REPAINT IS SOMETIMES REQUIRED, AND
+         * SOMETIMES NOT -- so it asks rather than assuming either way.
+         *
+         * A new round cycles between three round types with genuinely
+         * different layouts: a circle to read, a circle to build, and a plain
+         * "what is N% of M". Their drawing functions paint different regions,
+         * so switching between them leaves the previous layout's pixels
+         * wherever the new one does not reach. That is a real layout change
+         * and it needs the screen cleared.
+         *
+         * A new round of the SAME type is content: the same regions with
+         * different numbers in them. That is the common case -- the type
+         * changes once every three rounds -- and it now costs a repaint of
+         * the body rather than a wipe of the screen.
+         *
+         * Deciding by comparison rather than by rule is the point: nobody has
+         * to remember to update this when a fourth round type is added. */
+        const RoundType before = roundType_;
         newRound(host);
-        markFullDirty();
+        if (roundType_ != before) {
+            markFullDirty();
+        } else {
+            markDirty();
+        }
         return;
     }
 

--- a/src/games/ProfileGame.cpp
+++ b/src/games/ProfileGame.cpp
@@ -347,13 +347,13 @@ void ProfileGame::update(GameHost& host, const TouchPoint& touch) {
 
             if (!ok) {
                 board.beepError();
-                /* The entered digits have just been reset, so the dots have to
-                 * go. renderPinEntry() clears the panel itself, so markDirty()
-                 * happened to work -- but this screen is uniformly
-                 * full-repaint now, and a partial that only works because
-                 * something else clears is the kind of coupling that breaks
-                 * the next time either side moves. */
-                markFullDirty();
+                /* The entered digits have just been reset, so all four dots go
+                 * back to empty. That is a content change and nothing else on
+                 * the pad moves, so it is markDirty() -- and the dots erase
+                 * themselves, each fill covering its own predecessor exactly.
+                 * A rejected PIN is the moment somebody is about to type four
+                 * more digits, so it is the last place to want a full wipe. */
+                markDirty();
                 return;
             }
             board.beepOk();
@@ -392,11 +392,14 @@ void ProfileGame::update(GameHost& host, const TouchPoint& touch) {
     updateRename(host, touch);
 }
 
+/* markDirty(), not markFullDirty(): a digit moves four dots and nothing else,
+ * and the dots are the whole of renderDynamic() in this phase. Asking for a
+ * full repaint here is what put a Ui::clear() on every keypress. */
 void ProfileGame::appendPinDigit(uint8_t digit) {
     if (adminPinDigitCount_ < PIN_LENGTH) {
         adminPinAttempt_ = adminPinAttempt_ * 10 + digit;
         adminPinDigitCount_++;
-        markFullDirty();
+        markDirty();
     }
 }
 
@@ -404,16 +407,25 @@ void ProfileGame::deletePinDigit() {
     if (adminPinDigitCount_ > 0) {
         adminPinAttempt_ /= 10;
         adminPinDigitCount_--;
-        markFullDirty();
+        markDirty();
     }
 }
 
-void ProfileGame::renderPinEntry(GameHost& host) {
+/* THE PAD IS DRAWN IN TWO HALVES, AND THE DIVIDING LINE IS "DOES A DIGIT
+ * CHANGE IT?".
+ *
+ * This is the exception to the full-repaint rule stated below, and it earns
+ * it: typing a digit changes four small circles and nothing else, and this
+ * function used to open with Ui::clear() -- a 320x240 wipe, ~150 KB over SPI
+ * and ~30 ms of visible blanking -- once per keypress, on the one screen where
+ * the player is deliberately tapping four times in a row. It was the most
+ * noticeable flicker in the firmware for exactly that reason.
+ *
+ * The heading is chrome, not content: this pad only ever asks one question. */
+void ProfileGame::renderPinPadChrome(GameHost& host) {
     Ui::Renderer& tft = host.display();
     const int16_t W = static_cast<int16_t>(tft.width());
     const int16_t H = static_cast<int16_t>(tft.height());
-
-    Ui::clear(tft);
 
     Ui::drawButton(tft, pinCancelRect(W, H), "Back", Ui::panel(), Ui::outline(),
                    Ui::text(), false, 1);
@@ -421,18 +433,6 @@ void ProfileGame::renderPinEntry(GameHost& host) {
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(TC_DATUM);
     tft.drawString("Enter Admin PIN", W / 2, 6, 2);
-
-    /* Four dots, one per digit, filled from the left as digits arrive. The
-     * count is tracked separately from the value because "0000" and an empty
-     * field are the same number. */
-    const int16_t dotPitch = 26;
-    const int16_t dotsX0   = static_cast<int16_t>(W / 2 - (dotPitch * (PIN_LENGTH - 1)) / 2);
-    for (uint8_t i = 0; i < PIN_LENGTH; ++i) {
-        const int16_t x = static_cast<int16_t>(dotsX0 + i * dotPitch);
-        const uint16_t fill = i < adminPinDigitCount_ ? Ui::success() : Ui::panel();
-        tft.fillCircle(x, PIN_DOT_Y, PIN_DOT_R, fill);
-        tft.drawCircle(x, PIN_DOT_Y, PIN_DOT_R, Ui::outline());
-    }
 
     /* Rows 0-2 are 1-9; row 3 is DEL / 0 / OK. */
     for (uint8_t row = 0; row < PIN_PAD_ROWS; ++row) {
@@ -463,6 +463,30 @@ void ProfileGame::renderPinEntry(GameHost& host) {
     tft.setTextDatum(TL_DATUM);
 }
 
+/* The only thing a keypress changes.
+ *
+ * Four dots, one per digit, filled from the left as digits arrive. The count
+ * is tracked separately from the value because "0000" and an empty field are
+ * the same number.
+ *
+ * They need no erase and must not be given one: each is a filled circle at a
+ * fixed centre and radius, so the fill covers its own predecessor exactly --
+ * including the backwards case, a dot going from filled to empty on DEL or on
+ * a rejected PIN. Clearing a rect around them first would only add a flash. */
+void ProfileGame::renderPinDots(GameHost& host) {
+    Ui::Renderer& tft = host.display();
+    const int16_t W = static_cast<int16_t>(tft.width());
+
+    const int16_t dotPitch = 26;
+    const int16_t dotsX0   = static_cast<int16_t>(W / 2 - (dotPitch * (PIN_LENGTH - 1)) / 2);
+    for (uint8_t i = 0; i < PIN_LENGTH; ++i) {
+        const int16_t x = static_cast<int16_t>(dotsX0 + i * dotPitch);
+        const uint16_t fill = i < adminPinDigitCount_ ? Ui::success() : Ui::panel();
+        tft.fillCircle(x, PIN_DOT_Y, PIN_DOT_R, fill);
+        tft.drawCircle(x, PIN_DOT_Y, PIN_DOT_R, Ui::outline());
+    }
+}
+
 bool ProfileGame::renderChrome(GameHost& host) {
     (void)host;
     return false;   // see the header -- nothing here to repaint in isolation
@@ -480,11 +504,19 @@ bool ProfileGame::renderChrome(GameHost& host) {
  * opening with Ui::clear().
  *
  * So the split here is a migration onto the base class's methods and not an
- * optimisation. The two that could be made partial later -- the PIN dots and a
- * single visibility row -- are recorded in the audit rather than attempted on
- * the screen where getting it wrong is least acceptable. */
+ * optimisation -- with ONE exception, the PIN dots, which the audit recorded
+ * as a candidate and which has now been done. It is the exception because the
+ * cost was paid four times in a row while somebody watched: see the note above
+ * renderPinPadChrome(). The other candidate, a single visibility row, is still
+ * only recorded. */
 void ProfileGame::renderStatic(GameHost& host) {
     Ui::clear(host.display());
+    /* The pad's keys, heading and Back do not change while a PIN is typed, so
+     * they are painted here, once. Every route into and out of PinEntry asks
+     * for a full repaint, which is what makes that safe. */
+    if (phase_ == Phase::PinEntry) {
+        renderPinPadChrome(host);
+    }
 }
 
 void ProfileGame::renderDynamic(GameHost& host) {
@@ -495,7 +527,7 @@ void ProfileGame::renderDynamic(GameHost& host) {
     const bool tall = H > W;
 
     if (phase_ == Phase::PinEntry) {
-        renderPinEntry(host);
+        renderPinDots(host);
         return;
     }
 

--- a/src/games/ProfileGame.h
+++ b/src/games/ProfileGame.h
@@ -54,7 +54,11 @@ private:
     void beginPinEntry(uint8_t profile, PinPurpose purpose);
     void appendPinDigit(uint8_t digit);
     void deletePinDigit();
-    void renderPinEntry(GameHost& host);
+    /* Split by "does a digit change it?": the keys, heading and Back are
+     * chrome and painted once by renderStatic(); the four dots are the only
+     * thing a keypress touches. See the note in ProfileGame.cpp. */
+    void renderPinPadChrome(GameHost& host);
+    void renderPinDots(GameHost& host);
     void updateRename(GameHost& host, const TouchPoint& touch);
     void renderRename(GameHost& host);
 

--- a/src/games/SettingsGame.cpp
+++ b/src/games/SettingsGame.cpp
@@ -261,8 +261,14 @@ void SettingsGame::renderStatic(GameHost& host) {
 
     /* The change-PIN flow owns the whole screen while it runs, so it gets no
      * tab strip. Entering and leaving it are both full repaints, so the strip
-     * cannot be left behind. */
+     * cannot be left behind.
+     *
+     * The pad's chrome belongs here rather than in renderDynamic(): the keys,
+     * the heading and Back do not change while a PIN is being typed, and
+     * repainting them on every digit is what made this screen flash. */
     if (pinTask_ != PinTask::None) {
+        renderPinPadChrome(host, pinTask_ == PinTask::SetNew ? "Enter new PIN"
+                                                             : "Re-enter new PIN");
         return;
     }
 
@@ -281,24 +287,21 @@ void SettingsGame::renderDynamic(GameHost& host) {
     syncPanel(host);
     Ui::Renderer& tft = host.display();
 
+    /* A keypress changes four dots. It does not need the body cleared, and
+     * clearing it is precisely what the flicker was -- so this returns before
+     * the fill below rather than after it. */
+    if (pinTask_ != PinTask::None) {
+        renderPinDots(host);
+        return;
+    }
+
     /* Clear the body, not the screen. The tab renderers below paint controls
      * onto whatever is already there rather than erasing behind themselves --
      * a value going from "100%" to "25%" would otherwise leave its tail -- so
      * the ground they need still has to be laid. What this saves over the old
      * full clear is the top bar and the tab strip above it, and the top bar
      * costs a battery read and five glyphs every time it is drawn. */
-    const int16_t bodyTop = (pinTask_ == PinTask::None)
-                                ? static_cast<int16_t>(53) : TOP_BAR_HEIGHT;
-    tft.fillRect(0, bodyTop, panelW_, static_cast<int16_t>(panelH_ - bodyTop), Ui::bg());
-
-    if (pinTask_ == PinTask::SetNew) {
-        renderPinPad(host, "Enter new PIN");
-        return;
-    }
-    if (pinTask_ == PinTask::ConfirmNew) {
-        renderPinPad(host, "Re-enter new PIN");
-        return;
-    }
+    tft.fillRect(0, 53, panelW_, static_cast<int16_t>(panelH_ - 53), Ui::bg());
 
     switch (tab_) {
         case Tab::Device: renderDeviceTab(host); break;

--- a/src/games/SettingsGame.h
+++ b/src/games/SettingsGame.h
@@ -111,7 +111,11 @@ private:
     void renderPowerTab(GameHost& host);
     void renderSoundTab(GameHost& host);
     void renderAdminTab(GameHost& host);
-    void renderPinPad(GameHost& host, const char* heading);
+    /* Split by "does a digit change it?": the keys, heading and Back are
+     * chrome and painted once; the four dots are the only thing a keypress
+     * touches. See the note in SettingsPin.cpp. */
+    void renderPinPadChrome(GameHost& host, const char* heading);
+    void renderPinDots(GameHost& host);
 
     /* Shared by the unlock screen and the change-PIN flow. Returns true if the
      * touch landed on the pad, so callers can stop looking. */

--- a/src/games/SettingsPin.cpp
+++ b/src/games/SettingsPin.cpp
@@ -146,7 +146,20 @@ bool SettingsGame::handlePinPadTouch(GameHost& host, const TouchPoint& touch) {
     return false;
 }
 
-void SettingsGame::renderPinPad(GameHost& host, const char* heading) {
+/* THE PAD IS DRAWN IN TWO HALVES, AND THE DIVIDING LINE IS "DOES A DIGIT
+ * CHANGE IT?".
+ *
+ * Typing a digit changes four small circles and nothing else. The heading, the
+ * Back button and all twelve keys are identical before and after. Repainting
+ * them anyway cost a fill of the whole body plus twelve drawButton calls per
+ * keypress, which on this panel is visible as a flash on every tap -- on a
+ * screen where the player is deliberately tapping four times in a row, so it
+ * is the most-noticed flicker in the firmware.
+ *
+ * The heading is chrome rather than content because it only changes between
+ * PIN tasks (Enter new -> Re-enter new), and that transition already asks for
+ * a full repaint. If a third task is ever added, check that it does too. */
+void SettingsGame::renderPinPadChrome(GameHost& host, const char* heading) {
     Ui::Renderer& tft = host.display();
     const int16_t W = static_cast<int16_t>(tft.width());
     const int16_t H = static_cast<int16_t>(tft.height());
@@ -157,17 +170,6 @@ void SettingsGame::renderPinPad(GameHost& host, const char* heading) {
     tft.setTextColor(Ui::text(), Ui::bg());
     tft.setTextDatum(TC_DATUM);
     tft.drawString(heading, W / 2, 38, 2);
-
-    /* Dots, not the digits: the PIN is masked. The previous version printed
-     * it in plain text in a box, which defeats the point of having one. */
-    const int16_t dotPitch = 26;
-    const int16_t dotsX0   = static_cast<int16_t>(W / 2 - (dotPitch * (PIN_LENGTH - 1)) / 2);
-    for (uint8_t i = 0; i < PIN_LENGTH; ++i) {
-        const int16_t x = static_cast<int16_t>(dotsX0 + i * dotPitch);
-        const uint16_t fill = i < enteredPinDigits_ ? Ui::success() : Ui::panel();
-        tft.fillCircle(x, PIN_DOT_Y, PIN_DOT_R, fill);
-        tft.drawCircle(x, PIN_DOT_Y, PIN_DOT_R, Ui::outline());
-    }
 
     /* Rows 0-2 are 1-9; row 3 is DEL / 0 / OK. */
     for (uint8_t row = 0; row < PIN_PAD_ROWS; ++row) {
@@ -195,6 +197,29 @@ void SettingsGame::renderPinPad(GameHost& host, const char* heading) {
         }
     }
     tft.setTextDatum(TL_DATUM);
+}
+
+/* The only thing a keypress changes.
+ *
+ * Dots, not the digits: the PIN is masked. The previous version printed it in
+ * plain text in a box, which defeats the point of having one.
+ *
+ * These need no erase and must not be given one. Each is a filled circle drawn
+ * at a fixed centre and radius, so the fill covers its own predecessor exactly
+ * -- including the backwards case, a dot going from filled to empty on DEL.
+ * Clearing a rect around them first would only add a flash of background. */
+void SettingsGame::renderPinDots(GameHost& host) {
+    Ui::Renderer& tft = host.display();
+    const int16_t W = static_cast<int16_t>(tft.width());
+
+    const int16_t dotPitch = 26;
+    const int16_t dotsX0   = static_cast<int16_t>(W / 2 - (dotPitch * (PIN_LENGTH - 1)) / 2);
+    for (uint8_t i = 0; i < PIN_LENGTH; ++i) {
+        const int16_t x = static_cast<int16_t>(dotsX0 + i * dotPitch);
+        const uint16_t fill = i < enteredPinDigits_ ? Ui::success() : Ui::panel();
+        tft.fillCircle(x, PIN_DOT_Y, PIN_DOT_R, fill);
+        tft.drawCircle(x, PIN_DOT_Y, PIN_DOT_R, Ui::outline());
+    }
 }
 
 void SettingsGame::renderAdminTab(GameHost& host) {

--- a/src/games/TimeGame.cpp
+++ b/src/games/TimeGame.cpp
@@ -75,9 +75,20 @@ bool TimeGame::optionExists(uint16_t minutes, uint8_t upTo) const {
 }
 
 void TimeGame::newQuestion() {
-    /* New hands on the clock, and the clock is static -- only a full repaint
-     * replaces it. */
-    markFullDirty();
+    /* New hands on the clock. drawClock() opens with a fillCircle covering the
+     * whole face, so the old hands cannot survive it -- which is what lets the
+     * clock be dynamic and a new question cost a repaint of the face rather
+     * than of the screen.
+     *
+     * The buttons are not optional here: the loop repaints one only when its
+     * state changed, and the two that were never highlighted go 0 -> 0, so
+     * without this they would keep the previous question's times on them. */
+    markDirty();
+    drawnClock_ = false;
+    drawnHeader_ = false;
+    for (uint8_t i = 0; i < 4; ++i) {
+        drawnButton_[i] = 0xFF;
+    }
     selected_ = -1;
     answered_ = false;
 
@@ -224,9 +235,6 @@ void TimeGame::renderStatic(AppContext& host) {
     Ui::clear(tft);
     host.drawTopBar(title());
 
-    /* The clock face is the question. It is a circle, twelve ticks and two
-     * hands, and none of it moves while the player is choosing. */
-    drawClock(tft);
     Ui::drawLabel(tft, Rect{8, 133, 304, 16}, "Which time is shown?",
                   Ui::text(), 2, Align::Center);
 
@@ -237,10 +245,21 @@ void TimeGame::renderStatic(AppContext& host) {
     drawnStreak_ = 0xFFFF;
     drawnAnswered_ = !answered_;
     drawnHeader_ = false;
+    drawnClock_ = false;
 }
 
 void TimeGame::renderDynamic(AppContext& host) {
     Ui::Renderer& tft = host.display();
+
+    /* The clock face is the question: a circle, twelve ticks and two hands.
+     * None of it moves while the player is choosing, so it is gated -- but a
+     * new question moves the hands, and that must not cost a full repaint.
+     * drawClock() fills the whole face before drawing anything on it, so the
+     * previous hands are covered rather than left behind. */
+    if (!drawnClock_) {
+        drawClock(tft);
+        drawnClock_ = true;
+    }
 
     /* THIS SCREEN CANNOT REPAINT JUST THE TWO BUTTONS THAT CHANGED.
      *

--- a/src/games/TimeGame.h
+++ b/src/games/TimeGame.h
@@ -37,6 +37,9 @@ private:
     uint16_t drawnStreak_ = 0xFFFF;
     bool drawnAnswered_ = false;
     bool drawnHeader_ = false;
+    /* The clock face is dynamic, not static: a new question moves the hands,
+     * and a new question must not cost a full repaint. See renderDynamic(). */
+    bool drawnClock_ = false;
     uint16_t score_ = 0;
     uint16_t streak_ = 0;
     uint16_t bestStreak_ = 0;


### PR DESCRIPTION
Two render fixes, both verified on hardware (2.8-inch E32R28T-1, 4-inch E32R40T, and flashed to all four connected boards).

### PIN pads

Typing a digit changes four small circles. Both pads repainted everything — Profiles opened `renderPinEntry()` with `Ui::clear()`, a 320×240 wipe (~150 KB over SPI, ~30 ms blanking) **once per keypress**, on the one screen where the player is deliberately tapping four times in a row.

Both are now split by *does a digit change it?* — heading, Back and twelve keys painted once by `renderStatic()`; the four dots are the whole of `renderDynamic()`. The dots need no erase and must not be given one: each fill covers its predecessor exactly, including a dot emptying on DEL or a rejected PIN.

### Six quiz screens

Math, Multiplication, Counting, Time, Flags and Percent Circle classified the question panel as *static*, and only a full repaint replaces a static element — so every new question cost a full wipe, a top bar redraw and a battery read. The panel is dynamic now: gated so it isn't repainted every frame, repainted without clearing when the question changes.

**Where the redraw is kept, because it's genuinely needed:** Percent Circle's three round types have different layouts, so it compares the type across `newRound()` and clears only when it actually changed. Elements is untouched — its full repaints are tab switches and card open/close.

**The trap this nearly shipped with:** these screens repaint an answer button only when its *state* changed, so on a new question the two never-highlighted buttons go 0 → 0, get skipped, and keep the previous question's labels. The full repaint was hiding it. Same shape of bug in MathGame's header, which carries the elapsed clock. Both now invalidated explicitly in `newQuestion()`, and recorded in `docs/RENDER_AUDIT.md` so the next conversion doesn't repeat it.

Flash 2,372,313 (75.4%), RAM 72,908 (22.2%), `GITHUB_REF_NAME=dev`. All four checkers clean.