### PR TITLE
Open 5.10.0-SNAPSHOT on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 5.10.0-SNAPSHOT — Unreleased
+
+In development on `dev`. Nothing here has shipped; the version carries the
+`-SNAPSHOT` suffix so a board on a desk cannot be mistaken for the 5.9.1
+release, and `release.yml` refuses to publish a tag whose version carries it.
+
+`Board::compareVersions()` sorts a pre-release before the release of the same
+number, so a console on this build is correctly told that nothing newer exists
+rather than being nagged all cycle to install the 5.9.1 it is ahead of.
+
+**First thing this cycle: a two-console regression check of nearby play.** It
+has now been carried over twice. Two defects in that path were fixed late in
+5.9.0 — the acceptor never published its ply-0 answer, and a peer's turn was
+recorded only on the sighting that first brought it into range — so the code
+that shipped is not the code that was exercised on two boards, and it is the
+headline feature of that release.
+
+**Second: the boot banner should carry the device's stored STATE, not just its
+identity.** Diagnosing the 5.9.1 panel bug took far longer than it should
+have, because four boards on one commit produced four healthy, nearly
+identical logs while looking different from each other. Everything that
+changes what a screen shows — theme, brightness, layout, idle timeouts, mute
+— lives in NVS, survives a flash, and appeared nowhere in the log. A
+`[boot] state=` line was written during that investigation and used to rule
+out the theme hypothesis; it wants committing properly, with profile names
+deliberately left out for the same reason the SSID already is.
+
 ## 5.9.1 — 2026-09-08
 
 **A hotfix. 5.9.0 was withdrawn: it broke the display on two of the seven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,439,057 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,439,073 / 3,145,728 bytes,
 **77.5%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 76,508 / 327,680 (23.3%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/ci.yml)
 [![Pages](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml/badge.svg)](https://github.com/iamankushpandit/Gume/actions/workflows/pages.yml)
 [![Flash in browser](https://img.shields.io/badge/flash%20in%20browser-Web%20Serial-6f42c1)](https://iamankushpandit.github.io/Gume/)
-[![Version](https://img.shields.io/badge/version-5.9.1-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.10.0--SNAPSHOT-9a6700)](CHANGELOG.md)
 [![Games](https://img.shields.io/badge/games-35-2d7d9a)](#the-games)
 [![Platform](https://img.shields.io/badge/platform-ESP32--32E-e25822)](#build-and-flash)
 [![Framework](https://img.shields.io/badge/framework-Arduino%20%7C%20PlatformIO-orange)](https://platformio.org/)
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 35 |
-| Flash | 2,439,057 / 3,145,728 bytes (**77.5%**) |
+| Flash | 2,439,073 / 3,145,728 bytes (**77.5%**) |
 | RAM | 76,508 / 327,680 bytes (**23.3%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 
@@ -1090,8 +1090,8 @@ owner should be able to see what it is transmitting, from the device itself.**
 
 ## Version
 
-Current release: **5.9.1** — a hotfix withdrawing **5.9.0**, which broke
-the display on two boards and shipped a Freenove image that could not boot. See
+In development: **5.10.0-SNAPSHOT** — the last release was **5.9.1**, a
+hotfix withdrawing 5.9.0. See
 [CHANGELOG.md](CHANGELOG.md) for what has changed since.
 
 ---

--- a/include/AppVersion.h
+++ b/include/AppVersion.h
@@ -31,7 +31,7 @@
  * not go away -- it is waiting for the next name that does not fit. If you
  * change either, re-measure: the portrait launcher has about 38px of air
  * between the product name and this string, and that is the whole allowance. */
-#define BRAINO_VERSION          "5.9.1"
+#define BRAINO_VERSION          "5.10.0-SNAPSHOT"
 #define BRAINO_PRODUCT_NAME     "Braino!"
 /** The brand that publishes the console, and the owner of the marks. */
 #define BRAINO_COMPANY          "GoodTime Micro Company"


### PR DESCRIPTION
5.9.1 is released, so `dev` goes back to carrying a snapshot. A board flashed from `dev` then cannot be mistaken for the release it is ahead of, and `release.yml` refuses to publish a tag whose version still carries the suffix.

Flash moves 2,439,057 -> 2,439,073. That is the version string getting ten characters longer and nothing else. `dev` and `main` legitimately disagree on that figure between releases, and each branch states its own, because `check_docs.py` compares against whatever ELF is in the tree being checked.

## Two items recorded at the top of the cycle

**A two-console regression check of nearby play.** Carried over twice now, and it is the headline feature of 5.9.0. Two defects in that path were fixed after it was last exercised on two boards, so the shipped code is not the tested code.

**The boot banner should carry the device's stored state, not only its identity.** Diagnosing the 5.9.1 panel bug was slow for a specific, fixable reason: four boards on one commit produced four healthy and nearly identical logs while looking different from one another. Everything that changes what a screen shows — theme, brightness, layout, idle timeouts, mute — lives in NVS, survives a flash, and appeared nowhere in the log. A `[boot] state=` line was written during the investigation and used to rule out the theme hypothesis; it wants committing properly, with profile names left out for the same reason the SSID already is.

All five checkers clean.