### PR TITLE
Merge main into dev: the Hacktuber shout-out

### DIFF
--- a/site/index.template.html
+++ b/site/index.template.html
@@ -249,6 +249,33 @@ footer {
   <p class="note" id="download-links"></p>
 </section>
 
+<section id="video">
+  <h2>See it running</h2>
+  <div class="card">
+    <p style="margin-top:0">
+      <strong>Hacktuber</strong> showcased Braino on his channel &mdash; the
+      first time somebody outside this project picked it up, put it on real
+      hardware and showed it working. That is worth more than any amount of
+      documentation, and we are grateful for it.
+    </p>
+    <p>
+      <a href="https://www.youtube.com/watch?v=xvjQwQaIYu8&amp;t=14s">Watch the
+      showcase</a> &middot;
+      <a href="https://www.youtube.com/@Hacktuber">@Hacktuber on YouTube</a>
+    </p>
+    <p>
+      <strong>A walkthrough from us is on the way.</strong> The games, two
+      consoles playing each other across the room, and what it actually takes
+      to build one of these. Stay tuned.
+    </p>
+    <p class="note" style="margin-bottom:0">
+      Those are ordinary links rather than embedded players, deliberately: an
+      embed would load Google's tracking on this page, and the Privacy section
+      below says this page does not do that.
+    </p>
+  </div>
+</section>
+
 <section id="hardware">
   <h2>What you need</h2>
   <div class="card">


### PR DESCRIPTION
Brings `dev` level with `main`.

`main` carried two commits `dev` did not — the Pages env-list hotfix (#120)
and the Hacktuber credit (#122) — because both had to reach the site, which
deploys only from `main`. The hotfix had already arrived in `dev` through the
snapshot PR, so this merge brings across just the template change (27 lines).

**Nothing here touches `AppVersion.h`**, so `dev` keeps `5.10.0-SNAPSHOT` and
`main` keeps `5.9.0` — the intended state between releases. Verified after
merging.

Doing this now rather than at the next release because `dev` drifting behind
`main` is what blocked a release PR here once before, and it costs nothing to
keep them level.

All five checkers clean; `gen_site` builds.