### PR TITLE
Flash tool: never upload to a port whose board has changed

### DIFF
--- a/.claude/skills/braino-boards/SKILL.md
+++ b/.claude/skills/braino-boards/SKILL.md
@@ -138,3 +138,17 @@ confidence and the file should not hide which one it has.
 If the registry and a live banner disagree, the tool prints `!! registry says X,
 board says Y` rather than silently preferring either. Investigate; don't paper
 over it.
+
+The device id carries a second opinion: its prefix (`R40T-...`) is the tag of
+the firmware that first issued it, and it survives a reflash. When that tag
+disagrees with `board=`, the tool marks the port `!! ... probably the wrong
+image` and refuses to flash it -- that is how a 4-inch board running the
+2.8-inch image shows up. Look at the panel, then flash the right environment
+by hand.
+
+**Ports move while a flash is running.** A whole-bench build can take twenty
+minutes, and a replug or a USB power surge renumbers the COM ports in that
+time. That is how a 4-inch board once received the 2.8-inch image. `--flash`
+now asks every port again immediately before its upload and skips any that
+does not give the device id it gave at the start; if you flash by hand, do the
+same.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ release, and `release.yml` refuses to publish a tag whose version carries it.
 number, so a console on this build is correctly told that nothing newer exists
 rather than being nagged all cycle to install the 5.9.1 it is ahead of.
 
