### PR TITLE
4-inch 3x3 portrait launcher, redraw fixes, and per-board bench flashing

### DIFF
--- a/.claude/skills/braino-boards/SKILL.md
+++ b/.claude/skills/braino-boards/SKILL.md
@@ -9,7 +9,7 @@ description: Identify which Braino board is on which serial port, and flash the 
 single session and it is answerable in about ten seconds. Run this instead:
 
 ```bash
-python tools/identify_boards.py
+python tools/ESP32_boardUtil.py
 ```
 
 It prints one line per port: the board, the PlatformIO environment to flash it
@@ -18,7 +18,7 @@ every connected board correctly, in one step, taking and releasing the board
 lock on its own:
 
 ```bash
-python tools/identify_boards.py --flash
+python tools/ESP32_boardUtil.py --flash
 ```
 
 It builds every distinct environment **at the same time**, then uploads to **all
@@ -31,7 +31,7 @@ run it in the background.
 If other agents may be testing on the boards, never restart any of them:
 
 ```bash
-python tools/identify_boards.py --no-reset
+python tools/ESP32_boardUtil.py --no-reset
 ```
 
 ## Configure the bench — never by hand
@@ -106,7 +106,7 @@ s.open()`), or opening it resets the board.
   notice. Flash a candidate build, read `[boot] board=` back, then record it:
 
   ```bash
-  python tools/identify_boards.py --learn
+  python tools/ESP32_boardUtil.py --learn
   ```
 
 ## The banner's honest limit

--- a/.claude/skills/braino-boards/SKILL.md
+++ b/.claude/skills/braino-boards/SKILL.md
@@ -13,15 +13,28 @@ python tools/ESP32_boardUtil.py
 ```
 
 It prints one line per port: the board, the PlatformIO environment to flash it
-with, the firmware version, and `asked` or `reset` -- how it found out. To flash
-every connected board correctly, in one step, taking and releasing the board
-lock on its own:
+with, the firmware version, and `asked` or `reset` -- how it found out.
+
+**While testing a change, flash only the board you are working on:**
+
+```bash
+python tools/ESP32_boardUtil.py --flash --board E32R40T
+```
+
+`--board` takes a `BOARD_NAME` or an environment (`app_e32r40t`), and repeats
+for more than one. This is the default for testing. A new commit changes the
+build stamp, so every environment it builds is a full rebuild: flashing the
+whole bench to test a 4-inch launcher change cost four of them side by side,
+more than ten minutes, for one panel's worth of answer.
+
+Flash **every** connected board only when the owner asks for the whole bench
+-- checking a release on each board, say:
 
 ```bash
 python tools/ESP32_boardUtil.py --flash
 ```
 
-It builds every distinct environment **at the same time**, then uploads to **all
+Either way it takes and releases the board lock on its own. It builds every distinct environment **at the same time**, then uploads to **all
 boards at the same time** -- one agent flashing its whole bench in parallel is
 intended; two agents flashing at once is what the lock prevents. A failed build
 or board has its log in `.pio/build-<env>.log` / `.pio/upload-<port>.log` and

