### PR TITLE
Withdraw 5.9.0: the ID read corrupted the panel it was diagnosing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,58 @@
 # Changelog
 
-## 5.10.0-SNAPSHOT — Unreleased
+## 5.9.1 — 2026-09-08
 
-In development on `dev`. Nothing here has shipped; the version carries the
-`-SNAPSHOT` suffix so a board on a desk cannot be mistaken for the 5.9.0
-release, and `release.yml` refuses to publish a tag whose version carries it.
+**A hotfix. 5.9.0 was withdrawn: it broke the display on two of the seven
+supported boards, and its Freenove image could not boot at all.** Three
+defects, every one of them shipped by a change meant to make diagnosis easier.
 
-`Board::compareVersions()` sorts a pre-release before the release of the same
-number, so a console on this build is correctly told that nothing newer exists
-rather than being nagged all cycle to install the 5.9.0 it is ahead of.
+**The boot log's panel-ID read corrupted the display.** 5.9.0 printed the
+controller's ID register at boot. On the 2.8-inch E32R28T-1 and the Freenove
+FNK0104B the result was a screen with the top bar crushed into a band at the
+bottom edge and the rest of it never painted. TFT_eSPI's `readcommand8()` is
+not a read: it writes an undocumented `0xD9` index command, toggles CS
+mid-sequence, and restores neither the address window nor `MADCTL`. A panel
+that answers gives you an ID; a panel whose MISO is not wired back is left
+mid-command, and the next write inherits it.
 