+**`ESP32_boardUtil.py --flash` no longer uploads to a port whose board has
+changed.** Ports were identified before the builds and uploaded to after them,
+up to twenty minutes later, and COM numbers move in that time -- a replug, or a
+USB power surge renumbering everything. A 4-inch E32R40T came back on the port
+an E32R28T-1 had been identified on and received the 2.8-inch image: a dark
+panel with a working speaker. Every port is now asked again immediately before
+its upload and skipped unless it gives the same device id. And a board whose
+device id was issued by one model's firmware (`R40T-...`) while it reports
+another model (`board=E32R28T-1`) is refused as probably carrying the wrong
+image, rather than being flashed with that wrong image again; the tags are
+read from the board profiles through `platformio.ini`, not listed.
+
 **`ESP32_boardUtil.py --flash` checks that every board booted, and brings a
 stuck 4-inch board back by itself.** The reset at the end of an upload
 regularly left the E32R40T in a ROM boot loop -- `invalid header` or `flash

--- a/tools/ESP32_boardUtil.py
+++ b/tools/ESP32_boardUtil.py
@@ -290,6 +290,62 @@ def recover_rom_loop(py, esptool, port):
     return False
 
 
+def reconfirm(py, r):
+    """Is the board identified at this port still the one at this port?
+
+    Ports are identified before the builds and uploaded to after them, and a
+    build after a new commit can take twenty minutes. In that window the COM
+    numbers can move -- a board replugged, or Windows dropping every port on a
+    USB power surge and handing the numbers out again in a new order. That is
+    how a 4-inch E32R40T received the 2.8-inch image: it had come back on the
+    port an E32R28T-1 had been identified on, the upload went to the number,
+    and the result was a dark panel with a working speaker.
+
+    So each port is asked again, immediately before its upload, and must give
+    the same device id it gave at the start. None if it did; otherwise why
+    not, and the port is skipped.
+    """
+    reply = query_board(py, r["port"], 2.0) or query_board(py, r["port"], 2.0)
+    if not reply:
+        return "did not answer just before its upload, so it cannot be confirmed"
+    if r.get("device") and reply.get("device") != r["device"]:
+        return ("is now device %s, not the %s identified at the start -- the "
+                "ports moved" % (reply.get("device"), r["device"]))
+    return None
+
+
+def board_tags():
+    """BOARD_NAME -> the idTag its firmware stamps on device ids (`R28T`).
+
+    Derived, not listed: each [board_*] section of platformio.ini names its
+    BOARD_NAME -- what the banner reports -- and its GUME_BOARD_HEADER, and
+    that profile opens with its display name and then its tag. The display
+    name is not used, because for two CYD boards it is not the BOARD_NAME
+    ("ESP32-2432S028R (ILI9341)" against "ESP32-2432S028R").
+    """
+    tags = {}
+    try:
+        with open(os.path.join(ROOT, "platformio.ini"), encoding="utf-8") as f:
+            ini = f.read()
+    except OSError:
+        return tags
+    for body in re.findall(r"^\[board_\w+\](.*?)(?=^\[|\Z)", ini, re.M | re.S):
+        name = re.search(r'BOARD_NAME=\\"([^\\"]+)\\"', body)
+        header = re.search(r'GUME_BOARD_HEADER=\\"([^\\"]+)\\"', body)
+        if not (name and header):
+            continue
+        try:
+            with open(os.path.join(ROOT, "include", header.group(1)),
+                      encoding="utf-8", errors="replace") as f:
+                m = re.search(r'BoardProfile\s+BOARD\s*=\s*\{\s*"[^"]*",\s*"([^"]+)"',
+                              f.read())
+        except OSError:
+            continue
+        if m:
+            tags[name.group(1)] = m.group(1)
+    return tags
+
+
 def head_commit():
     out = subprocess.run(["git", "rev-parse", "--short=7", "HEAD"],
                          cwd=ROOT, capture_output=True, text=True)
@@ -379,6 +435,9 @@ def flash_all(py, esptool, results, boards=None):
     2. UPLOAD to every port at once, one process per port, with `-t nobuild`
        so nothing is rebuilt. Each board is its own USB device on its own
        port, so this is safe; one board failing does not stop the others.
+       Each port is asked again just before its upload and skipped unless it
+       gives the device id it gave at the start (reconfirm()): the builds
+       can take twenty minutes, and COM numbers move in that time.
     3. CHECK each board booted the new build, and bring any that the upload's
        reset left in the ROM boot loop back out of it -- see check_boot().
 
@@ -386,9 +445,10 @@ def flash_all(py, esptool, results, boards=None):
     two agents flashing the bench at the same time is exactly what the lock
     exists to stop, and nothing here changes that.
     """
-    unknown = [r for r in results if r["status"] in ("unknown", "silent")]
+    unknown = [r for r in results if r["status"] in ("unknown", "silent", "mismatch")]
     if unknown and not boards:
-        print("Refusing to flash: %d port(s) unidentified (%s)."
+        print("Refusing to flash: %d port(s) unidentified or not matching "
+              "their device id (%s)."
               % (len(unknown), ", ".join(r["port"] for r in unknown)))
         return 1
     if unknown:
@@ -459,6 +519,11 @@ def flash_all(py, esptool, results, boards=None):
             t0 = time.time()
             procs = []
             for r in uploads:
+                moved = reconfirm(py, r)
+                if moved:
+                    failed.append(r["port"])
+                    print("  ERR %-6s %s -- not flashing it" % (r["port"], moved))
+                    continue
                 log = open(os.path.join(ROOT, ".pio", "upload-%s.log" % r["port"]),
                            "w", encoding="utf-8", errors="replace")
                 p = subprocess.Popen(
@@ -479,7 +544,8 @@ def flash_all(py, esptool, results, boards=None):
             print("=== uploads finished in %ds" % (time.time() - t0))
             # Still under the lock: recovery resets a board, which is exactly
             # the kind of thing another agent must not be doing at the time.
-            flashed = [r for r in uploads if r["port"] not in failed]
+            flashed = [r for r in uploads
+                       if r["port"] not in failed and any(q is r for q, _p, _l in procs)]
             if flashed:
                 failed += check_boot(py, esptool, flashed)
     finally:
@@ -558,6 +624,7 @@ def main():
     args = ap.parse_args()
 
     py, esptool, reg = pio_python(), esptool_py(), load_registry()
+    tags = board_tags()
     skip = reg.get("skip_ports", {})
     results, learned = [], 0
 
@@ -600,6 +667,23 @@ def main():
                 row["conflict"] = ("registry says %s, board says %s"
                                    % (known["board"], banner))
             results.append(row)
+        elif banner and device_id and tags.get(banner) and \
+                device_id.rsplit("-", 1)[0] != tags[banner]:
+            # The id was issued by one model's firmware and the board is
+            # running another's. The banner describes the firmware, not the
+            # panel, so this is a board that was probably flashed with the
+            # wrong image -- exactly the case where trusting the banner would
+            # flash the wrong image again. Neither half proves the hardware,
+            # so neither is picked: the port is refused until someone who can
+            # see the board flashes the right build by hand.
+            results.append({"port": device, "status": "mismatch",
+                            "device": device_id, "chip": chip, "board": banner,
+                            "version": version, "via": via,
+                            "why": "device id %s was issued by %s firmware, but it "
+                                   "is running %s -- probably the wrong image; "
+                                   "check the panel and flash it by hand"
+                                   % (device_id, device_id.rsplit("-", 1)[0],
+                                      banner)})
         elif banner:
             env = env_for_board_name(reg, banner)
             row = {"port": device, "status": "new", "device": device_id,
@@ -655,6 +739,8 @@ def main():
                   % (p, r["chip"] or "?", r.get("why", "did not identify")))
             print("  %s  Not guessing. Flash a candidate build, read the "
                   "banner, then --learn." % (" " * width))
+        elif s == "mismatch":
+            print("  %s  %-20s !! %s" % (p, r["board"], r["why"]))
         else:
             print("  %s  -- %s" % (p, r["why"]))
 
@@ -666,7 +752,7 @@ def main():
     if args.board:
         print("--board only narrows --flash; nothing was flashed.")
 
-    unknown = sum(1 for r in results if r["status"] in ("unknown", "silent"))
+    unknown = sum(1 for r in results if r["status"] in ("unknown", "silent", "mismatch"))
     return 1 if unknown else 0
 
 


### PR DESCRIPTION
A flash this morning sent the 2.8-inch image to the 4-inch E32R40T, giving it a dark panel and a working speaker.

**Cause:** the tool identified ports before the builds and uploaded after them, about 20 minutes later. In between, the COM numbers moved: a replug or a USB power surge renumbers them. The 4-inch board came back on a port a 2.8-inch board had been identified on.

**Guards added to `tools/ESP32_boardUtil.py`:**
- **`reconfirm()`:** every port is asked again immediately before its upload, and skipped unless it gives the same device id as at the start.
- **Tag check:** a device id carries the tag of the firmware that first issued it (`R40T-...`), and the tag survives a reflash. If that tag disagrees with the `board=` the board reports, the port is refused as probably carrying the wrong image, instead of being flashed with that image again.
  - The tags are derived from each `[board_*]` section's `GUME_BOARD_HEADER` in `platformio.ini`, not listed by hand.

**Tested:**
- On the bench, the 4-inch board (flashed back to the E32R40T build by hand) reads as E32R40T with a matching tag.
- In simulation, a 4-inch reporting E32R28T-1 is refused by both identify and `--flash`.
- `reconfirm()` catches a changed device and a silent port.
