### PR TITLE
Open 5.8.0-SNAPSHOT on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.8.0-SNAPSHOT — Unreleased
+
+In development on `dev`. Nothing here has shipped; the version carries the
+`-SNAPSHOT` suffix so a board on a desk cannot be mistaken for the 5.7.0
+release, and About's **This build** page names the branch and commit.
+`release.yml` refuses to publish a tag whose version carries this suffix.
+
+The suffix now matters to one more thing than it used to. A console running a
+snapshot compares itself against the published manifest on its daily update
+check, and `Board::compareVersions()` sorts a pre-release BEFORE the release of
+the same number -- so a board flashed from `dev` at 5.8.0-SNAPSHOT is correctly
+told that nothing newer exists, rather than being nagged to install the 5.7.0 it
+is already ahead of.
+
 ## 5.7.0 — 2026-09-06
 
 **The sound was broken on two boards, the beacon could crash the device, and

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml)
 [![Pages](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml)
 [![Flash in browser](https://img.shields.io/badge/flash%20in%20browser-Web%20Serial-6f42c1)](https://iamankushpandit.github.io/Gume/)
-[![Version](https://img.shields.io/badge/version-5.7.0-9a6700)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.8.0--SNAPSHOT-9a6700)](CHANGELOG.md)
 [![Games](https://img.shields.io/badge/games-31-2d7d9a)](#the-games)
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
@@ -1020,7 +1020,7 @@ owner should be able to see what it is transmitting, from the device itself.**
 
 ## Version
 
-In development: **5.7.0** — the last release was **5.6.0**. See
+In development: **5.8.0-SNAPSHOT** — the last release was **5.7.0**. See
 [CHANGELOG.md](CHANGELOG.md) for what has changed since.
 
 ---

--- a/include/AppVersion.h
+++ b/include/AppVersion.h
@@ -31,7 +31,7 @@
  * not go away -- it is waiting for the next name that does not fit. If you
  * change either, re-measure: the portrait launcher has about 38px of air
  * between the product name and this string, and that is the whole allowance. */
-#define BRAINO_VERSION          "5.7.0"
+#define BRAINO_VERSION          "5.8.0-SNAPSHOT"
 #define BRAINO_PRODUCT_NAME     "Braino!"
 /** The brand that publishes the console, and the owner of the marks. */
 #define BRAINO_COMPANY          "GoodTime Micro Company"


### PR DESCRIPTION
5.7.0 is tagged and on `main`, so `dev` returns to a snapshot version — a board flashed from `dev` must not be mistakable for the release it is ahead of, and `release.yml` refuses to publish a tag carrying the suffix.

Worth noting: the suffix is now load-bearing for the new update check. `Board::compareVersions()` sorts a pre-release before the release of the same number, so a board on 5.8.0-SNAPSHOT is correctly told nothing newer exists rather than being nagged all cycle to install the 5.7.0 it is ahead of.

Build figures unchanged at 2,381,701 / 74,268, measured with `GITHUB_REF_NAME=dev`: the longer version string and shorter branch name cancel out inside flash alignment. All six checkers clean.