### PR TITLE
Open 5.7.0-SNAPSHOT on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## 5.6.0-SNAPSHOT — Unreleased
+## 5.7.0-SNAPSHOT — Unreleased
 
 In development on `dev`. Nothing here has shipped; the version carries the
-`-SNAPSHOT` suffix so a board on a desk cannot be mistaken for the 5.5.1
+`-SNAPSHOT` suffix so a board on a desk cannot be mistaken for the 5.6.0
 release, and About's **This build** page names the branch and commit.
 `release.yml` refuses to publish a tag whose version carries this suffix.
+
+## 5.6.0 — 2026-09-06
+
+**A new board, and two things to do with the consoles around you.** The
+3.2-inch LCDWIKI E32R32P is supported and flashable from the web installer;
+Nearby gains a Poke button, and the admin can give the devices in the room
+names that never leave this one.
 
 **Name the devices around you.** A tag like `A4F2` says nothing about whose
 console it is, so the admin can label one -- up to 10 characters -- and both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,7 +393,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,376,065 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,376,101 / 3,145,728 bytes,
 **75.5%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 73,388 / 327,680 (22.2%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -824,7 +824,7 @@ Before tagging, on `main`:
    figure by 16 bytes, which shipped to `main` wrong because the build was run
    on the tree as it stood before the release commit. The consequence is that
    `dev` and `main` legitimately carry different numbers between releases --
-   2,376,065 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
+   2,376,101 on `5.6.0-SNAPSHOT` against 2,371,981 on `5.5.1` -- and that is
    not drift to be reconciled. `check_docs.py` compares each document against
    whatever `.pio/build/app/firmware.elf` is sitting in *your* tree, so each
    branch has to state its own figure or the checks fail for anyone who builds

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml)
 [![Pages](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml)
 [![Flash in browser](https://img.shields.io/badge/flash%20in%20browser-Web%20Serial-6f42c1)](https://iamankushpandit.github.io/Gume/)
-[![Version](https://img.shields.io/badge/version-5.6.0--SNAPSHOT-9a6700)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.7.0--SNAPSHOT-9a6700)](CHANGELOG.md)
 [![Games](https://img.shields.io/badge/games-31-2d7d9a)](#the-games)
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 31 |
-| Flash | 2,376,065 / 3,145,728 bytes (**75.5%**) |
+| Flash | 2,376,101 / 3,145,728 bytes (**75.5%**) |
 | RAM | 73,388 / 327,680 bytes (**22.2%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -998,7 +998,7 @@ owner should be able to see what it is transmitting, from the device itself.**
 
 ## Version
 
-In development: **5.6.0-SNAPSHOT** — the last release was **5.5.1**. See
+In development: **5.7.0-SNAPSHOT** — the last release was **5.6.0**. See
 [CHANGELOG.md](CHANGELOG.md) for what has changed since.
 
 ---

--- a/include/AppVersion.h
+++ b/include/AppVersion.h
@@ -31,7 +31,7 @@
  * not go away -- it is waiting for the next name that does not fit. If you
  * change either, re-measure: the portrait launcher has about 38px of air
  * between the product name and this string, and that is the whole allowance. */
-#define BRAINO_VERSION          "5.6.0-SNAPSHOT"
+#define BRAINO_VERSION          "5.7.0-SNAPSHOT"
 #define BRAINO_PRODUCT_NAME     "Braino!"
 /** The brand that publishes the console, and the owner of the marks. */
 #define BRAINO_COMPANY          "GoodTime Micro Company"


### PR DESCRIPTION
5.6.0 is tagged and published, so `dev` goes back to carrying a snapshot — a board flashed from `dev` must not be mistakable for the release it is ahead of, and `release.yml` refuses to publish a tag whose version carries the suffix.

The 5.6.0 changelog section keeps its date and gains a summary; the "nothing here has shipped" boilerplate moves up to the new 5.7.0-SNAPSHOT heading.

Build figures re-measured on this branch: **2,376,101 flash (75.5%), 73,388 RAM (22.4%)**, against main's 2,376,053. `BRAINO_VERSION` is compiled into the image and `5.7.0-SNAPSHOT` is not the same length as `5.6.0`, so `dev` and `main` legitimately carry different numbers between releases — `check_docs` compares each branch against its own build.