### PR TITLE
Fix the dangling -e that broke the Pages deploy, and check for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           # Build environments with explicit -e flags for check_boards.py verification
           if [ "${{ github.event_name }}" = "push" ]; then
             # On pushes to main/dev: build all environments
-            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e app_esp32_2432s028_inv -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e -e app_e32r32p -e bringup_e32r32p -e batdiag_e32r32p -e s3diag -e diag4
+            pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e app_esp32_2432s028_inv -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e app_e32r32p -e bringup_e32r32p -e batdiag_e32r32p -e s3diag -e diag4
           else
             # On PR: build only affected environments
             ENVS="${{ steps.environments.outputs.envs }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -112,7 +112,7 @@ jobs:
       # through every net. An environment nobody builds is an environment
       # that is already broken and has not been told yet.
       - name: Build firmware
-        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e app_esp32_2432s028_inv -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e -e app_e32r32p -e bringup_e32r32p -e batdiag_e32r32p -e s3diag -e diag4
+        run: pio run -e app -e bringup -e batdiag -e wifidiag -e app_esp32_2432s028r -e bringup_esp32_2432s028r -e batdiag_esp32_2432s028r -e app_esp32_2432s028_st7789 -e app_esp32_2432s028_inv -e bringup_esp32_2432s028_st7789 -e batdiag_esp32_2432s028_st7789 -e app_fnk0104b -e app_e32r40t -e app_e32r32p -e bringup_e32r32p -e batdiag_e32r32p -e s3diag -e diag4
 
       # Flash is the scarce resource here (3 MB partition), so put the image
       # size where a reviewer sees it without opening the build log.

--- a/tools/check_boards.py
+++ b/tools/check_boards.py
@@ -204,6 +204,82 @@ def check_ini(problems, headers):
 
     check_reachable(problems, boards, board_envs)
     check_boardless_blurbs(problems, text)
+    check_workflow_envs(problems, text)
+
+
+def check_workflow_envs(problems, ini):
+    """Every environment the workflows name has to exist, and the command that
+    names them has to parse.
+
+    THIS EXISTS BECAUSE A DANGLING `-e` SHIPPED AND BROKE THE SITE. Removing a
+    board from `.github/workflows/pages.yml` left
+
+        -e app_e32r40t -e -e app_e32r32p
+
+    which PlatformIO rejects with "Got unexpected extra argument". CI went
+    green anyway, because a pull request builds a SELECTIVE list through the
+    ENVS variable and only the full-build path carries that flag list -- so the
+    fault was latent in ci.yml and fatal in pages.yml, which always builds
+    everything. The Pages deploy failed 49 seconds in, the site silently stayed
+    on the previous release, and the first anybody knew was noticing the game
+    count was wrong on the published page.
+
+    check_reachable() above could not have caught it: it asks whether each
+    board's env is mentioned, and a mention is exactly what a dangling flag
+    leaves intact. So this checks the shape of the command rather than its
+    contents, plus the reverse direction -- an env named in a workflow but
+    absent from platformio.ini, which is how a rename silently stops building
+    something.
+    """
+    envs = set(re.findall(r"^\[env:([\w.-]+)\]", ini, re.M))
+    if not envs:
+        problems.append("parsed no [env:*] sections out of platformio.ini")
+        return
+
+    for name in ("ci.yml", "pages.yml"):
+        try:
+            text = read(".github", "workflows", name)
+        except OSError:
+            continue                     # check_reachable() reports the absence
+
+        for line in text.splitlines():
+            if "pio run" not in line:
+                continue
+            # A -e with no environment after it. PlatformIO fails the whole
+            # command, so this is a build that never happens.
+            if re.search(r"-e\s+(?=-e\b)", line) or re.search(r"-e\s*$", line):
+                problems.append(
+                    ".github/workflows/%s has a `-e` with no environment after "
+                    "it: PlatformIO rejects the whole command, so nothing in it "
+                    "gets built. Usually left behind by deleting an env from "
+                    "the list." % name)
+                continue
+            for env in re.findall(r"-e\s+([\w.-]+)", line):
+                if env.startswith("$"):
+                    continue             # ENVS variable, expanded at run time
+                if env not in envs:
+                    problems.append(
+                        ".github/workflows/%s builds `-e %s`, which is not an "
+                        "[env:*] in platformio.ini -- that build fails the "
+                        "whole command." % (name, env))
+
+        # The space-separated lists (ENVS=, `for env in ...`) are how a pull
+        # request picks a subset, and a typo there skips a build silently
+        # rather than failing loudly.
+        for listing in re.findall(r'ENVS="([^"$]+)"', text):
+            for env in listing.split():
+                if env not in envs:
+                    problems.append(
+                        ".github/workflows/%s lists env `%s` in ENVS, which is "
+                        "not in platformio.ini." % (name, env))
+        for listing in re.findall(r"for env in ([^;]+);", text):
+            for env in listing.split():
+                if env.startswith("$"):
+                    continue             # expanded at run time
+                if env not in envs:
+                    problems.append(
+                        ".github/workflows/%s loops over env `%s`, which is "
+                        "not in platformio.ini." % (name, env))
 
 
 def check_reachable(problems, boards, board_envs):


### PR DESCRIPTION
The published site still advertises **33 games** after 5.9.0 shipped, because
the Pages deploy failed 49 seconds in and silently left the previous release
up. This is the fix, plus the check that should have caught it.

## What broke

Removing a board I had briefly added left this in **both** workflows:

```
-e app_e32r40t -e -e app_e32r32p
```

My revert did `.replace(' app_e32r24p','')` before
`.replace(' -e app_e32r24p','')`, so the first one stripped the env name off
its own flag. PlatformIO rejects the whole command — *"Got unexpected extra
argument"* — so nothing in it gets built.

## Why CI went green anyway

This is the part worth fixing. A pull request builds a **selective** list
through the `ENVS` variable, and only the full-build path carries that flag
list. So the identical broken line was **latent in `ci.yml` and fatal in
`pages.yml`**, which always builds everything. Nothing compared the two, and
nothing validated the command at all.

`check_reachable()` could not have caught it either: it asks whether each
board's environment is *mentioned* in the workflows, and a mention is exactly
what a dangling flag leaves intact.

## The guard

`check_workflow_envs()` checks the **shape** of the command rather than its
contents:

- a `-e` with no environment after it
- an environment named in a workflow that is not an `[env:*]` in
  `platformio.ini` — how a rename quietly stops building something
- the space-separated `ENVS=` and `for env in` lists, where a typo skips a
  build silently instead of failing loudly

Both failure modes were reintroduced deliberately and the checker caught each
before this was committed.

## Effect

Merging this re-runs Pages from `main`, which regenerates the installer page
from `AppRegistry` — so the game count corrects itself to 35 and the new
`app_esp32_2432s028_inv` build starts being offered.

Straight to `main` rather than through `dev` because Pages only deploys from
`main`, and the live page is currently wrong. `dev` picks it up in the
snapshot PR that follows.
