### PR TITLE
Credit Hacktuber on the page, and say our own video is coming

### DIFF
--- a/site/index.template.html
+++ b/site/index.template.html
@@ -249,6 +249,33 @@ footer {
   <p class="note" id="download-links"></p>
 </section>
 
+<section id="video">
+  <h2>See it running</h2>
+  <div class="card">
+    <p style="margin-top:0">
+      <strong>Hacktuber</strong> showcased Braino on his channel &mdash; the
+      first time somebody outside this project picked it up, put it on real
+      hardware and showed it working. That is worth more than any amount of
+      documentation, and we are grateful for it.
+    </p>
+    <p>
+      <a href="https://www.youtube.com/watch?v=xvjQwQaIYu8&amp;t=14s">Watch the
+      showcase</a> &middot;
+      <a href="https://www.youtube.com/@Hacktuber">@Hacktuber on YouTube</a>
+    </p>
+    <p>
+      <strong>A walkthrough from us is on the way.</strong> The games, two
+      consoles playing each other across the room, and what it actually takes
+      to build one of these. Stay tuned.
+    </p>
+    <p class="note" style="margin-bottom:0">
+      Those are ordinary links rather than embedded players, deliberately: an
+      embed would load Google's tracking on this page, and the Privacy section
+      below says this page does not do that.
+    </p>
+  </div>
+</section>
+
 <section id="hardware">
   <h2>What you need</h2>
   <div class="card">


### PR DESCRIPTION
Adds a **See it running** section to the installer page, between *Install it
from this page* and *What you need*.

## What it says

**Hacktuber** showcased the firmware on his channel — the first time anybody
outside this project picked it up, put it on real hardware and showed it
working. The section credits him and links
[the showcase](https://www.youtube.com/watch?v=xvjQwQaIYu8&t=14s) and
[@Hacktuber](https://www.youtube.com/@Hacktuber).

It also carries a **stay-tuned line for our own walkthrough** — the games, two
consoles playing each other across the room, and what it takes to build one.

## Links, not embeds — on purpose

An embedded player would load Google's tracking on every visit, and the
**Privacy section a few inches further down the same page** opens with *"No
accounts, analytics, telemetry, or personal-data collection."*

That paragraph is about the firmware, but nobody reading it on this page will
draw that distinction, and a privacy claim the page itself undercuts is worse
than no claim at all. So: plain anchors, no iframe, no thumbnail pulled from
`ytimg`.

Verified on the built page — external hosts are still only `github.com` and
`unpkg.com` (the flasher). `youtube.com` appears as an `href` and nothing else,
so nothing third-party loads at render. The section carries a short note
explaining this, so the next person doesn't "improve" it into an iframe.

## Why straight to `main`

The site deploys only from `main`, and `dev` cannot be merged there right now —
it carries `5.10.0-SNAPSHOT` and `main` has to hold a real version until the
next release. This is docs-only: no firmware, no generator logic, no version
strings. `check_docs` and `gen_site` both clean.

I'll back-merge `main` into `dev` straight after, so the next release branch
carries it too.
