### PR TITLE
Describe env:diag32p, and check the envs nothing was checking

### DIFF
--- a/tools/check_boards.py
+++ b/tools/check_boards.py
@@ -203,6 +203,7 @@ def check_ini(problems, headers):
             board_envs.setdefault(used[0], []).append(env)
 
     check_reachable(problems, boards, board_envs)
+    check_boardless_blurbs(problems, text)
 
 
 def check_reachable(problems, boards, board_envs):
@@ -263,6 +264,37 @@ def check_reachable(problems, boards, board_envs):
                     "`pack_release.py --strict` refuses to pack it, so the "
                     "release workflow would fail on the tag, after the tag "
                     "has already been pushed" % (board_id, env))
+
+
+def check_boardless_blurbs(problems, ini):
+    """Every environment needs a description, including the boardless ones.
+
+    check_reachable() below walks the environments that compose a [board_*]
+    section, which misses exactly the envs in BOARDLESS_ENVS -- and
+    `pack_release.py --strict` does not miss them. That gap is not theoretical:
+    env:diag32p shipped without a blurb, every check here reported clean, and
+    the release workflow failed on `pack_release` AFTER the v5.6.0 tag had been
+    pushed. Finding it at the tag is the worst possible moment, because the tag
+    is the thing that is awkward to take back.
+    """
+    for env in re.findall(r"^\[env:(\w+)\]", ini, re.M):
+        role = pack_release.env_role(env, "")
+        if role in pack_release.ENV_BLURBS:
+            continue
+        # Board-attached envs are covered by check_reachable(), which knows the
+        # board id and can strip the suffix. Only report what nothing else will.
+        if any(env.endswith("_%s" % b) for b in board_ids(ini)):
+            continue
+        problems.append(
+            "environment '%s' has no description in pack_release.py's "
+            "ENV_BLURBS -- `pack_release.py --strict` refuses to pack it, so "
+            "the release workflow would fail on the tag, after the tag has "
+            "already been pushed" % env)
+
+
+def board_ids(ini):
+    """The board ids declared by [board_*] sections."""
+    return re.findall(r"^\[board_(\w+)\]", ini, re.M)
 
 
 def check_agreement(problems, section, body, relative):

--- a/tools/pack_release.py
+++ b/tools/pack_release.py
@@ -88,6 +88,10 @@ ENV_BLURBS = {
     "diag4": "Bring-up probe for an unsupported 4-inch ST7796 board: identifies the panel controller over SPI, sweeps candidate backlight pins and tests both touch wirings.",
     "s3diag": "Bring-up probe for an unsupported ESP32-S3 board: panel, "
               "rotation, I2C touch scan and battery divider. Not the console.",
+    "diag32p": "Bring-up probe for the 3.2-inch E32R32P (ST7789P3): identifies "
+               "the panel controller over SPI, sweeps candidate backlight pins, "
+               "checks colour order and rotation, and tests both touch wirings. "
+               "Not the console.",
 }
 
 


### PR DESCRIPTION
**The v5.6.0 release workflow failed**, on `pack_release --strict`:

```
no description in ENV_BLURBS for: diag32p -- a release that offers a
firmware nobody can identify is worse than one that omits it
```

It failed *after* the tag was pushed, which is the worst moment to find it. **Nothing was published** — there is no v5.6.0 release, and no assets anyone could have downloaded.

## Why the existing check missed it

`check_boards.py` already had this check. It walks the environments that compose a `[board_*]` section and strips the board suffix to find the role — so `app_e32r32p`, `bringup_e32r32p` and `batdiag_e32r32p` were all covered by the existing `app` / `bringup` / `batdiag` blurbs.

`env:diag32p` is deliberately **boardless**, listed in `BOARDLESS_ENVS` because a `[board_*]` section is a claim of support and a bring-up probe is not one. Boardless envs were precisely the set the check never looked at. `pack_release` makes no such distinction: it packs every environment `platformio.ini` declares.

So the check now covers them too, reporting only what `check_reachable()` will not so the same problem is not stated twice.

**Verified by making it fail:** renaming the blurb makes it name `diag32p` with the message above, and restoring it goes green. A guard nobody has seen fire is not a guard — which is the same reasoning 5.5.1 used for its GPIO25 compile-time guard.

## After this merges

The `v5.6.0` tag has to be moved to the fixed commit. Since nothing was published, deleting and re-pushing the tag is safe — the rule about a published release being impossible to quietly correct does not apply to a release that does not exist.

Build figures unchanged at **2,376,053 flash (75.5%), 73,388 RAM (22.4%)** — this touches `tools/` only, no firmware.