### PR TITLE
Flash tool: check every board booted, and recover the E32R40T's ROM loop

### DIFF
--- a/.claude/skills/braino-boards/SKILL.md
+++ b/.claude/skills/braino-boards/SKILL.md
@@ -96,8 +96,11 @@ Current firmware answers `identify` (or `identify?`) on the serial port with one
 older firmware, a diag build, a blank flash -- gets reset so its boot banner can
 be read. Resetting is not free: it discards whatever the board was doing, one
 2.8-inch board's USB drops off the bus as its app starts (so the banner is
-lost), and an E32R40T has been seen stuck in a `flash read err` boot loop
-after a reset until its battery was pulled.
+lost), and an E32R40T is regularly left in a `flash read err` / `invalid
+header` ROM boot loop by a reset -- including the one at the end of an upload.
+`--flash` checks every board it flashed afterwards and brings a looping one
+back by itself (a reset from download mode, no battery pull); a board it could
+not recover is reported as FAILED.
 
 If you write your own serial script, open the port with DTR and RTS already
 low (`s = serial.Serial(); s.dtr = False; s.rts = False; s.port = ...;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ release, and `release.yml` refuses to publish a tag whose version carries it.
 number, so a console on this build is correctly told that nothing newer exists
 rather than being nagged all cycle to install the 5.9.1 it is ahead of.
 
+**`ESP32_boardUtil.py --flash` checks that every board booted, and brings a
+stuck 4-inch board back by itself.** The reset at the end of an upload
+regularly left the E32R40T in a ROM boot loop -- `invalid header` or `flash
+read err`, panel dark -- with an intact image in flash. After the uploads, still
+holding the board lock, the tool now asks each board it flashed which build it
+is running, without resetting it. One that is silent and whose serial shows the
+loop gets a reset from download mode (esptool `flash_id` staying in the
+bootloader, then `read_mac` with a hard reset), up to three times, which is
+what had been bringing it back by hand; it writes nothing, and the MAC esptool
+prints is discarded unread. A board still looping is reported as FAILED; one
+running a build other than the commit just built is flagged.
+
 **Nearby stops repainting its list for every beacon it hears.** The peer
 table's change counter moves on every advertisement received, not only when
 something about a peer changed, so with a few consoles in the room the list was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1317,17 +1317,24 @@ ESP32-2432S028R. `docs/PORTING.md` is the checklist for adding a board.
     changing the admin PIN or which profile is admin, peer labels, the update
     check and the NTP server. Each is a decision for the maintainer, not a
     convenience.
-- **An EN reset can strand an E32R40T.** Seen on the bench three times in one
-  day: after the reset button, an RTS reset from a serial tool, or a USB power
-  surge, the ROM loops `flash read err, 988` / `RTCWDT_RTC_RESET` every ~350ms
-  with the panel dark, and only pulling the battery recovers it. **It is not
-  the GPIO12 strap**, which was the first guess (GPIO12 is also the shared
-  MISO): the ROM prints `boot:0x17`, whose MTDI bit is clear, so 3.3V flash was
-  selected. Everything seen fits the flash chip itself being left in a state
-  an EN reset does not clear -- EN resets the ESP32, not the flash -- after
-  the app has been running; a board fresh from esptool boots. Cause not yet
-  found. A dark 4-inch board is worth a passive serial capture before it is
-  worth a reflash, and it cannot be flashed while looping.
+- **An EN reset can strand an E32R40T, and the flash tool now recovers it.**
+  After the reset button, an RTS reset from a serial tool, a USB power surge
+  -- and, most often, the hard reset at the end of an upload -- the ROM loops
+  `flash read err, 988` or `invalid header: 0x20000368` / `RTCWDT_RTC_RESET`
+  every ~350ms with the panel dark. **It is not the GPIO12 strap**, which was
+  the first guess (GPIO12 is also the shared MISO): the ROM prints
+  `boot:0x17`, whose MTDI bit is clear, so 3.3V flash was selected. **Nor is
+  the image damaged**: read back while looping, the bootloader at 0x1000 was
+  byte for byte correct, and the failing read differed from it by three bits
+  at the same address -- a marginal read at the moment of some resets. Cause
+  not yet found. What recovers it without a battery pull is a reset that comes
+  *from download mode*: `esptool --after no_reset flash_id`, then `esptool
+  --before no_reset --after hard_reset read_mac`, repeating the pair (never
+  the second step alone) if it fails. `ESP32_boardUtil.py --flash` asks every
+  board it flashed for its build afterwards and runs that recovery on any
+  whose serial shows the loop (`check_boot()`), so a flash no longer leaves a
+  dark 4-inch board behind. By hand: capture the serial passively before
+  reflashing; it cannot be flashed while looping.
 - **There is no `id=` field in the banner, and putting one back needs more
   care than it looks.** 5.9.0 printed the controller's ID register and broke the
   display on two of the seven boards: `tft.readcommand8()` writes an

--- a/tools/ESP32_boardUtil.py
+++ b/tools/ESP32_boardUtil.py
@@ -231,6 +231,111 @@ def read_chip(py, esptool, port):
     return (chip.group(1).strip() if chip else None, alive)
 
 
+# What the ROM prints when it cannot boot the app it was just given, over and
+# over, every ~350 ms. See recover_rom_loop().
+ROM_LOOP_RE = re.compile(r"invalid header|flash read err|RTCWDT_RTC_RESET")
+# How long a freshly flashed board gets to boot before it is asked anything.
+BOOT_WAIT_S = 5
+RECOVERY_ATTEMPTS = 3
+
+
+def listen(py, port, seconds=2.5):
+    """Whatever a board prints on its own, without resetting it."""
+    script = (
+        "import serial,sys,time\n"
+        "s=serial.Serial()\n"
+        "s.port=%r; s.baudrate=115200; s.timeout=0.2\n"
+        "s.dtr=False; s.rts=False\n"
+        "s.open()\n"
+        "d=b''; t=time.time()\n"
+        "while time.time()-t < %f: d += s.read(512)\n"
+        "s.close(); sys.stdout.write(d.decode('utf-8','replace'))\n"
+    ) % (port, seconds)
+    out = subprocess.run([py, "-c", script], capture_output=True, text=True)
+    return out.stdout or ""
+
+
+def recover_rom_loop(py, esptool, port):
+    """Bring a board out of the ROM boot loop without anyone pulling a battery.
+
+    Seen repeatedly on the E32R40T straight after an upload: the reset at the
+    end of the flash lands it in `invalid header` / `flash read err` with the
+    panel dark, over and over, although the image in flash is intact -- read
+    back byte for byte while it looped. What reliably brings it back is a
+    reset that comes FROM download mode rather than from a running chip: one
+    esptool command that enters the bootloader and stays there, then a second
+    that starts from that state and hard-resets. Measured on the bench:
+
+      - the pair works; the second step alone, retried after it once failed,
+        never does -- so a failed attempt repeats the whole pair;
+      - it writes nothing and erases nothing: flash_id and read_mac only read.
+
+    esptool prints the chip's MAC on every connect. That output is captured
+    and dropped unread, like read_chip()'s: a MAC names a board for the life
+    of the silicon and must not reach a log.
+
+    True once the board answers `identify?` again.
+    """
+    if not esptool:
+        return False
+    for _attempt in range(RECOVERY_ATTEMPTS):
+        subprocess.run([py, esptool, "--port", port, "--after", "no_reset",
+                        "flash_id"], capture_output=True, text=True)
+        subprocess.run([py, esptool, "--port", port, "--before", "no_reset",
+                        "--after", "hard_reset", "read_mac"],
+                       capture_output=True, text=True)
+        time.sleep(BOOT_WAIT_S)
+        if query_board(py, port, 3.0):
+            return True
+    return False
+
+
+def head_commit():
+    out = subprocess.run(["git", "rev-parse", "--short=7", "HEAD"],
+                         cwd=ROOT, capture_output=True, text=True)
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+def check_boot(py, esptool, flashed):
+    """Ask every board just flashed whether it is running the new build.
+
+    An upload that esptool verified says the bytes are in flash; it does not
+    say the board booted them. So each one is asked, unreset, after
+    BOOT_WAIT_S. A silent board is listened to: if the ROM is looping, it is
+    recovered (recover_rom_loop) rather than left for somebody to find dark.
+    Returns the ports that are still stuck -- those count as failures. A board
+    that is silent for any other reason is reported and not failed: one
+    2.8-inch board's USB is known to drop off the bus as its app starts.
+    """
+    commit = head_commit()
+    stuck = []
+    print("\n=== checking each board booted it")
+    time.sleep(BOOT_WAIT_S)
+    for r in flashed:
+        port, how = r["port"], ""
+        reply = query_board(py, port, 3.0) or query_board(py, port, 3.0)
+        if not reply and ROM_LOOP_RE.search(listen(py, port)):
+            print("  ... %-6s is in the ROM boot loop -- recovering it" % port)
+            if recover_rom_loop(py, esptool, port):
+                reply = query_board(py, port, 3.0)
+                how = "  (recovered from the ROM boot loop)"
+            else:
+                stuck.append(port)
+                print("  ERR %-6s still looping after %d recoveries -- pull its "
+                      "battery and press reset" % (port, RECOVERY_ATTEMPTS))
+                continue
+        if not reply:
+            print("  ??  %-6s did not answer (asleep, or its USB dropped as the "
+                  "app started)" % port)
+            continue
+        build = reply.get("build", "?")
+        print("  %s %-6s %-22s %s%s" % ("ok " if commit in build else "!! ",
+                                        port, r["board"], build, how))
+        if commit and commit not in build:
+            print("       expected a build of %s" % commit)
+    return stuck
+
+
 def lock_path():
     """The board lock, in the shared git common dir so every worktree sees it.
 
@@ -247,7 +352,7 @@ def lock_path():
     return os.path.join(common, "gume-board.lock")
 
 
-def flash_all(results, boards=None):
+def flash_all(py, esptool, results, boards=None):
     """Flash every identified board with its own environment -- in parallel.
 
     Refuses outright if anything is UNKNOWN. Flashing a board with the wrong
@@ -274,6 +379,8 @@ def flash_all(results, boards=None):
     2. UPLOAD to every port at once, one process per port, with `-t nobuild`
        so nothing is rebuilt. Each board is its own USB device on its own
        port, so this is safe; one board failing does not stop the others.
+    3. CHECK each board booted the new build, and bring any that the upload's
+       reset left in the ROM boot loop back out of it -- see check_boot().
 
     The lock is still global. Parallel flashing is for ONE agent's boards --
     two agents flashing the bench at the same time is exactly what the lock
@@ -317,6 +424,9 @@ def flash_all(results, boards=None):
 
     failed = []
     try:
+        # A fresh worktree has no .pio/ until its first build, and the logs
+        # below go there before any build has run.
+        os.makedirs(os.path.join(ROOT, ".pio"), exist_ok=True)
         envs = sorted({r["env"] for r in targets})
         built = set()
         print("\n=== building %d environment(s) at once: %s"
@@ -367,6 +477,11 @@ def flash_all(results, boards=None):
                     failed.append(r["port"])
                     print("       see %s" % os.path.relpath(log.name, ROOT))
             print("=== uploads finished in %ds" % (time.time() - t0))
+            # Still under the lock: recovery resets a board, which is exactly
+            # the kind of thing another agent must not be doing at the time.
+            flashed = [r for r in uploads if r["port"] not in failed]
+            if flashed:
+                failed += check_boot(py, esptool, flashed)
     finally:
         # Released on every path, including a failed flash and a Ctrl-C. A
         # lock left behind blocks every later agent, and stale locks here are
@@ -547,7 +662,7 @@ def main():
         print("\nRecorded %d new board(s) in tools/board_registry.json." % learned)
 
     if args.flash:
-        return flash_all(results, args.board)
+        return flash_all(py, esptool, results, args.board)
     if args.board:
         print("--board only narrows --flash; nothing was flashed.")
 


### PR DESCRIPTION
The reset at the end of an upload regularly leaves the E32R40T in a ROM boot loop (`invalid header` or `flash read err`, panel dark), even though the image in flash is intact. It had to be recovered by hand every time.

## What changed in `tools/ESP32_boardUtil.py`
- **`check_boot()`:** after the uploads, still holding the board lock, each flashed board is asked for its build without being reset.
  - A board running a build other than the commit just built is flagged.
- **`recover_rom_loop()`:** runs on any board that is silent and whose serial shows the loop. It is the sequence that worked by hand:
  - `esptool --after no_reset flash_id` (enters the bootloader and stays there);
  - then `--before no_reset --after hard_reset read_mac`;
  - the whole pair repeats up to 3 times, because retrying the second step alone never worked.
  - It writes nothing, and the MAC esptool prints is discarded unread.
  - A board still looping afterwards is reported as FAILED.
- **Crash fix:** `.pio/` is now created before the first log is written. A fresh worktree has none, so `--flash` crashed there before building anything.

## Docs
- CLAUDE.md's hardware note on the loop was stale ("only pulling the battery recovers it", "a board fresh from esptool boots") and is corrected.
- The braino-boards skill and the CHANGELOG are updated.

## Tested on the bench E32R40T
- A `--flash --board E32R40T` run with the check: the board booted cleanly, and the check confirmed `fix/e32r40t-recovery @ 2649d92`.
- The recovery pair run on the live board: it reset through download mode and answered again in 8 s.
- Not yet tested: recovery from an actual loop. The board could not be made to loop on demand (four resets, four clean boots), so that path relies on the same sequence that worked by hand, twice today.