-**Worth doing early in this cycle:** a two-console regression check of nearby
-play. Two defects in that path were fixed late in 5.9.0 — the acceptor never
-published its ply-0 answer, and a peer's turn was recorded only on the
-sighting that first brought it into range — so the code that shipped is not
-the code that was exercised on two boards.
+What made this expensive to find is worth recording. The firmware was *healthy
+throughout* — 48fps, a 23ms worst frame against a 20ms budget, a flat heap, no
+stall, no panic, sitting on `ctx='Profiles'`, a screen whose drawing code is
+byte-identical between the two releases. Every instrument said the software
+was fine and every instrument was right: the corruption was in the panel, put
+there by the diagnostic. The field was worthless even where it appeared to
+work — across all seven boards it only ever answered `00:00:00` (MISO absent)
+or `FF:FF:FF` (floating high), and not one returned a real ID. It is removed
+rather than guarded, and `AppRuntime.cpp` records what a future board would
+have to do to earn it back.
+
+**The Freenove's merged image and its web-installer entry put the bootloader
+at the wrong offset.** `pack_release.py` hardcoded `--chip esp32` and a
+`0x1000` bootloader offset for every environment, and `gen_site.py` wrote that
+same offset into the manifest esp-web-tools consumes. The ESP32-S3 reads its
+bootloader from `0x0`, found padding there, and looped on `invalid header:
+0xff`. Every part downloads, every hash verifies, the progress bar completes,
+and the board is dead — so **nobody could install the Freenove from the web
+page for as long as it was offered**, and the failure looked like a successful
+install. Both tools now derive the offset per chip: `pack_release.py` reads
+the chip id out of the ESP image header of the bootloader it is packing, so it
+cannot drift when a board is added, and `gen_site.py` keys off the same `chip`
+field it already hands over as `chipFamily`. An unknown chip is a hard failure
+in both, because quietly defaulting to `0x1000` is exactly how this shipped.
+
+**`FLASHING.txt` claimed flashing preserves NVS. That is false for the merged
+image.** The four separate parts do leave it alone — nothing is written between
+`0x9000` and `0xe000`. The merged image is one contiguous blob from `0x0`, so
+it necessarily paves that region with `0xFF`, erasing profiles, scores and the
+touch calibration. Right for installing onto a new board, wrong for updating
+one somebody is using, and the file now says so per path. It was believed
+during this very investigation and cost a development board its stored state.
+
+**Still outstanding, carried over from 5.9.0:** a two-console regression check
+of nearby play. Two defects in that path were fixed late in 5.9.0 — the
+acceptor never published its ply-0 answer, and a peer's turn was recorded only
+on the sighting that first brought it into range — so the code that shipped is
+not the code that was exercised on two boards.
 
 ## 5.9.0 — 2026-09-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,439,425 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,439,057 / 3,145,728 bytes,
 **77.5%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 76,508 / 327,680 (23.3%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their
@@ -1048,10 +1048,19 @@ ESP32-2432S028R. `docs/PORTING.md` is the checklist for adding a board.
   that survives being flashed with the wrong image -- which is exactly how a
   2.8-inch board reported itself as a 4-inch for half an hour. `board=` and
   `panel=` are compiled in and therefore describe the firmware, not the
-  hardware; `id=` is read back off the controller and is the one line that can
-  contradict the profile, though it answers zeroes on any board whose MISO is
-  not wired back. Keep all four: between them they turn "which board is this?"
-  into a paste rather than an afternoon.
+  hardware. **There is no `id=` field, and putting one back needs more care
+  than it looks.** 5.9.0 printed the controller's ID register and broke the
+  display on two of the seven boards: `tft.readcommand8()` writes an
+  undocumented 0xD9, toggles CS mid-sequence and restores neither the address
+  window nor MADCTL, so a panel whose MISO is not wired back is left
+  mid-command and the next write inherits it. The symptom is the top bar
+  crushed into a band at one edge and the rest of the screen never painted,
+  while the loop reports 48fps, a 23ms worst frame and a flat heap -- every
+  instrument saying the firmware is healthy, because it is. The corruption was
+  in the panel, put there by the diagnostic. Across all seven boards the field
+  only ever answered `00:00:00` or `FF:FF:FF`; not one returned a real ID, so
+  it could not do the job it cost a panel to attempt. The remaining three lines
+  turn "which board is this?" into a paste rather than an afternoon.
 - **The RGB LED's red and green lines are crossed on this unit** relative to the usual standard pinout â€” `rgb.r = 16`, `rgb.g = 4`, `rgb.b = 17` in the E32R28T-1 profile. This is already corrected there and verified on hardware; do not "fix" it again. Common anode, so drive is inverted â€” which the profile states rather than the driver assuming.
 - Touch is bit-banged SPI on the E32R28T-1 and the ESP32-2432S028 variants
   (the TFT owns HSPI); on the E32R32P and the E32R40T the XPT2046 **shares the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml)
 [![Pages](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml)
 [![Flash in browser](https://img.shields.io/badge/flash%20in%20browser-Web%20Serial-6f42c1)](https://iamankushpandit.github.io/Gume/)
-[![Version](https://img.shields.io/badge/version-5.10.0--SNAPSHOT-9a6700)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.9.1-blue)](CHANGELOG.md)
 [![Games](https://img.shields.io/badge/games-35-2d7d9a)](#the-games)
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 35 |
-| Flash | 2,439,425 / 3,145,728 bytes (**77.5%**) |
+| Flash | 2,439,057 / 3,145,728 bytes (**77.5%**) |
 | RAM | 76,508 / 327,680 bytes (**23.3%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -1090,7 +1090,8 @@ owner should be able to see what it is transmitting, from the device itself.**
 
 ## Version
 
-In development: **5.10.0-SNAPSHOT** — the last release was **5.9.0**. See
+Current release: **5.9.1** — a hotfix withdrawing **5.9.0**, which broke
+the display on two boards and shipped a Freenove image that could not boot. See
 [CHANGELOG.md](CHANGELOG.md) for what has changed since.
 
 ---

--- a/include/AppVersion.h
+++ b/include/AppVersion.h
@@ -31,7 +31,7 @@
  * not go away -- it is waiting for the next name that does not fit. If you
  * change either, re-measure: the portrait launcher has about 38px of air
  * between the product name and this string, and that is the whole allowance. */
-#define BRAINO_VERSION          "5.10.0-SNAPSHOT"
+#define BRAINO_VERSION          "5.9.1"
 #define BRAINO_PRODUCT_NAME     "Braino!"
 /** The brand that publishes the console, and the owner of the marks. */
 #define BRAINO_COMPANY          "GoodTime Micro Company"

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -313,18 +313,38 @@ void BrainoApp::logIdentity() {
                   (unsigned long)(ESP.getFlashChipSize() / 1024),
                   (unsigned long)(ESP.getPsramSize() / 1024));
 
-    /* The controller's ID register. Read AFTER the panel is up, which it is by
-     * the time begin() reaches here. Wrapped in its own line because a board
-     * with MISO unconnected answers zeroes and that is worth seeing rather
-     * than hiding. */
-    TFT_eSPI& tft = board_.display();
-    const uint8_t id1 = tft.readcommand8(0x04, 1);
-    const uint8_t id2 = tft.readcommand8(0x04, 2);
-    const uint8_t id3 = tft.readcommand8(0x04, 3);
-    Serial.printf("[boot] panel=%s%s %dx%d bl=IO%d id=%02X:%02X:%02X\n",
+    /* THERE IS NO `id=` FIELD HERE, AND THERE MUST NOT BE ONE AGAIN.
+     *
+     * 5.9.0 read the controller's ID register with three
+     * `tft.readcommand8(0x04, n)` calls and printed the answer. It shipped,
+     * and it broke the display on two of the seven boards: the panel came up
+     * with the top bar crushed into a band at the bottom edge and the rest of
+     * the screen never painted -- an address-window symptom, on a board whose
+     * loop was meanwhile running at 48fps with a 23ms worst frame, a flat heap
+     * and no stall. Every diagnostic said the firmware was healthy, because it
+     * was. The corruption was in the panel, put there by the diagnostic.
+     *
+     * TFT_eSPI's readcommand8() is not a read. It writes 0xD9 -- an
+     * undocumented index-register command -- toggles CS mid-sequence, issues
+     * the command and clocks a byte back, and it restores neither the address
+     * window nor MADCTL. On a panel that answers you get an ID; on a panel
+     * whose MISO is not wired back you get whatever the bus floats to AND a
+     * controller left mid-command, which the next write inherits.
+     *
+     * The field was worth nothing even where it appeared to work: across all
+     * seven supported boards it only ever answered 00:00:00 (MISO absent) or
+     * FF:FF:FF (floating high). Not one returned a real ID. So this was a
+     * diagnostic that could not diagnose, paid for with a corrupted panel.
+     *
+     * If a future board genuinely wires MISO back and the ID is genuinely
+     * wanted, it needs a PanelProfile field saying so and a setRotation()
+     * reissued afterwards to rebuild the window -- never an unconditional
+     * read. Until a board needs it, the correct version of this line is the
+     * one that does not touch the panel at all. */
+    Serial.printf("[boot] panel=%s%s %dx%d bl=IO%d\n",
                   GUME_PANEL_DRIVER, GUME_PANEL_INVERTED ? "+inv" : "",
                   (int)BOARD.panel.nativeWidth, (int)BOARD.panel.nativeHeight,
-                  (int)BOARD.panel.backlightPin, id1, id2, id3);
+                  (int)BOARD.panel.backlightPin);
 
     Serial.printf("[boot] touch=%s cs=IO%d irq=IO%d sd=%s rgb=%s bat=%s\n",
                   BOARD.touch.kind == TouchKind::CapacitiveFt6336u

--- a/tools/gen_site.py
+++ b/tools/gen_site.py
@@ -47,6 +47,36 @@ PARTS = (
     ("firmware.bin",   0x10000),
 )
 
+# Where each chip family's ROM reads the bootloader from. ONLY the bootloader
+# moves; the other three offsets are the same on every target.
+#
+# This existed as a single 0x1000 until 5.9.1, which meant the manifest handed
+# esp-web-tools an ESP32 layout for the ESP32-S3 board. The S3 ROM reads 0x0,
+# found the 0xFF the manifest left there, and looped on "invalid header: 0xff".
+# Every part downloaded and verified, the progress bar completed, and the board
+# was dead -- so the page reported a successful install of a firmware that
+# could never boot, for as long as that board was offered.
+#
+# Keyed by the `chip` in BOARD_DETAILS, which is also the chipFamily
+# esp-web-tools is given, so the two cannot disagree.
+BOOTLOADER_OFFSET = {
+    "ESP32":    0x1000,
+    "ESP32-S2": 0x1000,
+    "ESP32-S3": 0x0,
+    "ESP32-C3": 0x0,
+}
+
+
+def parts_for(chip):
+    """The manifest's parts list for one chip family."""
+    if chip not in BOOTLOADER_OFFSET:
+        die("board chip %r has no bootloader offset. Add it to "
+            "BOOTLOADER_OFFSET -- defaulting to 0x1000 is how the S3 board "
+            "shipped an image that verified and could not boot." % chip)
+    offset = BOOTLOADER_OFFSET[chip]
+    return tuple((name, offset if name == "bootloader.bin" else stock)
+                 for name, stock in PARTS)
+
 # One entry per PlatformIO environment offered on the page. `label` is what the
 # picker shows; `note` is the sentence under it, and has to be honest about
 # what the diagnostic builds do -- they replace the games entirely.
@@ -602,7 +632,8 @@ def manifest_for(board, variant, release):
         "new_install_prompt_erase": False,
         "builds": [{
             "chipFamily": board["chip"],
-            "parts": [{"path": name, "offset": offset} for name, offset in PARTS],
+            "parts": [{"path": name, "offset": offset}
+                      for name, offset in parts_for(board["chip"])],
         }],
     }
 

--- a/tools/pack_release.py
+++ b/tools/pack_release.py
@@ -53,12 +53,61 @@ import textwrap
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-FLASH_PARTS = (
-    ("bootloader.bin", "0x1000"),
-    ("partitions.bin", "0x8000"),
-    ("boot_app0.bin",  "0xe000"),
-    ("firmware.bin",   "0x10000"),
-)
+# The parts, in flash order. Only the BOOTLOADER's offset depends on the chip
+# -- the other three are the standard Arduino-ESP32 layout on every target.
+PART_NAMES = ("bootloader.bin", "partitions.bin", "boot_app0.bin",
+              "firmware.bin")
+
+# Where each chip's ROM looks for the bootloader. THIS IS NOT COSMETIC: put an
+# ESP32-S3 bootloader at 0x1000 and the ROM reads 0xFF from 0x0, prints
+# "invalid header: 0xff" and loops forever. Every hash still verifies, so the
+# flash reports success and the board is simply dead -- which is exactly how
+# 5.9.0 shipped a Freenove image that could not boot, and a web-installer
+# entry that bricked the board it was offered for.
+#
+# Chip ids are the values in the ESP image header, which is why they are read
+# off the artifact rather than guessed from an environment name.
+CHIP_IDS = {
+    0:  ("esp32",    0x1000),
+    2:  ("esp32s2",  0x1000),
+    5:  ("esp32c3",  0x0),
+    9:  ("esp32s3",  0x0),
+    12: ("esp32c2",  0x0),
+    13: ("esp32c6",  0x0),
+    16: ("esp32h2",  0x0),
+}
+
+
+def chip_of(bootloader_path):
+    """Read the chip and its bootloader offset out of the image header.
+
+    Derived from the bytes being packed rather than from a table keyed on the
+    environment name, so it cannot drift when a board is added: the header is
+    written by the very build this is packing. Bytes 0 is the magic and 12..13
+    are the chip id, little-endian.
+    """
+    with open(bootloader_path, "rb") as handle:
+        header = handle.read(16)
+    if len(header) < 14 or header[0] != 0xE9:
+        die("%s is not an ESP image (magic 0x%02X, expected 0xE9)"
+            % (bootloader_path, header[0] if header else 0))
+    chip_id = header[12] | (header[13] << 8)
+    if chip_id not in CHIP_IDS:
+        die("%s reports chip id %d, which this packer does not know. Add it to "
+            "CHIP_IDS with the offset its ROM reads the bootloader from -- "
+            "guessing 0x1000 is how an unbootable image ships."
+            % (bootloader_path, chip_id))
+    return CHIP_IDS[chip_id]
+
+
+def flash_parts(bootloader_offset):
+    """The four parts with their offsets, for one chip."""
+    return (
+        ("bootloader.bin", "0x%x" % bootloader_offset),
+        ("partitions.bin", "0x8000"),
+        ("boot_app0.bin",  "0xe000"),
+        ("firmware.bin",   "0x10000"),
+    )
 
 # What each environment is for, in the words the README and CLAUDE.md use.
 # An environment with no entry still ships -- it just gets no description, and
@@ -184,17 +233,21 @@ def esptool_command():
         "PlatformIO fetches tool-esptoolpy")
 
 
-def merge(env_dir, parts, out_path):
+def merge(env_dir, parts, out_path, chip, bootloader_offset):
     """Flatten the four parts into one image to be written at 0x0.
 
     flash_mode/freq/size are `keep`: esptool reads them from the bootloader
     header the build produced, so this cannot contradict the board.
+
+    `--chip` was hardcoded to esp32 here until 5.9.1, which put the S3's
+    bootloader at 0x1000 in the merged image and produced a file that verifies
+    perfectly and cannot boot.
     """
     command = esptool_command() + [
-        "--chip", "esp32", "merge_bin", "-o", out_path,
+        "--chip", chip, "merge_bin", "-o", out_path,
         "--flash_mode", "keep", "--flash_freq", "keep", "--flash_size", "keep",
     ]
-    for name, offset in FLASH_PARTS:
+    for name, offset in flash_parts(bootloader_offset):
         command += [offset, parts[name]]
     result = subprocess.run(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
@@ -274,21 +327,33 @@ def flashing_notes(version, built, entries):
         "-" * 70,
         "Flashing the merged image (one command)",
         "-" * 70,
-        "  esptool.py --chip esp32 --port COM5 --baud 460800 \\",
+        "  esptool.py --chip %s --port COM5 --baud 460800 \\"
+        % entries[0][2]["chip"],
         "      write_flash 0x0 %s" % entries[0][2]["merged_name"],
         "",
         "The merged file already contains the four parts below at their",
         "offsets, and carries the flash mode, frequency and size the firmware",
         "was built with.",
         "",
+        "THE --chip AND THE BOOTLOADER OFFSET ARE PER BOARD. The ESP32 reads",
+        "its bootloader from 0x1000 and the ESP32-S3 from 0x0, so a command",
+        "copied from the wrong board's section produces an image that",
+        "verifies every hash and then loops on `invalid header: 0xff`. The",
+        "table below is generated per environment for that reason.",
+        "",
         "-" * 70,
         "Flashing the parts separately",
         "-" * 70,
-        "  esptool.py --chip esp32 --port COM5 --baud 460800 write_flash \\",
     ]
-    for name, offset in FLASH_PARTS:
-        lines.append("      %-7s %s \\" % (offset, entries[0][2][name + "_name"]))
-    lines[-1] = lines[-1].rstrip(" \\")
+    for env, board, parts in entries:
+        lines.append("  %s (%s):" % (env, parts["chip"]))
+        lines.append("  esptool.py --chip %s --port COM5 --baud 460800 "
+                     "write_flash \\" % parts["chip"])
+        rows = flash_parts(parts["bootloader_offset"])
+        for name, offset in rows:
+            lines.append("      %-7s %s \\" % (offset, parts[name + "_name"]))
+        lines[-1] = lines[-1].rstrip(" \\")
+        lines.append("")
     lines += [
         "",
         "Substitute another environment's name to flash a diagnostic.",
@@ -296,10 +361,21 @@ def flashing_notes(version, built, entries):
         "-" * 70,
         "What flashing destroys",
         "-" * 70,
-        "NVS holds touch calibration, player profiles and scores. A plain",
-        "write_flash of these images leaves NVS alone; `esptool.py",
-        "erase_flash` does not, and takes the touch calibration with it, so",
-        "the panel needs recalibrating on first boot.",
+        "NVS holds touch calibration, player profiles and scores.",
+        "",
+        "Flashing the FOUR PARTS leaves NVS alone: nothing is written between",
+        "0x9000 and 0xe000, where it lives.",
+        "",
+        "Flashing the MERGED image ERASES IT. The merged file is one",
+        "contiguous blob starting at 0x0, so it necessarily covers the NVS",
+        "region and writes 0xFF padding across it. Profiles, scores and the",
+        "touch calibration are gone and the panel needs recalibrating on",
+        "first boot. That is the right behaviour for installing onto a new",
+        "board and the wrong one for updating a board somebody is using --",
+        "use the four parts for an update. This file previously claimed both",
+        "paths preserved NVS, which was true only of the parts.",
+        "",
+        "`esptool.py erase_flash` erases everything, always.",
         "",
         "-" * 70,
         "Verifying a download",
@@ -326,7 +402,7 @@ def pack(version, out_dir, built, strict):
 
         label = "-".join(filter(None, ("braino", version, board, env)))
         parts = {}
-        for name, _offset in FLASH_PARTS:
+        for name in PART_NAMES:
             source = (stock_boot_app0 if name == "boot_app0.bin"
                       else os.path.join(env_dir, name))
             if not os.path.exists(source):
@@ -337,8 +413,12 @@ def pack(version, out_dir, built, strict):
             parts[name] = source
             parts[name + "_name"] = target_name
 
+        chip, bootloader_offset = chip_of(parts["bootloader.bin"])
+        parts["chip"] = chip
+        parts["bootloader_offset"] = bootloader_offset
         parts["merged_name"] = "%s-merged.bin" % label
-        merge(env, parts, os.path.join(out_dir, parts["merged_name"]))
+        merge(env, parts, os.path.join(out_dir, parts["merged_name"]),
+              chip, bootloader_offset)
 
         if env_role(env, board) not in ENV_BLURBS:
             missing_blurb.append(env)


### PR DESCRIPTION
5.9.0 broke the display on two of the seven boards and shipped a Freenove image that could not boot. Three defects, all from one change meant to make diagnosis *easier*. This is 5.9.1.

## 1. The boot log's panel-ID read corrupted the display

5.9.0 printed the controller's ID register. On the E32R28T-1 and the Freenove FNK0104B the screen came up with the top bar crushed into a band at the bottom edge and the rest never painted.

`tft.readcommand8()` is not a read: it writes an undocumented `0xD9` index command, toggles CS mid-sequence, and restores neither the address window nor `MADCTL`. A panel that answers gives you an ID; a panel whose MISO is not wired back is left mid-command and the next write inherits it.

**Why this was expensive to find, and worth recording:** the firmware was healthy the whole time — 48fps, a 23ms worst frame against a 20ms budget, a flat heap, no stall, no panic, sitting on `ctx='Profiles'`, a screen whose drawing code is byte-identical between the two releases. Every instrument said the software was fine and every instrument was right. The corruption was in the panel, put there by the diagnostic.

It is removed rather than guarded, because it was worthless even where it appeared to work: across all seven boards it only ever answered `00:00:00` (MISO absent) or `FF:FF:FF` (floating high) and never a real ID. `AppRuntime.cpp` records what a future board would have to do to earn it back — a `PanelProfile` field, and a re-issued `setRotation()`.

## 2. Nobody could install the Freenove from the web page

`pack_release.py` hardcoded `--chip esp32` and a `0x1000` bootloader offset for every environment; `gen_site.py` wrote the same offset into the manifest esp-web-tools consumes. The ESP32-S3 reads its bootloader from `0x0`, found padding, and looped on `invalid header: 0xff` — with every part downloaded and every hash verified, so the page reported a successful install of a firmware that could never boot.

Both now derive the offset per chip. The packer reads the chip id out of the ESP image header of the bootloader it is packing, so it cannot drift when a board is added; the site keys off the same `chip` field it already hands over as `chipFamily`. An unknown chip is a hard failure in both, because defaulting to `0x1000` is exactly how this shipped.

Verified from the regenerated manifests: S3 bootloader at `0x0`, the six ESP32 boards unchanged at `0x1000`.

## 3. FLASHING.txt was wrong about NVS

It claimed `write_flash` preserves NVS. True of the four separate parts; false of the merged image, which spans from `0x0` and paves the NVS region with `0xFF`, erasing profiles, scores and touch calibration. Now stated per path. That line was believed during this investigation and cost a development board its stored state.

## Verification

- **On hardware:** v5.9.0 with *only* the three `readcommand8()` calls removed renders correctly on the E32R28T-1 that v5.9.0 as released breaks — same NVS, same `layout=Horizontal`, same theme, nothing else changed. 5.8.0 good / 5.9.0 bad / 5.9.0-minus-the-read good.
- The Freenove was bricked and recovered by hand, which is how the offset defect was found and confirmed.
- All five checkers clean; `gen_site.py` regenerates.
- `pio run -e app` with `GITHUB_REF_NAME=main`: flash 2,439,057 / 3,145,728 (77.5%), RAM 76,508 / 327,680 (23.3%). README and CLAUDE.md updated to match.

## Still outstanding

A two-console regression check of nearby play, carried over from 5.9.0 — two defects in that path were fixed after it was last exercised on two boards, so the shipped code is not the code that was tested.