--- a/.claude/skills/braino-boards/SKILL.md
+++ b/.claude/skills/braino-boards/SKILL.md
@@ -21,6 +21,13 @@ lock on its own:
 python tools/identify_boards.py --flash
 ```
 
+It builds every distinct environment **at the same time**, then uploads to **all
+boards at the same time** -- one agent flashing its whole bench in parallel is
+intended; two agents flashing at once is what the lock prevents. A failed build
+or board has its log in `.pio/build-<env>.log` / `.pio/upload-<port>.log` and
+does not stop the others. A first build of a board model can take minutes, so
+run it in the background.
+
 If other agents may be testing on the boards, never restart any of them:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,10 @@ because history, clones, forks and tarballs all keep copies.
 - The boot banner prints `device=`, never `mac=`. That line gets pasted into
   public issues.
 - `tools/board_registry.json` is gitignored; the `.example.json` ships with
-  placeholders and `identify_boards.py --learn` fills in the real one locally.
+  placeholders and `ESP32_boardUtil.py --learn` fills in the real one locally.
 - **Ask a board before you reset it.** Current firmware answers `identify` on
   the serial port with one `ok ...` line (device id, board, version, build)
-  and keeps running; `identify_boards.py` does this first and resets only a
+  and keeps running; `ESP32_boardUtil.py` does this first and resets only a
   board that stays silent. `--no-reset` never resets. A reset discards another
   agent's in-flight test, and on the bench an E32R40T once needed its battery
   pulled to boot again after one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,18 @@ the same board now prints 2 bytes a second. It was not the cause of slow
 frames: the loop ran at 48.9 frames a second before and 49.6 after, and the
 ~150 ms worst frame is unchanged, so that is a separate question.
 
+**The 4-inch launcher shows nine apps a page in portrait.** A 3x3 grid of
+96x112 tiles instead of 2x2, so the catalogue is five pages rather than eleven.
+Landscape keeps its 2x3, and every smaller panel is unchanged: the grid is
+chosen from the panel's size by `LauncherLayout::grid()`, which the tile
+rects, the page size and the tile colours all read. Tile colours step by row as
+well as column on a three-wide grid, since `slot % 3` would have painted each
+column one colour. At 88px a subtitle no longer fits five of the apps -- Math's
+"addition & subtraction" is the widest -- and font 1 is already the smallest
+font the firmware carries, so there a subtitle that does not fit goes onto two
+lines; every title on the page moves up one line to match, so the grid stays
+even.
+
 **A low battery no longer flashes the whole screen.** The battery and update
 notices asked for a full repaint to show their banner and another to take it
 away, and the battery one repeated for as long as the cell stayed low. They

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,18 @@ the same board now prints 2 bytes a second. It was not the cause of slow
 frames: the loop ran at 48.9 frames a second before and 49.6 after, and the
 ~150 ms worst frame is unchanged, so that is a separate question.
 
+**A low battery no longer flashes the whole screen.** The battery and update
+notices asked for a full repaint to show their banner and another to take it
+away, and the battery one repeated for as long as the cell stayed low. They
+now repaint only the header, as the Nearby banner already did.
+
+**The screen saver's paddles stop flickering.** Both were blanked and redrawn
+on every frame, including the one standing still for half of each rally, and
+the wordmark's full-width erase band cut through both as it bobbed. The band
+now stops short of the paddles, and a paddle repaints only when it moves,
+changes colour or the ball passes through it -- erasing only the rows it has
+left, so it does not blink on its way past.
+
 **First thing this cycle: a two-console regression check of nearby play.** It
 has now been carried over twice. Two defects in that path were fixed late in
 5.9.0 — the acceptor never published its ply-0 answer, and a peer's turn was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,9 @@ connected board's environment once, all at the same time, then uploads to
 every port in parallel under one hold of the board lock. The old name
 described half of what it does. `configure_boards.py` imports it under the new
 name; entries for earlier releases below keep the name it had then.
+`--flash --board E32R40T` flashes only that board, which is what testing a
+change should use: flashing the whole bench to test a 4-inch change rebuilt
+four environments from scratch.
 
 **The 4-inch launcher shows nine apps a page in portrait.** A 3x3 grid of
 96x112 tiles instead of 2x2, so the catalogue is five pages rather than eleven.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ fixed here is the tree, and the possibility of a repeat.
   people paste into public issues, which is how a local identifier stops being
   local.
 - **The registry is gitignored**, with `board_registry.example.json` shipping
-  placeholders and `identify_boards.py --learn` filling in the real one per
+  placeholders and `ESP32_boardUtil.py --learn` filling in the real one per
   machine. esptool still reads a MAC off the chip when a board cannot
   introduce itself — an empty flash, or after a merged-image install wiped
   NVS — and it stays on that machine.
@@ -56,7 +56,7 @@ names on, so it needs agreement first — like any other change to the
 advertisement.
 
 **A running board can be asked what it is, without being reset.** The boot
-banner prints once, at power-up, so `identify_boards.py` used to reset every
+banner prints once, at power-up, so `ESP32_boardUtil.py` used to reset every
 board on the desk to hear it — discarding whatever each was doing, and not even
 reliably: one bench board's USB bridge drops off the bus for a moment as the
 app starts, taking the banner with it, and a 4-inch board reset from its
@@ -69,7 +69,7 @@ button can refuse to boot until its battery is pulled.
   arguments, no state change, nothing granted — and carries the banner's facts
   only: never the MAC, a profile, a score or an SSID. A query does not count as
   activity, so a tool polling the desk does not keep screens awake.
-- **`identify_boards.py` asks first** and falls back to reset-and-listen only
+- **`ESP32_boardUtil.py` asks first** and falls back to reset-and-listen only
   for a board that does not answer (older firmware, a diag build, a blank
   flash). It now prints each board's firmware version and whether the board was
   *asked* or *reset*. `--no-reset` asks and never resets.
@@ -87,7 +87,7 @@ calls the same services the UI does:
   `help` is derived from the table. Every command answers with exactly one
   line: `ok key="value" ...` or `err <code> <message>`. `identify` now answers
   in that grammar too (`ok v="1" device=...` instead of `[ident] v="1" ...`);
-  `identify?` and `settings?` still work as aliases, and `identify_boards.py`
+  `identify?` and `settings?` still work as aliases, and `ESP32_boardUtil.py`
   accepts both reply forms.
 - **CRUD, where the entity has it.** `get [key]` / `set <key> <value>` cover
   every setting the Settings and Wi-Fi screens offer — theme, brightness,
@@ -132,6 +132,13 @@ issues. `CONFIG_NIMBLE_CPP_LOG_LEVEL=2` keeps NimBLE's warnings and errors;
 the same board now prints 2 bytes a second. It was not the cause of slow
 frames: the loop ran at 48.9 frames a second before and 49.6 after, and the
 ~150 ms worst frame is unchanged, so that is a separate question.
+
+**`tools/identify_boards.py` is now `tools/ESP32_boardUtil.py`.** It stopped
+being only an identifier when it learned to flash: `--flash` builds each
+connected board's environment once, all at the same time, then uploads to
+every port in parallel under one hold of the board lock. The old name
+described half of what it does. `configure_boards.py` imports it under the new
+name; entries for earlier releases below keep the name it had then.
 
 **The 4-inch launcher shows nine apps a page in portrait.** A 3x3 grid of
 96x112 tiles instead of 2x2, so the catalogue is five pages rather than eleven.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1005,7 +1005,7 @@ So: write the geometry once, at file scope, and derive every clear rectangle fro
 
 Most games still repaint wholesale. Cinnamon is the reference for partial redraw â€” it was also a photosensitivity concern at full-flash rates, so prefer partial redraw for anything that updates rapidly.
 
-Playable games are authored against a fixed 320Ã—240 landscape canvas. Launcher and system/UI apps support portrait (`LayoutMode::Vertical`; the launcher uses 4 tiles/page vs 6 in landscape).
+Playable games are authored against a fixed 320Ã—240 landscape canvas. Launcher and system/UI apps support portrait (`LayoutMode::Vertical`; the launcher uses 4 tiles/page vs 6 in landscape, and 9 -- a 3x3 grid -- in portrait on a panel whose short side is at least 320px, i.e. the 4-inch board. `LauncherLayout::grid()` is the one answer to "how many columns and rows", read by the tile rects, the page size and the tile colouring alike; in the 3x3 grid a subtitle too wide for its 88px goes onto two lines rather than being chopped).
 
 **System/UI apps** (Settings, Wi-Fi, SystemInfo, Profiles, Scores, About, and any future app-style screens beyond the playable game catalog) must support **both landscape and portrait orientations**. They must read `tft.width()` / `tft.height()` at render time rather than the compile-time constants `SCREEN_WIDTH` / `SCREEN_HEIGHT`, and lay themselves out responsively. Use `Ui::drawTab()` + `Ui::drawTabBaseline()` for multi-section content; the tab strip width adapts by dividing `tft.width()` at render time.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,7 +521,10 @@ may flash several boards at once, and should: each board is its own USB device
 on its own port. `python tools/ESP32_boardUtil.py --flash` does exactly that
 under one hold of the lock -- it builds each distinct environment once, all at
 the same time, then uploads to every port in parallel with `-t nobuild`, with
-one log per build and per port in `.pio/`. Parallel builds were measured, not
+one log per build and per port in `.pio/`. **When testing, add `--board
+<BOARD_NAME>` and flash only the board the change is for**; the whole bench is
+for when the owner asks for it, since a new commit makes every environment a
+full rebuild. Parallel builds were measured, not
 assumed: after a new commit, four environments took 210 s one after another
 and 97 s side by side, because each rebuild is mostly single-core dependency
 scanning and linking. Do not hand-roll a second parallel flasher; extend that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,7 +556,7 @@ The same reasoning applies to any lock PlatformIO itself leaves in `~/.platformi
 
 ### Shared budgets
 
-Flash is global and nearly the binding constraint (2,448,109 / 3,145,728 bytes,
+Flash is global and nearly the binding constraint (2,448,885 / 3,145,728 bytes,
 **77.8%**; NimBLE plus the BT controller account for ~192 KB of that). RAM sits
 at 76,660 / 327,680 (23.4%) -- higher than it was, deliberately: RowList traded
 864 bytes of static RAM for zero heap traffic and storage diagnostics keep their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,18 @@ That path resolves to the same file from every worktree, and is never committed.
 "$PID|flash|$(Get-Location)|$(Get-Date -Format o)" | Set-Content $lock -Encoding utf8
 ```
 
+**The lock is per agent, not per board.** Two agents must never flash the
+bench at the same time -- that is what it is for. But the one agent holding it
+may flash several boards at once, and should: each board is its own USB device
+on its own port. `python tools/identify_boards.py --flash` does exactly that
+under one hold of the lock -- it builds each distinct environment once, all at
+the same time, then uploads to every port in parallel with `-t nobuild`, with
+one log per build and per port in `.pio/`. Parallel builds were measured, not
+assumed: after a new commit, four environments took 210 s one after another
+and 97 s side by side, because each rebuild is mostly single-core dependency
+scanning and linking. Do not hand-roll a second parallel flasher; extend that
+one.
+
 **Release it in all cases** when the build, flash or monitor session ends â€” including on failure. `Remove-Item $lock`.
 
 ### If the lock is already held

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ So:
   pasted into a public issue, which is how a "local" identifier stops being
   local. Do not add the MAC back to it.
 - **`tools/board_registry.json` is gitignored.** `board_registry.example.json`
-  ships instead, with placeholder ids, and `identify_boards.py --learn` fills
+  ships instead, with placeholder ids, and `ESP32_boardUtil.py --learn` fills
   in the real one per machine. Reading a MAC off a chip with esptool is still
   correct when a board cannot introduce itself -- an empty flash, or after a
   merged-image install wiped NVS -- but it stays on that machine.
@@ -518,7 +518,7 @@ That path resolves to the same file from every worktree, and is never committed.
 **The lock is per agent, not per board.** Two agents must never flash the
 bench at the same time -- that is what it is for. But the one agent holding it
 may flash several boards at once, and should: each board is its own USB device
-on its own port. `python tools/identify_boards.py --flash` does exactly that
+on its own port. `python tools/ESP32_boardUtil.py --flash` does exactly that
 under one hold of the lock -- it builds each distinct environment once, all at
 the same time, then uploads to every port in parallel with `-t nobuild`, with
 one log per build and per port in `.pio/`. Parallel builds were measured, not
@@ -1060,7 +1060,7 @@ tools/                    gen_screens.py, gen_site.py, check_docs.py,
                           configure_boards.py + bench_config.example.json
                           (set every board up from one config over the
                           serial console; the real config is gitignored),
-                          identify_boards.py + board_registry.example.json
+                          ESP32_boardUtil.py + board_registry.example.json
                           (which board is on which port, keyed by the
                           firmware's own Board::deviceId(); the real registry
                           is gitignored because it names one person's boards)
@@ -1215,7 +1215,7 @@ ESP32-2432S028R. `docs/PORTING.md` is the checklist for adding a board.
   describe the firmware, not the hardware, which is exactly how a 2.8-inch
   board reported itself as a 4-inch for half an hour.
 - **A running board answers `identify` with the same facts, unreset.** One
-  line, every value quoted; `identify_boards.py` asks before it resets
+  line, every value quoted; `ESP32_boardUtil.py` asks before it resets
   anything. It carries **only the banner's facts** (no MAC, profile, score or
   SSID) and needs no PIN. Open the port with DTR and RTS already low, or
   opening it resets the board and defeats the point.
@@ -1236,7 +1236,7 @@ ESP32-2432S028R. `docs/PORTING.md` is the checklist for adding a board.
     matches `(\w+)="..."`. **Add a command as a row, never as another string
     match**, and never give it a second reply shape. `identify?`, `settings`
     and `settings?` are kept as aliases because tools on `dev` already send
-    them; `identify_boards.py` also accepts the `[ident] ...` reply that
+    them; `ESP32_boardUtil.py` also accepts the `[ident] ...` reply that
     pre-console snapshot builds give.
   - **CRUD, where the entity has it.** Settings are fixed keys, so they are
     Read and Update: `get [key]` and `set <key> <value>` over one settings

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ no data collection.** Two radios exist and both are narrow by design:
 | | |
 |---|---|
 | Games | 35 |
-| Flash | 2,448,109 / 3,145,728 bytes (**77.8%**) |
+| Flash | 2,448,885 / 3,145,728 bytes (**77.8%**) |
 | RAM | 76,660 / 327,680 bytes (**23.4%**) |
 | Artwork | 195 country flags, 50 state flags, 50 state outlines — 763 KB (34% of the image) |
 

--- a/README.md
+++ b/README.md
@@ -1200,7 +1200,7 @@ wrong PINs lock the console for 30 seconds. `game all <id> off` switches one
 game off for every player at once. Chess, Sea Battle and Cursive cannot be
 hidden yet (a known limit of per-player visibility).
 
-`python tools/identify_boards.py` uses `identify` to say which board is on
+`python tools/ESP32_boardUtil.py` uses `identify` to say which board is on
 which port. To set up several boards at once, copy
 `tools/bench_config.example.json` to `tools/bench_config.json` (gitignored)
 and run `python tools/configure_boards.py`.

--- a/include/BoardProfile.h
+++ b/include/BoardProfile.h
@@ -225,7 +225,7 @@ struct BatteryProfile {
 
 struct BoardProfile {
     /* NO WHITESPACE IN THIS NAME. It is printed in the boot banner as
-     * `[boot] board=<name>` and tools/identify_boards.py reads that back as a
+     * `[boot] board=<name>` and tools/ESP32_boardUtil.py reads that back as a
      * single token, so a name with a space in it is silently truncated and the
      * tool then reports a mismatch against its own registry. One board here
      * shipped as "ESP32-2432S028Rv3 (ST7789)" and did exactly that. Hyphens,

--- a/src/engine/AppRuntime.cpp
+++ b/src/engine/AppRuntime.cpp
@@ -547,13 +547,17 @@ void BrainoApp::tickBatteryWarning(uint32_t nowMs) {
     requestBannerRepaint();
 }
 
-/* The strip is painted over the screen's own header, so the screen underneath
- * has to redraw before it can genuinely go away again. */
+/* The strip is painted over the screen's own header, so the header underneath
+ * has to redraw before it can genuinely go away again -- the header, not the
+ * screen. This used to call requestRender(), so the battery warning wiped the
+ * whole panel twice per cycle, once to appear and once to leave, and repeated
+ * that for as long as the cell stayed low. Nearby's banner had already moved
+ * to the chrome path; this is the same fix for the battery and update notices.
+ * A screen that cannot repaint its chrome alone still gets a full repaint,
+ * through the fallback in loop(). */
 void BrainoApp::requestBannerRepaint() {
     bannerNeedsPaint_ = true;
-    if (view_ == View::Game && activeGame_ != nullptr) {
-        activeGame_->requestRender();
-    }
+    requestChromeRender();
 }
 
 void BrainoApp::drawHeaderBanner(bool screenRepainted) {

--- a/src/engine/AppRuntime.h
+++ b/src/engine/AppRuntime.h
@@ -308,6 +308,11 @@ private:
     uint16_t ssav_color_ = 0;
     uint32_t ssav_lastFrameMs_ = 0;
     int16_t ssav_textCy_ = -1;
+    /* Where each paddle was last painted, and in what colour; -1 means not
+     * painted yet. The paddles repaint only when these change. */
+    int16_t ssav_lyDrawn_ = -1;
+    int16_t ssav_ryDrawn_ = -1;
+    uint16_t ssav_padColorDrawn_ = 0;
 
     uint32_t lastBannerGeneration_ = 0;
     bool bannerNeedsPaint_ = false;

--- a/src/engine/AppRuntimeIdentity.cpp
+++ b/src/engine/AppRuntimeIdentity.cpp
@@ -124,7 +124,7 @@ void BrainoApp::logIdentity() {
 /* ASKED, NOT RESET: THE SERIAL PORT ANSWERS ONE QUESTION.
  *
  * The boot banner is printed once, at power-up, so the only way to hear it
- * again was to reset the board -- which is what tools/identify_boards.py did
+ * again was to reset the board -- which is what tools/ESP32_boardUtil.py did
  * to every board on the desk, every time. A reset throws away whatever the
  * board was doing (a game half played, a test another agent was running), and
  * it is not even reliable: one bench board's USB bridge drops off the bus for
@@ -138,7 +138,7 @@ void BrainoApp::logIdentity() {
  *      panel="ILI9341_2" up="3605"
  *
  * (one line on the wire; wrapped here). 5.10.0-SNAPSHOT builds from before the
- * console answered with an `[ident]` tag in place of `ok`; identify_boards.py
+ * console answered with an `[ident]` tag in place of `ok`; ESP32_boardUtil.py
  * accepts both. Every value is quoted, because
  * BOARD_NAME and the build time can both contain spaces and the tool once cut
  * a board name off at one. `v` is the format's own version, so a later field
@@ -148,7 +148,7 @@ void BrainoApp::logIdentity() {
  * a property of the bench, not of Braino. Any image flashed onto one of these
  * boards -- the diag builds, a bring-up probe, a future firmware under another
  * name -- can answer the same query with the same line, and
- * identify_boards.py will recognise it without changing. The `board=` field is
+ * ESP32_boardUtil.py will recognise it without changing. The `board=` field is
  * what says which firmware answered.
  *
  * The reply must never become a second way to read player data: it is the

--- a/src/engine/AppRuntimeLauncher.cpp
+++ b/src/engine/AppRuntimeLauncher.cpp
@@ -21,14 +21,44 @@ void copyFittedText(Ui::Renderer& tft, const char* source, char* dest, size_t ca
         dest[strlen(dest) - 1] = '\0';
     }
 }
+
+/* Break `source` at a space into two lines that each fit `maxW`, keeping the
+ * first line as long as it can be. False when there is no such break -- a
+ * single word too wide for the tile, or text that needs three lines. */
+bool splitIntoTwoLines(Ui::Renderer& tft, const char* source, char* first, char* second,
+                       size_t cap, int16_t maxW, uint8_t font) {
+    if (cap == 0 || source == nullptr) {
+        return false;
+    }
+    snprintf(first, cap, "%s", source);
+    for (size_t i = strlen(first); i-- > 1;) {
+        if (first[i] != ' ') {
+            continue;
+        }
+        first[i] = '\0';
+        if (tft.textWidth(first, font) > maxW) {
+            first[i] = ' ';
+            continue;
+        }
+        // The shortest second line there can be; if this misses, all do.
+        snprintf(second, cap, "%s", first + i + 1);
+        return tft.textWidth(second, font) <= maxW;
+    }
+    return false;
+}
 }
 
 uint8_t BrainoApp::launcherEntryCount() {
     return appVisibleCount(board_);
 }
 
+/* Against the live panel, because the portrait grid depends on its size. The
+ * launcher's rotation is applied before its begin(), so this is always the
+ * orientation the page is about to be drawn in. */
 uint8_t BrainoApp::launcherPageSize() {
-    return LauncherLayout::pageSize(board_.layoutMode());
+    return LauncherLayout::pageSize(board_.layoutMode(),
+                                    static_cast<int16_t>(renderer_.width()),
+                                    static_cast<int16_t>(renderer_.height()));
 }
 
 const AppDefinition& BrainoApp::launcherEntry(uint8_t filteredIndex) {
@@ -272,6 +302,8 @@ bool LauncherGame::renderChrome(GameHost& host) {
 
 /* Background and header. Only on a full repaint -- paging does not touch it. */
 void LauncherGame::renderStatic(GameHost& host) {
+    static_assert(MAX_TILES >= LauncherLayout::MAX_PAGE_SIZE,
+                  "slotHasButton_ cannot cover every tile on a page");
     Ui::clear(host.display());
     drawHeader(host);
     /* The panel has just been wiped, so no slot has a frame on it any more. */
@@ -305,6 +337,12 @@ void LauncherGame::renderDynamic(GameHost& host) {
     const uint8_t pageSize = host.launcherPageSize();
     const uint8_t start = page_ * pageSize;
     const uint8_t total = host.launcherEntryCount();
+    const LauncherLayout::Grid grid = LauncherLayout::grid(mode, lW, lH);
+    /* Three columns in portrait -- the 4-inch panel -- leaves 88px for a
+     * subtitle, and five of them are wider than that at font 1, which is
+     * already the smallest font the firmware carries. So there, and only
+     * there, a subtitle that does not fit goes onto two lines. */
+    const bool wrapSubtitles = tall && grid.cols >= 3;
 
     /* One text size for the whole page, chosen so every label on it fits.
      *
@@ -376,7 +414,7 @@ void LauncherGame::renderDynamic(GameHost& host) {
          * before this lists the same three colours, so nothing changed for
          * them -- but a theme made of four shades of green cannot have bright
          * blue, green and red rectangles as the first thing anyone sees. */
-        const uint16_t fill = Ui::tileFill(slot % 3);
+        const uint16_t fill = Ui::tileFill(LauncherLayout::tileFillIndex(slot, grid));
         /* The button itself is invariant across pages -- its rect comes from
          * the slot and its colour from `slot % 3`, neither of which a page
          * change touches. Ui::drawButton pushes TWO full tile areas (a shadow
@@ -456,16 +494,41 @@ void LauncherGame::renderDynamic(GameHost& host) {
             drawLauncherIcon(icon, entry.icon(), r, fill,
                              static_cast<int16_t>(cxT / iconScale),
                              static_cast<int16_t>(iconY / iconScale));
+            /* With wrapping on, the title sits one subtitle line higher on
+             * EVERY tile, whether its own subtitle wraps or not. A grid
+             * implies its cells are alike -- titles at two heights on one page
+             * would read as a fault, and would jump as pages turn. */
+            const int16_t textW = static_cast<int16_t>(r.w - 8);
+            const int16_t subPitch = static_cast<int16_t>(10 * textScale);
+            const int16_t subY = static_cast<int16_t>(r.y + r.h * 0.906f);
+            const int16_t titleY = static_cast<int16_t>(
+                r.y + r.h * 0.708f - (wrapSubtitles ? subPitch : 0));
             tft.setTextColor(TFT_WHITE, fill);
             tft.setTextDatum(MC_DATUM);
             tft.setTextSize(textScale);
-            copyFittedText(tft, entry.title(), label, sizeof(label),
-                           static_cast<int16_t>(r.w - 8), 2);
-            tft.drawString(label, cxT, static_cast<int16_t>(r.y + r.h * 0.708f), 2);
+            copyFittedText(tft, entry.title(), label, sizeof(label), textW, 2);
+            tft.drawString(label, cxT, titleY, 2);
             tft.setTextColor(Ui::rgb(235, 245, 255), fill);
-            copyFittedText(tft, entry.subtitle(), label, sizeof(label),
-                           static_cast<int16_t>(r.w - 8), 1);
-            tft.drawString(label, cxT, static_cast<int16_t>(r.y + r.h * 0.906f), 1);
+            char second[sizeof(label)];
+            if (!wrapSubtitles) {
+                copyFittedText(tft, entry.subtitle(), label, sizeof(label), textW, 1);
+                tft.drawString(label, cxT, subY, 1);
+            } else if (tft.textWidth(entry.subtitle(), 1) > textW &&
+                       splitIntoTwoLines(tft, entry.subtitle(), label, second,
+                                         sizeof(label), textW, 1)) {
+                tft.drawString(label, cxT, static_cast<int16_t>(subY - subPitch), 1);
+                tft.drawString(second, cxT, subY, 1);
+            } else {
+                /* One line, centred in the two-line block. Cut with a dot if
+                 * even wrapping could not save it, so a clipped word never
+                 * passes for a whole one. */
+                copyFittedText(tft, entry.subtitle(), label, sizeof(label), textW, 1);
+                const size_t kept = strlen(label);
+                if (kept > 0 && kept < strlen(entry.subtitle())) {
+                    label[kept - 1] = '.';
+                }
+                tft.drawString(label, cxT, static_cast<int16_t>(subY - subPitch / 2), 1);
+            }
             tft.setTextSize(1);
         } else {
             /* Everything hangs off the tile's own centre line.

--- a/src/engine/AppRuntimeScreenSaver.cpp
+++ b/src/engine/AppRuntimeScreenSaver.cpp
@@ -136,17 +136,18 @@ void BrainoApp::renderScreenSaver() {
         ssav_hits_ = 0;
         ssav_color_ = Ui::rgb(80, 180, 255);
         ssav_textCy_ = -1;
+        ssav_lyDrawn_ = -1;
+        ssav_ryDrawn_ = -1;
         ssav_initialized_ = true;
     }
 
     constexpr int16_t PAD_H = 40;
     constexpr int16_t PAD_W = 6;
+    constexpr int16_t PAD_R = 3;
     constexpr int16_t BALL = 6;
     constexpr int16_t LX = 10;
     const int16_t RX = static_cast<int16_t>(effW - 10);
 
-    tft.fillRect(LX - PAD_W / 2, static_cast<int16_t>(ssav_ly_ - PAD_H / 2 - 2), PAD_W, PAD_H + 4, TFT_BLACK);
-    tft.fillRect(RX - PAD_W / 2, static_cast<int16_t>(ssav_ry_ - PAD_H / 2 - 2), PAD_W, PAD_H + 4, TFT_BLACK);
     /* Kept, because everything below has to know where the hole is. The ball is
      * the only thing that moves across the whole panel, so it is the only
      * thing that can punch through the text, the net or the badge -- and those
@@ -231,12 +232,18 @@ void BrainoApp::renderScreenSaver() {
      * The integer y is what matters, so the band is only touched when THAT
      * changes -- or when the ball has gone through the text, which is the one
      * other thing that can damage it. */
+    /* The band stops short of both paddle columns. It used to run the full
+     * width, so every step of the bob wiped a slice out of whichever paddle it
+     * crossed, and a paddle standing still had to be repainted anyway. The
+     * wordmark is centred and far narrower than the gap between them. */
+    const int16_t bandX = static_cast<int16_t>(LX + PAD_W / 2);
+    const int16_t bandW = static_cast<int16_t>(RX - PAD_W / 2 - bandX);
     const int16_t bandY = static_cast<int16_t>(cy - TEXT_BAND_TOP);
     const bool textMoved = (cy != ssav_textCy_);
-    const bool textHit = hitsBall(0, bandY, effW, TEXT_BAND_H);
+    const bool textHit = hitsBall(bandX, bandY, bandW, TEXT_BAND_H);
     if (textMoved || textHit) {
         if (ssav_textCy_ >= 0) {
-            tft.fillRect(0, static_cast<int16_t>(ssav_textCy_ - TEXT_BAND_TOP), effW,
+            tft.fillRect(bandX, static_cast<int16_t>(ssav_textCy_ - TEXT_BAND_TOP), bandW,
                          TEXT_BAND_H, TFT_BLACK);
         }
         tft.setTextDatum(MC_DATUM);
@@ -277,8 +284,48 @@ void BrainoApp::renderScreenSaver() {
     tft.fillRect(batX, batY, static_cast<int16_t>(batW + 6), 16, TFT_BLACK);
     Ui::drawBatteryBadge(tft, batCx, batCy, batPct, batPower, TFT_BLACK);
 
-    tft.fillRoundRect(LX - PAD_W / 2, static_cast<int16_t>(ssav_ly_ - PAD_H / 2), PAD_W, PAD_H, 3, ssav_color_);
-    tft.fillRoundRect(RX - PAD_W / 2, static_cast<int16_t>(ssav_ry_ - PAD_H / 2), PAD_W, PAD_H, 3, ssav_color_);
+    /* THE PADDLES ARE REPAINTED WHEN THEY MOVE, NOT WHEN A FRAME HAPPENS.
+     *
+     * Only one paddle tracks the ball at a time, so the other stands still for
+     * half of every rally -- and both used to be erased to black and redrawn
+     * every frame regardless, which on the panel is a paddle flickering while
+     * it does nothing. Now a paddle is touched only when its integer position
+     * or its colour changes, or the ball's erase has cut into it.
+     *
+     * A moving paddle erases just the rows it has left: the old rect minus the
+     * new one's straight-sided middle. The overlap is repainted in the colour
+     * it already had, so it does not blink on its way past. */
+    const bool recolour = (ssav_color_ != ssav_padColorDrawn_);
+    auto paintPaddle = [&](int16_t cx, float yCentre, int16_t& drawnTop) {
+        const int16_t left = static_cast<int16_t>(cx - PAD_W / 2);
+        const int16_t top = static_cast<int16_t>(yCentre - PAD_H / 2);
+        const bool painted = drawnTop >= 0;
+        const bool damaged = painted && hitsBall(left, drawnTop, PAD_W, PAD_H);
+        if (painted && top == drawnTop && !recolour && !damaged) {
+            return;
+        }
+        if (painted && top != drawnTop) {
+            const int16_t oldBottom = static_cast<int16_t>(drawnTop + PAD_H);
+            const int16_t keepTop = static_cast<int16_t>(top + PAD_R);
+            const int16_t keepBottom = static_cast<int16_t>(top + PAD_H - PAD_R);
+            const int16_t upperEnd = min(oldBottom, keepTop);
+            if (upperEnd > drawnTop) {
+                tft.fillRect(left, drawnTop, PAD_W, static_cast<int16_t>(upperEnd - drawnTop),
+                             TFT_BLACK);
+            }
+            const int16_t lowerStart = max(drawnTop, keepBottom);
+            if (oldBottom > lowerStart) {
+                tft.fillRect(left, lowerStart, PAD_W, static_cast<int16_t>(oldBottom - lowerStart),
+                             TFT_BLACK);
+            }
+        }
+        tft.fillRoundRect(left, top, PAD_W, PAD_H, PAD_R, ssav_color_);
+        drawnTop = top;
+    };
+    paintPaddle(LX, ssav_ly_, ssav_lyDrawn_);
+    paintPaddle(RX, ssav_ry_, ssav_ryDrawn_);
+    ssav_padColorDrawn_ = ssav_color_;
+
     tft.fillRoundRect(static_cast<int16_t>(ssav_bx_ - BALL), static_cast<int16_t>(ssav_by_ - BALL), BALL * 2, BALL * 2, 2, ssav_color_);
     tft.fillRoundRect(static_cast<int16_t>(ssav_bx_ - BALL / 2), static_cast<int16_t>(ssav_by_ - BALL / 2), BALL, BALL, 1, TFT_WHITE);
 }

--- a/src/engine/LauncherGame.h
+++ b/src/engine/LauncherGame.h
@@ -34,7 +34,9 @@ private:
      * previous page has no frame to reuse, and drawing only its interior leaves
      * a bare rectangle with no rounded edge, border or shadow.
      *
-     * Six tiles in landscape, four in portrait; eight is room to spare. */
-    static constexpr uint8_t MAX_TILES = 8;
+     * Six tiles in landscape, four in portrait, nine in portrait on the
+     * 4-inch panel. Must be at least LauncherLayout::MAX_PAGE_SIZE, which
+     * renderStatic() static_asserts. */
+    static constexpr uint8_t MAX_TILES = 9;
     bool slotHasButton_[MAX_TILES] = {};
 };

--- a/src/hal/Board.h
+++ b/src/hal/Board.h
@@ -389,7 +389,7 @@ public:
      * home, and nothing can undo it afterwards. This id is the opposite in
      * every respect that matters -- the firmware owns it, it means nothing off
      * this device, and a factory reset issues a new one. Prefer it anywhere a
-     * board has to be told apart: the boot banner, tools/identify_boards.py,
+     * board has to be told apart: the boot banner, tools/ESP32_boardUtil.py,
      * a bug report.
      *
      * The trade is honest and worth knowing: because it lives in NVS it does

--- a/src/ui/LauncherLayout.cpp
+++ b/src/ui/LauncherLayout.cpp
@@ -111,22 +111,48 @@ Rect tileRect(uint8_t slot, Board::LayoutMode mode, int16_t screenW, int16_t scr
 
     const bool tall = mode == Board::LayoutMode::Vertical;
     const int16_t headerH = tall ? LAUNCHER_HEADER_H_TALL : LAUNCHER_HEADER_H_WIDE;
-    const uint8_t rows = tall ? 2 : 3;
+    const Grid g = grid(mode, screenW, screenH);
 
-    // Two columns either way: three gaps across, one more than the row count down.
-    const int16_t tileW = static_cast<int16_t>((screenW - GAP * 3) / 2);
+    // One more gap than there are tiles, in each direction.
+    const int16_t tileW = static_cast<int16_t>((screenW - GAP * (g.cols + 1)) / g.cols);
     const int16_t tileH = static_cast<int16_t>(
-        (screenH - headerH - FOOTER_H - GAP * (rows + 1)) / rows);
+        (screenH - headerH - FOOTER_H - GAP * (g.rows + 1)) / g.rows);
 
-    const uint8_t col = slot % 2;
-    const uint8_t row = slot / 2;
+    const uint8_t col = slot % g.cols;
+    const uint8_t row = slot / g.cols;
     return Rect{static_cast<int16_t>(GAP + col * (tileW + GAP)),
                 static_cast<int16_t>(headerH + GAP + row * (tileH + GAP)),
                 tileW, tileH};
 }
 
-uint8_t pageSize(Board::LayoutMode mode) {
-    return mode == Board::LayoutMode::Vertical ? 4 : 6;
+namespace {
+constexpr Grid GRID_WIDE{2, 3};
+constexpr Grid GRID_TALL{2, 2};
+constexpr Grid GRID_TALL_DENSE{3, 3};
+static_assert(GRID_WIDE.cols * GRID_WIDE.rows <= MAX_PAGE_SIZE &&
+              GRID_TALL.cols * GRID_TALL.rows <= MAX_PAGE_SIZE &&
+              GRID_TALL_DENSE.cols * GRID_TALL_DENSE.rows <= MAX_PAGE_SIZE,
+              "a launcher grid holds more tiles than MAX_PAGE_SIZE");
+}  // namespace
+
+Grid grid(Board::LayoutMode mode, int16_t screenW, int16_t screenH) {
+    if (mode != Board::LayoutMode::Vertical) {
+        return GRID_WIDE;
+    }
+    const int16_t shortSide = screenW < screenH ? screenW : screenH;
+    return shortSide >= DENSE_PORTRAIT_MIN_W ? GRID_TALL_DENSE : GRID_TALL;
+}
+
+uint8_t pageSize(Board::LayoutMode mode, int16_t screenW, int16_t screenH) {
+    const Grid g = grid(mode, screenW, screenH);
+    return static_cast<uint8_t>(g.cols * g.rows);
+}
+
+uint8_t tileFillIndex(uint8_t slot, const Grid& g) {
+    if (g.cols % 3 != 0) {
+        return static_cast<uint8_t>(slot % 3);
+    }
+    return static_cast<uint8_t>((slot % g.cols + slot / g.cols) % 3);
 }
 
 }  // namespace LauncherLayout

--- a/src/ui/LauncherLayout.h
+++ b/src/ui/LauncherLayout.h
@@ -33,6 +33,30 @@ Rect profileRect(Board::LayoutMode mode, int16_t screenW);
  * the header and pager correctly reached the edges. A default of 320/240 here
  * would be that same literal, just hidden where nobody would look for it. */
 Rect tileRect(uint8_t slot, Board::LayoutMode mode, int16_t screenW, int16_t screenH);
-uint8_t pageSize(Board::LayoutMode mode);
+
+/* How many columns and rows of tiles the launcher shows. One answer, read by
+ * tileRect(), pageSize() and the tile colouring, so the grid that is drawn,
+ * the grid that is hit-tested and the number of apps per page cannot disagree.
+ *
+ * Landscape is 2x3 on every panel. Portrait is 2x2, except on a panel whose
+ * short side is at least DENSE_PORTRAIT_MIN_W -- today only the 4-inch board
+ * -- where it is 3x3: 96x112 tiles there, still wider than the 2.8-inch
+ * board's portrait tiles are tall, and nine apps a page instead of four. It is
+ * decided from the glass, not from which board this is, because nothing under
+ * src/ may name a board. */
+struct Grid {
+    uint8_t cols;
+    uint8_t rows;
+};
+constexpr int16_t DENSE_PORTRAIT_MIN_W = 320;
+/** The most tiles any grid puts on one page. */
+constexpr uint8_t MAX_PAGE_SIZE = 9;
+Grid grid(Board::LayoutMode mode, int16_t screenW, int16_t screenH);
+uint8_t pageSize(Board::LayoutMode mode, int16_t screenW, int16_t screenH);
+
+/* Which of the palette's three tile fills a slot gets. slot % 3 on a
+ * two-column grid, as it always was; on a three-column grid that would paint
+ * every column one colour, so there it steps by row as well. */
+uint8_t tileFillIndex(uint8_t slot, const Grid& g);
 
 }  // namespace LauncherLayout

--- a/tools/ESP32_boardUtil.py
+++ b/tools/ESP32_boardUtil.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Say which board is on which serial port, without anyone being asked.
 
-    python tools/identify_boards.py            # identify everything attached
-    python tools/identify_boards.py --learn    # ...and record what it found
-    python tools/identify_boards.py --json     # machine-readable, for scripting
-    python tools/identify_boards.py --flash    # build each model once, flash all at once
-    python tools/identify_boards.py --no-reset # ask only; never restart a board
+    python tools/ESP32_boardUtil.py            # identify everything attached
+    python tools/ESP32_boardUtil.py --learn    # ...and record what it found
+    python tools/ESP32_boardUtil.py --json     # machine-readable, for scripting
+    python tools/ESP32_boardUtil.py --flash    # build each model once, flash all at once
+    python tools/ESP32_boardUtil.py --no-reset # ask only; never restart a board
 
 Why this exists
 ---------------
@@ -110,7 +110,7 @@ def load_registry():
         seed["boards"] = {}          # the template's entries are placeholders
         seed["_comment"] = [
             "Local, gitignored, and specific to this machine. Populated by",
-            "`python tools/identify_boards.py --learn`.",
+            "`python tools/ESP32_boardUtil.py --learn`.",
         ]
         with open(REGISTRY, "w", encoding="utf-8", newline="\n") as f:
             json.dump(seed, f, indent=2, ensure_ascii=False)

--- a/tools/ESP32_boardUtil.py
+++ b/tools/ESP32_boardUtil.py
@@ -5,6 +5,7 @@
     python tools/ESP32_boardUtil.py --learn    # ...and record what it found
     python tools/ESP32_boardUtil.py --json     # machine-readable, for scripting
     python tools/ESP32_boardUtil.py --flash    # build each model once, flash all at once
+    python tools/ESP32_boardUtil.py --flash --board E32R40T   # ...only that board
     python tools/ESP32_boardUtil.py --no-reset # ask only; never restart a board
 
 Why this exists
@@ -246,12 +247,20 @@ def lock_path():
     return os.path.join(common, "gume-board.lock")
 
 
-def flash_all(results):
+def flash_all(results, boards=None):
     """Flash every identified board with its own environment -- in parallel.
 
     Refuses outright if anything is UNKNOWN. Flashing a board with the wrong
     panel's build is the failure this whole file exists to prevent, and
     "most of them were right" is not a state anybody can act on afterwards.
+
+    `boards` narrows it to the board being worked on: a list of BOARD_NAMEs
+    (`E32R40T`) or environments (`app_e32r40t`), case-insensitive. Without it
+    a change meant for one board rebuilt and reflashed the whole bench -- four
+    full builds side by side, since a new commit changes the build stamp and
+    so every object -- to test something only one panel could show. With it,
+    an UNKNOWN port elsewhere on the bench is reported rather than refused:
+    it cannot be matched, so it cannot be flashed by mistake.
 
     Two phases, under ONE hold of the board lock:
 
@@ -271,13 +280,23 @@ def flash_all(results):
     exists to stop, and nothing here changes that.
     """
     unknown = [r for r in results if r["status"] in ("unknown", "silent")]
-    if unknown:
+    if unknown and not boards:
         print("Refusing to flash: %d port(s) unidentified (%s)."
               % (len(unknown), ", ".join(r["port"] for r in unknown)))
         return 1
+    if unknown:
+        print("Not flashing %d unidentified port(s): %s."
+              % (len(unknown), ", ".join(r["port"] for r in unknown)))
 
     targets = [r for r in results
                if r["status"] in ("known", "new", "learned") and r.get("env")]
+    if boards:
+        wanted = {b.lower() for b in boards}
+        targets = [r for r in targets
+                   if r["board"].lower() in wanted or r["env"].lower() in wanted]
+        if not targets:
+            print("No connected board matches --board %s." % ", ".join(boards))
+            return 1
     if not targets:
         print("Nothing to flash.")
         return 1
@@ -412,6 +431,10 @@ def main():
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     ap.add_argument("--flash", action="store_true",
                     help="flash every identified board with its own env")
+    ap.add_argument("--board", action="append", metavar="NAME",
+                    help="with --flash, flash only boards whose BOARD_NAME or "
+                         "env is NAME (e.g. E32R40T or app_e32r40t); repeat "
+                         "for more than one")
     ap.add_argument("--no-reset", action="store_true",
                     help="only ask; never reset a board that does not answer")
     args = ap.parse_args()
@@ -521,7 +544,9 @@ def main():
         print("\nRecorded %d new board(s) in tools/board_registry.json." % learned)
 
     if args.flash:
-        return flash_all(results)
+        return flash_all(results, args.board)
+    if args.board:
+        print("--board only narrows --flash; nothing was flashed.")
 
     unknown = sum(1 for r in results if r["status"] in ("unknown", "silent"))
     return 1 if unknown else 0

--- a/tools/board_registry.example.json
+++ b/tools/board_registry.example.json
@@ -1,7 +1,7 @@
 {
   "_comment": [
     "TEMPLATE. Copy to tools/board_registry.json, which is gitignored, and",
-    "let `python tools/identify_boards.py --learn` fill it in from the",
+    "let `python tools/ESP32_boardUtil.py --learn` fill it in from the",
     "boards on YOUR desk.",
     "",
     "WHY THIS FILE IS A TEMPLATE AND THE REAL ONE IS NEVER COMMITTED.",

--- a/tools/configure_boards.py
+++ b/tools/configure_boards.py
@@ -60,7 +60,7 @@ import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
-import identify_boards as ib  # noqa: E402  (reuse discovery, registry, lock)
+import ESP32_boardUtil as ib  # noqa: E402  (reuse discovery, registry, lock)
 
 DEFAULT_CONFIG = os.path.join(HERE, "bench_config.json")
 EXAMPLE_CONFIG = os.path.join(HERE, "bench_config.example.json")

--- a/tools/identify_boards.py
+++ b/tools/identify_boards.py
@@ -4,7 +4,7 @@
     python tools/identify_boards.py            # identify everything attached
     python tools/identify_boards.py --learn    # ...and record what it found
     python tools/identify_boards.py --json     # machine-readable, for scripting
-    python tools/identify_boards.py --flash    # build and flash each one correctly
+    python tools/identify_boards.py --flash    # build each model once, flash all at once
     python tools/identify_boards.py --no-reset # ask only; never restart a board
 
 Why this exists
@@ -17,8 +17,8 @@ session, which is two times too many.
 
 So the port is treated as an address, not an identity. At each address:
 
-1. **Ask.** Current firmware answers `identify?` with one `[ident]` line --
-   device id, board, version, build -- and keeps running. Nothing is reset, so
+1. **Ask.** Current firmware answers `identify?` with one `ok v="1" ...` line
+   -- device id, board, version, build -- and keeps running. Nothing is reset, so
    a game in progress or another agent's test is not disturbed. This is the
    normal path.
 2. **Reset and listen**, only if nothing answered: older firmware, a diag
@@ -247,11 +247,28 @@ def lock_path():
 
 
 def flash_all(results):
-    """Flash every identified board with its own environment.
+    """Flash every identified board with its own environment -- in parallel.
 
     Refuses outright if anything is UNKNOWN. Flashing a board with the wrong
     panel's build is the failure this whole file exists to prevent, and
     "most of them were right" is not a state anybody can act on afterwards.
+
+    Two phases, under ONE hold of the board lock:
+
+    1. BUILD each distinct environment once, all at the same time. Boards of
+       the same model share a build. Measured after a new commit, four
+       environments one after another took 210 s and in parallel 97 s: each
+       rebuild is one changed object plus dependency scanning and linking,
+       which is mostly single-core, so side by side they barely compete. Each
+       environment has its own build directory and its own generated stamp
+       header, and the object cache is safe to share between processes.
+    2. UPLOAD to every port at once, one process per port, with `-t nobuild`
+       so nothing is rebuilt. Each board is its own USB device on its own
+       port, so this is safe; one board failing does not stop the others.
+
+    The lock is still global. Parallel flashing is for ONE agent's boards --
+    two agents flashing the bench at the same time is exactly what the lock
+    exists to stop, and nothing here changes that.
     """
     unknown = [r for r in results if r["status"] in ("unknown", "silent")]
     if unknown:
@@ -259,7 +276,8 @@ def flash_all(results):
               % (len(unknown), ", ".join(r["port"] for r in unknown)))
         return 1
 
-    targets = [r for r in results if r["status"] in ("known", "new", "learned") and r.get("env")]
+    targets = [r for r in results
+               if r["status"] in ("known", "new", "learned") and r.get("env")]
     if not targets:
         print("Nothing to flash.")
         return 1
@@ -277,13 +295,56 @@ def flash_all(results):
 
     failed = []
     try:
-        for r in targets:
-            print("\n=== %s  %s  env:%s" % (r["port"], r["board"], r["env"]))
-            rc = subprocess.run(
-                ["pio", "run", "-e", r["env"], "-t", "upload",
-                 "--upload-port", r["port"]], cwd=ROOT, shell=True).returncode
-            if rc != 0:
-                failed.append(r["port"])
+        envs = sorted({r["env"] for r in targets})
+        built = set()
+        print("\n=== building %d environment(s) at once: %s"
+              % (len(envs), ", ".join(envs)))
+        t0 = time.time()
+        builds = []
+        for env in envs:
+            log = open(os.path.join(ROOT, ".pio", "build-%s.log" % env),
+                       "w", encoding="utf-8", errors="replace")
+            builds.append((env, log, subprocess.Popen(
+                ["pio", "run", "-e", env], cwd=ROOT, shell=True,
+                stdout=log, stderr=subprocess.STDOUT), time.time()))
+        for env, log, proc, started in builds:
+            rc = proc.wait()
+            log.close()
+            print("  %s env:%-24s %3ds" % ("ok " if rc == 0 else "ERR", env,
+                                           time.time() - started))
+            if rc == 0:
+                built.add(env)
+            else:
+                failed += [r["port"] for r in targets if r["env"] == env]
+                print("       see %s" % os.path.relpath(log.name, ROOT))
+        print("=== builds finished in %ds" % (time.time() - t0))
+
+        uploads = [r for r in targets if r["env"] in built]
+        if uploads:
+            print("\n=== uploading to %d board(s) at once: %s"
+                  % (len(uploads), ", ".join("%s(%s)" % (r["port"], r["env"])
+                                             for r in uploads)))
+            t0 = time.time()
+            procs = []
+            for r in uploads:
+                log = open(os.path.join(ROOT, ".pio", "upload-%s.log" % r["port"]),
+                           "w", encoding="utf-8", errors="replace")
+                p = subprocess.Popen(
+                    ["pio", "run", "-e", r["env"], "-t", "nobuild", "-t", "upload",
+                     "--upload-port", r["port"]],
+                    cwd=ROOT, shell=True, stdout=log, stderr=subprocess.STDOUT)
+                procs.append((r, p, log))
+            for r, p, log in procs:
+                rc = p.wait()
+                log.close()
+                ok = rc == 0 and "Hash of data verified" in open(
+                    log.name, encoding="utf-8", errors="replace").read()
+                print("  %s %-6s %-22s env:%s" % ("ok " if ok else "ERR", r["port"],
+                                                r["board"], r["env"]))
+                if not ok:
+                    failed.append(r["port"])
+                    print("       see %s" % os.path.relpath(log.name, ROOT))
+            print("=== uploads finished in %ds" % (time.time() - t0))
     finally:
         # Released on every path, including a failed flash and a Ctrl-C. A
         # lock left behind blocks every later agent, and stale locks here are


### PR DESCRIPTION
# What changed

- **The 4-inch launcher shows nine apps a page in portrait**: a 3x3 grid of 96x112 tiles instead of 2x2, so the catalogue is five pages rather than eleven. Landscape and every smaller panel are unchanged.
- **A low battery no longer flashes the whole screen**, and **the screen saver's paddles no longer flicker**.
- **Bench flashing**: `--flash` builds each connected board's environment in parallel and uploads to every port at once. `--flash --board E32R40T` flashes only the board under test. The tool is renamed `identify_boards.py` -> `ESP32_boardUtil.py`, since it now flashes as well as identifies.

# Why

**Launcher.** The 4-inch panel had room for more than four tiles in portrait. The grid is now chosen from the panel's size by `LauncherLayout::grid()`, the single answer read by the tile rects, the page size and the tile colours.

At 88px, five subtitles no longer fit (Math, US States, State Maps, Cursive, Nearby), and font 1 is already the smallest font compiled in. So in the 3x3 grid a subtitle that doesn't fit is broken at a space onto two lines, and every title on the page moves up a line to keep rows even. Tile fills step by row as well as column, because `slot % 3` would paint each column one colour in a three-wide grid.

**Low battery.** The battery and update notices called `requestRender()` to show their banner and again to remove it. A low battery therefore wiped the panel twice per warning cycle for as long as the cell stayed low. They now go through `requestChromeRender()`, like the Nearby banner.

**Screen saver.** Both paddles were erased and redrawn every frame, including the one standing still, and the wordmark's full-width erase band cut through both. Now a paddle repaints only when it moves, changes colour or the ball crosses it, and the band stops short of the paddle columns.

**Flashing.** Reflashing the whole bench to test a one-board change meant four full builds side by side. The skill and CLAUDE.md now make `--board` the default when testing, and the whole bench the owner's call.

# How it was tested

- [x] `pio run` succeeds. `env:app` was built on this branch. `env:app_e32r40t` was built on the same changes before they were rebased onto current `dev`.
- [x] `python tools/check_docs.py`, `check_boards.py`, `check_catalog.py` and `check_frame_rules.py` are clean
- [ ] Flashed and used on hardware. The E32R40T was flashed with these changes (pre-rebase build) and the upload verified, but the 3x3 grid, the subtitle wrap and the saver have **not yet been checked by eye on the panel**.
- [ ] Both orientations checked. Landscape is untouched in code; portrait 3x3 was only checked against a PIL mock-up drawn from the firmware's geometry.

`--board` filtering was tested offline against stubbed board lists: no match refuses, no filter with an unknown port still refuses, and a filter selects only that environment. It was then used for the real 4-inch flash.

**Size figures** (`pio run -e app`, this branch):

```
RAM:   23.4% (used 76660 bytes from 327680 bytes)
Flash: 77.8% (used 2448885 bytes from 3145728 bytes)
```

Flash is 776 bytes over `dev`; RAM is unchanged.

# Docs in the same commit

- [x] `README.md`: size figures and the tool name
- [x] `CHANGELOG.md`
- [x] `CLAUDE.md` / `AGENTS.md` / the `braino-boards` skill
- [ ] `python tools/gen_screens.py` re-run. Not needed: the 2.8-inch mock-ups are unchanged, and no 4-inch launcher mock-up exists yet.

# The two rules that outrank everything

- [x] **This adds no new outbound flow.**
- [x] **No AI attribution in the commits.**
